### PR TITLE
docs: Update README (158 tools) and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# CLAUDE.md - BoondManager MCP Server
+
+## Project Overview
+
+MCP (Model Context Protocol) server for the BoondManager API. Exposes 158 tools across 36 domains, allowing Claude to interact with BoondManager ERP/CRM data.
+
+- **Language**: TypeScript (strict mode), ES2022, Node16 module resolution
+- **Runtime**: Node.js >= 20
+- **Transport**: stdio (no network port)
+- **API format**: JSON:API (BoondManager REST API)
+
+## Commands
+
+```bash
+npm run build          # TypeScript compilation (tsc)
+npm run dev            # Watch mode (tsc --watch)
+npm start              # Run server (node dist/index.js)
+npm test               # Run all tests (vitest run)
+npm run test:coverage  # Tests + V8 coverage
+npm run lint           # ESLint
+npm run lint:fix       # ESLint with auto-fix
+npm run typecheck      # tsc --noEmit
+```
+
+Run a single test file:
+```bash
+npx vitest run src/tools/candidates.test.ts
+```
+
+## Architecture
+
+```
+src/
+├── index.ts              # Entry point: creates McpServer, registers all tools, starts stdio transport
+├── constants.ts          # DEFAULT_BASE_URL, pagination limits, API_PATHS, ENTITY_TABS
+├── types.ts              # JsonApiResource, JsonApiResponse, BoondConfig, SearchParams
+├── services/
+│   └── boond-client.ts   # HTTP client: apiRequest(), buildSearchQuery(), formatListResponse(), formatDetailResponse()
+├── schemas/
+│   └── index.ts          # Zod schemas: SearchSchema, IdSchema, IdTabSchema, plus entity-specific create/update schemas
+└── tools/
+    ├── index.ts          # Barrel export of all register*Tools functions
+    ├── crud-factory.ts   # Generic CRUD tool factory (registerSearchTool, registerGetTool, etc.)
+    └── *.ts              # One file per domain (37 tool files)
+```
+
+### Key Patterns
+
+**CRUD Factory** (`crud-factory.ts`): Generic functions to register search/get/create/update/delete tools. Used by: candidates, resources, contacts, companies, opportunities, projects, products. Call signature: `registerSearchTool(server, opts)` where `opts = { entityName, entityNamePlural, apiPath, prefix }`.
+
+**Tab tools**: Major entities (candidates, resources, contacts, companies, opportunities, projects) register additional tools for each tab endpoint. These are registered in loops over `ENTITY_TABS[entity]` from constants.ts. Tool name pattern: `boond_{entity}_{tab_name}` (hyphens replaced with underscores).
+
+**Simple domains**: Most admin/reference domains (accounts, agencies, roles, etc.) register only search + get with direct `server.registerTool()` calls.
+
+**JSON:API body builder**: `buildJsonApiBody(type, attributes, id?)` in crud-factory.ts builds the `{ data: { type, attributes } }` payload. Filters out undefined values.
+
+## Tool Naming Convention
+
+All tool names follow: `boond_{domain}_{operation}`
+
+- Operations: `search`, `get`, `create`, `update`, `delete`
+- Tab tools: `boond_{entity}_{tab_name}` (e.g., `boond_resources_technical_data`)
+- Reporting: `boond_reporting_{type}` (e.g., `boond_reporting_companies`)
+- Application: `boond_application_dictionary`, `boond_application_current_user`
+
+## Testing
+
+- **Framework**: Vitest 4 (with `globals: true`)
+- **Pattern**: Each tool file has a corresponding `.test.ts` file
+- **Approach**: Mock `McpServer` with `{ registerTool: vi.fn() }`, then verify:
+  1. Correct number of `registerTool` calls
+  2. Correct tool names
+  3. Correct MCP annotations (readOnlyHint, destructiveHint, idempotentHint)
+- **Coverage**: V8 provider, excludes test files and index.ts
+- **Current stats**: 40 test files, 255 tests
+
+### Test file template (for read-only search+get domains):
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerXxxTools } from "./xxx.js";
+
+function createMockServer() {
+  return { registerTool: vi.fn() } as unknown as McpServer;
+}
+
+describe("registerXxxTools", () => {
+  let server: McpServer;
+  beforeEach(() => { server = createMockServer(); });
+
+  it("should register N tools", () => {
+    registerXxxTools(server);
+    expect(server.registerTool).toHaveBeenCalledTimes(N);
+  });
+
+  it("should register all expected tool names", () => {
+    registerXxxTools(server);
+    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
+    expect(names).toContain("boond_xxx_search");
+    expect(names).toContain("boond_xxx_get");
+  });
+
+  it("should register all tools as readOnly", () => {
+    registerXxxTools(server);
+    for (const call of vi.mocked(server.registerTool).mock.calls) {
+      expect(call[1].annotations?.readOnlyHint).toBe(true);
+    }
+  });
+});
+```
+
+## Adding a New Domain
+
+1. Create `src/tools/{domain}.ts` with a `register{Domain}Tools(server: McpServer)` function
+2. For simple search+get: use direct `server.registerTool()` calls with `SearchSchema`/`IdSchema`
+3. For full CRUD: use `crud-factory.ts` functions or direct registration
+4. Export from `src/tools/index.ts`
+5. Register in `src/index.ts`
+6. Add API path to `API_PATHS` in `constants.ts` (if applicable)
+7. Create `src/tools/{domain}.test.ts` following the test pattern above
+8. Run `npm test && npm run lint && npm run typecheck && npm run build`
+
+## MCP Annotations
+
+Every tool must declare annotations:
+- `readOnlyHint: true` for search/get operations
+- `destructiveHint: true` for delete operations
+- `idempotentHint: true` for search/get/update operations
+- `openWorldHint: true` for search operations (paginated, keyword-filtered)
+
+## Authentication
+
+Configured via environment variables (never hardcoded):
+- `BOOND_USER` + `BOOND_PASSWORD` (BasicAuth, base64-encoded)
+- `BOOND_API_TOKEN` (JWT Bearer)
+- `BOOND_BASE_URL` (optional, defaults to `https://ui.boondmanager.com/api`)
+
+## CI/CD
+
+- **CI** (`.github/workflows/ci.yml`): Runs on push/PR to main. Matrix: Node 20 + 22. Steps: install, lint, typecheck, test:coverage, build.
+- **Release** (`.github/workflows/release.yml`): Triggered on version tags.
+- **Dependabot**: Configured for npm dependencies.
+
+## Code Style
+
+- ESLint 10 + typescript-eslint (recommended config)
+- `@typescript-eslint/no-unused-vars` with `argsIgnorePattern: "^_"`
+- `@typescript-eslint/no-explicit-any` as warning
+- No semicolons preference not enforced (current code uses semicolons)
+- French descriptions in tool metadata (titles, descriptions)
+- English for code, comments, and commit messages

