### PR TITLE
fix: pass date and period parameters in invoice search

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -246,6 +246,7 @@ export const InvoiceSearchSchema = z.object({
   projectId: z.string().optional().describe("Filtrer par ID projet"),
   startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
+  period: z.string().optional().describe("Type de période (created, updated, expectedPayment, performedPayment, period)"),
   page: z.number().int().min(1).default(1).describe("Numéro de page"),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -28,6 +28,9 @@ Returns: Liste des factures correspondantes.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
+      if (params.startDate) query["startDate"] = params.startDate;
+      if (params.endDate) query["endDate"] = params.endDate;
+      query["period"] = params.period || "period";
       const response = await apiRequest("/invoices", "GET", undefined, query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "facture") }],


### PR DESCRIPTION
## Summary

Fixed invoice search to properly pass date filtering parameters to the BoondManager API.

## Changes

- **Schema**: Added `period` parameter to `InvoiceSearchSchema` to specify which date field to filter on
- **Implementation**: Forward `startDate`, `endDate`, and `period` parameters in the API query

## Problem

The invoice search was missing critical date filtering parameters:
- `startDate` and `endDate` were defined in the schema but not forwarded to the API query
- The `period` parameter was missing entirely, needed to specify which date field to filter on (created, updated, expectedPayment, performedPayment, or period)

This fix ensures the API receives the date range and period type for proper invoice filtering.

## Testing

- TypeScript compilation passes
- Linting passes
- Type checking passes