--- a/README.md
+++ b/README.md
@@ -4,64 +4,135 @@
 [![npm version](https://img.shields.io/npm/v/boondmanager-mcp-server.svg)](https://www.npmjs.com/package/boondmanager-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant à Claude (Desktop, Cowork, Code) de rechercher, consulter, créer et modifier des enregistrements dans votre instance BoondManager.
+Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claude (Desktop, Cowork, Code) de rechercher, consulter, creer et modifier des enregistrements dans votre instance BoondManager.
 
-## 🎯 Domaines couverts
+**158 outils** couvrant **36 domaines** de l'API BoondManager.
 
-| Domaine | Outils | Description |
-|---------|--------|-------------|
-| **Candidats** | search, get, create, update, delete + 4 onglets | Gestion du vivier de candidats |
-| **Ressources** | search, get, create, update, delete + 6 onglets | Gestion des collaborateurs/consultants |
-| **Contacts** | search, get, create, update, delete + 3 onglets | Contacts clients et partenaires |
-| **Sociétés** | search, get, create, update, delete + 3 onglets | Entreprises clientes et prospects |
-| **Opportunités** | search, get, create, update, delete + 3 onglets | Pipeline commercial |
-| **Actions** | search, get, create, delete | Suivi d'activité (appels, emails, RDV) |
-| **Feuilles de temps** | search, get, resource timesheets | Consultation des temps saisis |
-| **Projets** | search, get, create, update, delete + 4 onglets | Gestion des missions / projets |
-| **Factures** | search, get, create, update, delete | Facturation client |
-| **Bons de commande** | search, get, create, update, delete | Bons de commande |
-| **Livraisons / CRA** | search, get | Comptes rendus d'activité |
-| **Absences** | search, get, create, update, delete | Congés, RTT, maladie |
-| **Notes de frais** | search, get, create, update, delete | Remboursement de frais |
-| **Produits** | search, get, create, update, delete | Catalogue de produits/prestations |
-| **Positionnements** | search, get, create, delete | Placement candidats/ressources |
-| **Paiements** | search, get | Suivi des règlements |
-| **Avantages** | search, get | Tickets restaurant, mutuelle, primes... |
-| **Application** | dictionnaire, utilisateur courant | Dictionnaires de référence et profil |
+## Domaines couverts
 
-**Total : 84 outils**
+### CRM & Commercial
 
-### Détail des onglets par entité
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Candidats** | 10 | CRUD + information, technical-data, administrative, actions, positionings |
+| **Ressources** | 15 | CRUD + information, technical-data, administrative, advantages, actions, positionings, projects, times-reports, expenses-reports, absences-reports |
+| **Contacts** | 11 | CRUD + information, actions, opportunities, projects, orders, invoices |
+| **Societes** | 14 | CRUD + information, contacts, actions, opportunities, projects, orders, invoices, purchases, provider-invoices |
+| **Opportunites** | 10 | CRUD + information, actions, positionings, projects, simulation |
 
-| Entité | Onglets disponibles |
+### Gestion de projets
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Projets** | 12 | CRUD + information, actions, simulation, deliveries-groupments, orders, purchases, productivity |
+| **Positionnements** | 4 | search, get, create, delete |
+| **Livraisons / CRA** | 2 | search, get |
+| **Achats / Sous-traitance** | 4 | search, get, create, delete |
+
+### Facturation & Finance
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Factures client** | 5 | CRUD complet |
+| **Factures fournisseur** | 2 | search, get |
+| **Bons de commande** | 5 | CRUD complet |
+| **Paiements** | 2 | search, get |
+| **Notes de frais** | 5 | CRUD complet |
+| **Produits** | 5 | CRUD complet |
+
+### RH & Temps
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Absences** | 5 | CRUD complet |
+| **Planning absences** | 1 | search (vue globale) |
+| **Feuilles de temps** | 3 | search, get, resource timesheets |
+| **Contrats** | 2 | get, create |
+| **Avantages** | 2 | search, get |
+
+### Suivi d'activite
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Actions** | 4 | search, get, create, delete |
+| **Validations** | 2 | search, get |
+| **Todolists** | 2 | search, get |
+
+### Reporting
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Reporting societes** | 1 | search |
+| **Reporting projets** | 1 | search |
+| **Reporting ressources** | 1 | search |
+| **Reporting synthese** | 1 | search |
+| **Reporting plans de production** | 1 | search |
+
+### Administration & Configuration
+
+| Domaine | Outils | Operations |
+|---------|--------|------------|
+| **Comptes utilisateurs** | 2 | search, get |
+| **Agences** | 2 | search, get |
+| **Business Units** | 2 | search, get |
+| **Poles** | 2 | search, get |
+| **Roles** | 2 | search, get |
+| **Calendriers** | 2 | search, get |
+| **Drapeaux / Etiquettes** | 2 | search, get |
+| **Webhooks** | 2 | search, get |
+| **Logs d'audit** | 2 | search, get |
+| **Notifications** | 2 | search, get |
+| **Fils de discussion** | 2 | search, get |
+| **Application** | 2 | dictionnaire, utilisateur courant |
+
+### Detail des onglets par entite
+
+Les entites principales disposent d'outils dedies par onglet pour un acces cible :
+
+| Entite | Onglets disponibles |
 |--------|-------------------|
-| Candidats | information, technical, actions, documents |
-| Ressources | information, technical, financial, actions, contracts, documents |
-| Contacts | information, actions, documents |
-| Sociétés | information, actions, documents |
-| Opportunités | information, actions, documents |
-| Projets | information, planning, actions, documents |
+| Candidats | information, technical-data, administrative, actions, positionings |
+| Ressources | information, technical-data, administrative, advantages, actions, positionings, projects, times-reports, expenses-reports, absences-reports |
+| Contacts | information, actions, opportunities, projects, orders, invoices |
+| Societes | information, contacts, actions, opportunities, projects, orders, invoices, purchases, provider-invoices |
+| Opportunites | information, actions, positionings, projects, simulation |
+| Projets | information, actions, simulation, deliveries-groupments, orders, purchases, productivity |
 
-## 📋 Prérequis
+## Prerequis
 
 - Node.js >= 20
-- Un compte BoondManager avec accès API activé
-- L'option "Allow API Rest calls using BasicAuth authentication" activée dans la configuration BoondManager (si BasicAuth)
+- Un compte BoondManager avec acces API active
+- L'option "Allow API Rest calls using BasicAuth authentication" activee dans la configuration BoondManager (si BasicAuth)
 
-## 🚀 Installation
+## Installation
+
+### Via npm (recommande)
 
 ```bash
-git clone <votre-repo>/boondmanager-mcp-server
+npx boondmanager-mcp-server
+```
+
+Ou installation globale :
+
+```bash
+npm install -g boondmanager-mcp-server
+boondmanager-mcp-server
+```
+
+### Depuis les sources
+
+```bash
+git clone https://github.com/fauguste/boondmanager-mcp-server.git
 cd boondmanager-mcp-server
 npm install
 npm run build
 ```
 
-## ⚙️ Configuration
+## Configuration
 
 ### Variables d'environnement
 
-**Option 1 : BasicAuth (recommandé pour démarrer)**
+**Option 1 : BasicAuth (recommande pour demarrer)**
 ```bash
 export BOOND_USER="votre_login"
 export BOOND_PASSWORD="votre_mot_de_passe"
@@ -72,10 +143,12 @@ export BOOND_PASSWORD="votre_mot_de_passe"
 export BOOND_API_TOKEN="votre_token_jwt"
 ```
 
-**Option 3 : URL personnalisée (si instance dédiée)**
+**Option 3 : URL personnalisee (si instance dediee)**
 ```bash
 export BOOND_BASE_URL="https://votre-instance.boondmanager.com/api"
 ```
+
+Par defaut, l'URL est `https://ui.boondmanager.com/api`.
 
 ### Configuration Claude Desktop / Cowork
 
@@ -83,6 +156,23 @@ Ajoutez dans votre fichier de configuration Claude :
 
 **macOS** : `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows** : `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "boondmanager": {
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_USER": "votre_login",
+        "BOOND_PASSWORD": "votre_mot_de_passe"
+      }
+    }
+  }
+}
+```
+
+Ou si installe depuis les sources :
 
 ```json
 {
@@ -99,59 +189,99 @@ Ajoutez dans votre fichier de configuration Claude :
 }
 ```
 
-## 💬 Exemples d'utilisation
+## Exemples d'utilisation
 
-Une fois configuré, vous pouvez demander à Claude :
+Une fois configure, vous pouvez demander a Claude :
 
-- *"Recherche les candidats avec des compétences en React à Paris"*
-- *"Montre-moi les détails de la ressource #12345"*
-- *"Crée un nouveau contact Jean Dupont chez Acme Corp"*
-- *"Liste toutes les opportunités en cours"*
-- *"Quelles sont les actions récentes sur le candidat #789 ?"*
-- *"Mets à jour l'email du contact #456"*
-- *"Affiche les feuilles de temps de la ressource #100 pour mars 2025"*
-- *"Crée un projet Mission Alpha pour la société #42"*
-- *"Recherche les factures en attente de paiement"*
-- *"Liste les absences prévues ce mois-ci"*
-- *"Affiche les notes de frais de la ressource #200"*
-- *"Quels sont les bons de commande du projet #55 ?"*
-- *"Récupère le dictionnaire des types d'actions"*
-- *"Positionne le candidat #10 sur l'opportunité #20"*
+**CRM & Commercial**
+- *"Recherche les candidats avec des competences en React a Paris"*
+- *"Montre-moi les details techniques de la ressource #12345"*
+- *"Cree un nouveau contact Jean Dupont chez Acme Corp"*
+- *"Liste toutes les opportunites en cours"*
+- *"Quels sont les positionnements de l'opportunite #20 ?"*
+
+**Gestion de projets**
+- *"Cree un projet Mission Alpha pour la societe #42"*
 - *"Affiche le planning du projet #33"*
+- *"Quels sont les bons de commande du projet #55 ?"*
+- *"Affiche la productivite du projet #12"*
 
-## 🏗️ Architecture
+**Facturation & Finance**
+- *"Recherche les factures en attente de paiement"*
+- *"Liste les factures fournisseur de la societe #100"*
+- *"Affiche les achats du projet #55"*
+
+**RH & Temps**
+- *"Affiche les feuilles de temps de la ressource #100 pour mars 2025"*
+- *"Liste les absences prevues ce mois-ci"*
+- *"Affiche les notes de frais de la ressource #200"*
+- *"Quels sont les avantages de la ressource #50 ?"*
+
+**Suivi d'activite**
+- *"Quelles sont les actions recentes sur le candidat #789 ?"*
+- *"Affiche les validations en attente"*
+- *"Liste les taches de ma todolist"*
+
+**Reporting**
+- *"Affiche le reporting de synthese globale"*
+- *"Quel est le reporting de productivite des ressources ?"*
+
+**Administration**
+- *"Recupere le dictionnaire des types d'actions"*
+- *"Liste les agences et business units"*
+- *"Affiche les webhooks configures"*
+
+## Architecture
 
 ```
 boondmanager-mcp-server/
 ├── src/
-│   ├── index.ts              # Point d'entrée MCP (stdio)
-│   ├── constants.ts          # Configuration et constantes
+│   ├── index.ts              # Point d'entree MCP (stdio)
+│   ├── constants.ts          # Configuration, API paths, onglets
 │   ├── types.ts              # Types TypeScript (JSON:API)
 │   ├── services/
 │   │   └── boond-client.ts   # Client HTTP API BoondManager
 │   ├── schemas/
-│   │   └── index.ts          # Schémas Zod (validation)
+│   │   └── index.ts          # Schemas Zod (validation des entrees)
 │   └── tools/
-│       ├── index.ts          # Export barrel
-│       ├── crud-factory.ts   # Factory générique CRUD (DRY)
-│       ├── candidates.ts     # Outils candidats (CRUD + onglets)
-│       ├── resources.ts      # Outils ressources (CRUD + onglets)
-│       ├── contacts.ts       # Outils contacts (CRUD + onglets)
-│       ├── companies.ts      # Outils sociétés (CRUD + onglets)
-│       ├── opportunities.ts  # Outils opportunités (CRUD + onglets)
-│       ├── actions.ts        # Outils actions
-│       ├── timesheets.ts     # Outils feuilles de temps
-│       ├── projects.ts       # Outils projets (CRUD + onglets)
-│       ├── invoices.ts       # Outils factures
-│       ├── orders.ts         # Outils bons de commande
-│       ├── deliveries.ts     # Outils livraisons / CRA
-│       ├── absences.ts       # Outils absences
-│       ├── expenses.ts       # Outils notes de frais
-│       ├── products.ts       # Outils produits
-│       ├── positionings.ts   # Outils positionnements
-│       ├── payments.ts       # Outils paiements
-│       ├── advantages.ts     # Outils avantages
-│       └── application.ts    # Outils application (dictionnaires)
+│       ├── index.ts          # Barrel export de tous les domaines
+│       ├── crud-factory.ts   # Factory generique CRUD (DRY)
+│       ├── candidates.ts     # 10 outils (CRUD + 5 onglets)
+│       ├── resources.ts      # 15 outils (CRUD + 10 onglets)
+│       ├── contacts.ts       # 11 outils (CRUD + 6 onglets)
+│       ├── companies.ts      # 14 outils (CRUD + 9 onglets)
+│       ├── opportunities.ts  # 10 outils (CRUD + 5 onglets)
+│       ├── projects.ts       # 12 outils (CRUD + 7 onglets)
+│       ├── actions.ts        # 4 outils
+│       ├── timesheets.ts     # 3 outils
+│       ├── invoices.ts       # 5 outils
+│       ├── orders.ts         # 5 outils
+│       ├── deliveries.ts     # 2 outils
+│       ├── absences.ts       # 5 outils
+│       ├── expenses.ts       # 5 outils
+│       ├── products.ts       # 5 outils
+│       ├── positionings.ts   # 4 outils
+│       ├── payments.ts       # 2 outils
+│       ├── advantages.ts     # 2 outils
+│       ├── contracts.ts      # 2 outils
+│       ├── purchases.ts      # 4 outils
+│       ├── provider-invoices.ts # 2 outils
+│       ├── accounts.ts       # 2 outils
+│       ├── agencies.ts       # 2 outils
+│       ├── business-units.ts # 2 outils
+│       ├── poles.ts          # 2 outils
+│       ├── roles.ts          # 2 outils
+│       ├── calendars.ts      # 2 outils
+│       ├── flags.ts          # 2 outils
+│       ├── webhooks.ts       # 2 outils
+│       ├── logs.ts           # 2 outils
+│       ├── notifications.ts  # 2 outils
+│       ├── threads.ts        # 2 outils
+│       ├── todolists.ts      # 2 outils
+│       ├── validations.ts    # 2 outils
+│       ├── reporting.ts      # 5 outils
+│       ├── planning-absences.ts # 1 outil
+│       └── application.ts    # 2 outils
 ├── dist/                     # Build JavaScript
 ├── .github/                  # CI/CD, templates, Dependabot
 ├── package.json
@@ -161,17 +291,18 @@ boondmanager-mcp-server/
 └── README.md
 ```
 
-## 🔒 Sécurité
+## Securite
 
-- Les credentials ne transitent jamais via le réseau MCP — ils sont configurés en variables d'environnement locales
-- Le serveur tourne en local (stdio), pas de port réseau exposé
+- Les credentials ne transitent jamais via le reseau MCP -- ils sont configures en variables d'environnement locales
+- Le serveur tourne en local (stdio), pas de port reseau expose
 - Compatible avec les exigences ISO 27001
-- L'API BoondManager est hébergée en France et conforme RGPD
+- L'API BoondManager est hebergee en France et conforme RGPD
+- Authentification par BasicAuth (base64) ou JWT Bearer token
 
-## 🔧 Développement
+## Developpement
 
 ```bash
-# Mode watch pour le développement
+# Mode watch pour le developpement
 npm run dev
 
 # Build
@@ -181,21 +312,31 @@ npm run build
 npm start
 
 # Tests
-npm test
-npm run test:coverage
+npm test               # 255 tests
+npm run test:coverage  # Avec couverture
 
-# Lint
+# Qualite
 npm run lint
 npm run typecheck
 ```
 
-## 📚 Ressources
+### Stack technique
+
+- **Runtime** : Node.js >= 20 (ES2022)
+- **Langage** : TypeScript 5.8+ (mode strict)
+- **MCP SDK** : @modelcontextprotocol/sdk 1.12+
+- **Validation** : Zod 4
+- **Tests** : Vitest 4 + couverture V8
+- **Lint** : ESLint 10 + typescript-eslint
+- **Transport** : stdio (pas de port reseau)
+
+## Ressources
 
 - [Documentation API BoondManager](https://doc.boondmanager.com/api-externe/)
 - [Collection Postman BoondManager](https://www.postman.com/boondmanager)
-- [Spécification MCP](https://modelcontextprotocol.io/)
-- [pyboondmanager (référence Python)](https://github.com/tominardi/pyboondmanager)
+- [Specification MCP](https://modelcontextprotocol.io/)
+- [pyboondmanager (reference Python)](https://github.com/tominardi/pyboondmanager)
 
-## 📄 Licence
+## Licence
 
 MIT - Silamir


### PR DESCRIPTION
## Summary
- Rewrite README with accurate tool inventory: **158 tools** across **36 domains**
- Organize domains by category (CRM, Projects, Finance, HR, Reporting, Admin)
- Add detailed tab listings per entity with actual API endpoint names
- Add `npx` install instructions and enriched usage examples
- Create CLAUDE.md with architecture guide, testing patterns, naming conventions, and contributor guide

## Test plan
- [x] `npm run lint` — no errors
- [x] `npm run typecheck` — no errors
- [x] `npm test` — 255/255 tests passing
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)