### PR TITLE
Add Streamable HTTP transport & server factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for the BoondManager API. Exposes 158 tools 
 
 - **Language**: TypeScript (strict mode), ES2022, Node16 module resolution
 - **Runtime**: Node.js >= 20
-- **Transport**: stdio (no network port)
+- **Transports**: stdio (default, no network port) and Streamable HTTP (MCP 2025-03-26, for gateways/remote)
 - **API format**: JSON:API (BoondManager REST API)
 
 ## Commands
@@ -31,9 +31,12 @@ npx vitest run src/tools/candidates.test.ts
 
 ```
 src/
-├── index.ts              # Entry point: creates McpServer, registers all tools, starts stdio transport
+├── index.ts              # Entry point: initClient(), selects transport (stdio or http) via MCP_TRANSPORT
+├── server.ts             # createMcpServer() factory — instantiates McpServer + registers all tools
 ├── constants.ts          # DEFAULT_BASE_URL, pagination limits, API_PATHS, ENTITY_TABS
 ├── types.ts              # JsonApiResource, JsonApiResponse, BoondConfig, SearchParams
+├── transports/
+│   └── http.ts           # startHttpTransport() + resolveHttpOptions() — MCP Streamable HTTP server
 ├── services/
 │   └── boond-client.ts   # HTTP client: apiRequest(), buildSearchQuery(), formatListResponse(), formatDetailResponse()
 ├── schemas/
@@ -128,6 +131,26 @@ Every tool must declare annotations:
 - `destructiveHint: true` for delete operations
 - `idempotentHint: true` for search/get/update operations
 - `openWorldHint: true` for search operations (paginated, keyword-filtered)
+
+## Transports
+
+The server selects its transport from `MCP_TRANSPORT`:
+
+- **`stdio`** (default): wraps `StdioServerTransport`, used by Claude Desktop / Claude Code locally.
+- **`http`** (alias: `streamable-http`): starts a Node HTTP server using `StreamableHTTPServerTransport` from the MCP SDK. Intended for MCP gateways and remote deployments.
+
+HTTP env vars (see `src/transports/http.ts::resolveHttpOptions`):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `MCP_HTTP_HOST` | `127.0.0.1` | Listen interface |
+| `MCP_HTTP_PORT` | `3000` | TCP port |
+| `MCP_HTTP_PATH` | `/mcp` | Endpoint path |
+| `MCP_HTTP_STATEFUL` | `false` | `true` to enable session mode (`Mcp-Session-Id`) |
+| `MCP_HTTP_BEARER_TOKEN` | — | Require `Authorization: Bearer <token>` on every request |
+| `MCP_HTTP_JSON_RESPONSE` | `false` | `true` to return JSON instead of SSE streams |
+
+Stateless mode spins up a fresh `McpServer`+`StreamableHTTPServerTransport` per POST. Stateful mode keeps a `sessionId → transport` map and expects the client to echo `Mcp-Session-Id`.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,105 @@ export BOOND_BASE_URL="https://votre-instance.boondmanager.com/api"
 
 Par defaut, l'URL est `https://ui.boondmanager.com/api`.
 
+## Transports
+
+Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.
+
+| Transport | Valeur | Cas d'usage |
+|-----------|--------|-------------|
+| **stdio** (defaut) | `stdio` ou non defini | Claude Desktop, Claude Code, integration locale |
+| **Streamable HTTP** | `http` (alias : `streamable-http`) | Gateway MCP, deploiement distant, conteneurs |
+
+### Streamable HTTP (pour les gateways MCP)
+
+Depuis la v1.4.0, le serveur peut etre expose en HTTP (specification MCP Streamable HTTP 2025-03-26) afin d'etre branche derriere une passerelle MCP ou deploye comme service.
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HTTP_HOST=0.0.0.0        # defaut: 127.0.0.1
+export MCP_HTTP_PORT=3000           # defaut: 3000
+export MCP_HTTP_PATH=/mcp           # defaut: /mcp
+export MCP_HTTP_BEARER_TOKEN=xxx    # optionnel: protege l'endpoint
+export BOOND_API_TOKEN=...          # (credentials BoondManager, comme en stdio)
+
+npx boondmanager-mcp-server
+# 🚀 BoondManager MCP Server running (streamable HTTP transport)
+# 📡 Endpoint: http://0.0.0.0:3000/mcp
+# 🔑 Mode: stateless
+```
+
+**Variables d'environnement HTTP**
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `MCP_TRANSPORT` | `stdio` | `http` pour activer le transport HTTP |
+| `MCP_HTTP_HOST` | `127.0.0.1` | Interface d'ecoute (`0.0.0.0` pour exposer) |
+| `MCP_HTTP_PORT` | `3000` | Port TCP |
+| `MCP_HTTP_PATH` | `/mcp` | Chemin HTTP de l'endpoint MCP |
+| `MCP_HTTP_STATEFUL` | `false` | `true` pour activer le mode stateful (session `Mcp-Session-Id`) |
+| `MCP_HTTP_BEARER_TOKEN` | _(vide)_ | Si defini, le serveur exige `Authorization: Bearer <token>` |
+| `MCP_HTTP_JSON_RESPONSE` | `false` | `true` pour forcer des reponses JSON (sans SSE) |
+
+**Stateless (defaut)** : chaque requete HTTP POST est independante, idealement adapte a un gateway qui multiplexe plusieurs serveurs MCP. Aucune session n'est conservee cote serveur.
+
+**Stateful** : le serveur genere un `Mcp-Session-Id` a l'initialisation que le client doit renvoyer dans chaque requete suivante. Utile pour les clients MCP natifs qui beneficient du streaming SSE et des notifications serveur.
+
+#### Exemple : verifier l'endpoint
+
+```bash
+curl -s -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {},
+      "clientInfo": { "name": "curl", "version": "1.0" }
+    }
+  }'
+```
+
+#### Exemple : Claude Code via HTTP
+
+```bash
+claude mcp add --transport http \
+  --header "Authorization: Bearer votre_token_local" \
+  boondmanager https://mcp.votre-domaine.com/mcp
+```
+
+#### Exemple : configuration `.mcp.json` HTTP
+
+```json
+{
+  "mcpServers": {
+    "boondmanager": {
+      "type": "http",
+      "url": "https://mcp.votre-domaine.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MCP_HTTP_BEARER_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+#### Exemple : Docker
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_BEARER_TOKEN=$(openssl rand -hex 32) \
+  -e BOOND_API_TOKEN=$BOOND_API_TOKEN \
+  node:20-alpine \
+  npx -y boondmanager-mcp-server
+```
+
+> **Securite** : en HTTP, les credentials BoondManager restent cote serveur (variables d'environnement du conteneur). Seul le token MCP (`MCP_HTTP_BEARER_TOKEN`) circule entre le client et le serveur. Derriere un reverse proxy, ajoutez TLS (HTTPS) et limitez l'acces reseau au gateway.
+
 ## Exemples d'utilisation
 
 Une fois configure, vous pouvez demander a Claude :
@@ -315,9 +414,12 @@ Une fois configure, vous pouvez demander a Claude :
 ```
 boondmanager-mcp-server/
 ├── src/
-│   ├── index.ts              # Point d'entree MCP (stdio)
+│   ├── index.ts              # Point d'entree MCP (selection du transport)
+│   ├── server.ts             # Factory createMcpServer() + liste des domaines
 │   ├── constants.ts          # Configuration, API paths, onglets
 │   ├── types.ts              # Types TypeScript (JSON:API)
+│   ├── transports/
+│   │   └── http.ts           # Transport Streamable HTTP (gateway/remote)
 │   ├── services/
 │   │   └── boond-client.ts   # Client HTTP API BoondManager
 │   ├── schemas/
@@ -372,11 +474,12 @@ boondmanager-mcp-server/
 
 ## Securite
 
-- Les credentials ne transitent jamais via le reseau MCP -- ils sont configures en variables d'environnement locales
-- Le serveur tourne en local (stdio), pas de port reseau expose
+- Les credentials BoondManager (JWT ou BasicAuth) ne transitent jamais via le protocole MCP -- ils sont configures en variables d'environnement cote serveur uniquement
+- En mode **stdio**, le serveur tourne en local, aucun port reseau n'est expose
+- En mode **streamable HTTP**, protegez l'endpoint avec `MCP_HTTP_BEARER_TOKEN` + TLS (HTTPS via reverse proxy) et restreignez l'acces reseau a votre gateway
 - Compatible avec les exigences ISO 27001
 - L'API BoondManager est hebergee en France et conforme RGPD
-- Authentification par BasicAuth (base64) ou JWT Bearer token
+- Authentification BoondManager : JWT (recommande), BasicAuth, ou JWT construit automatiquement a partir des composants
 
 ## Developpement
 
@@ -407,7 +510,7 @@ npm run typecheck
 - **Validation** : Zod 4
 - **Tests** : Vitest 4 + couverture V8
 - **Lint** : ESLint 10 + typescript-eslint
-- **Transport** : stdio (pas de port reseau)
+- **Transports** : stdio (defaut) + Streamable HTTP (MCP 2025-03-26)
 
 ## Ressources
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,90 +1,17 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { initClient } from "./services/boond-client.js";
-import {
-  registerCandidateTools,
-  registerResourceTools,
-  registerContactTools,
-  registerCompanyTools,
-  registerOpportunityTools,
-  registerActionTools,
-  registerTimesheetTools,
-  registerProjectTools,
-  registerInvoiceTools,
-  registerOrderTools,
-  registerDeliveryTools,
-  registerAbsenceTools,
-  registerExpenseTools,
-  registerProductTools,
-  registerPositioningTools,
-  registerPaymentTools,
-  registerAdvantageTools,
-  registerApplicationTools,
-  registerContractTools,
-  registerPurchaseTools,
-  registerProviderInvoiceTools,
-  registerAccountTools,
-  registerAgencyTools,
-  registerBusinessUnitTools,
-  registerRoleTools,
-  registerLogTools,
-  registerNotificationTools,
-  registerThreadTools,
-  registerTodolistTools,
-  registerFlagTools,
-  registerCalendarTools,
-  registerWebhookTools,
-  registerValidationTools,
-  registerPoleTools,
-  registerReportingTools,
-  registerPlanningAbsenceTools,
-} from "./tools/index.js";
+import { createMcpServer, REGISTERED_DOMAINS } from "./server.js";
+import { resolveHttpOptions, startHttpTransport } from "./transports/http.js";
 
-const server = new McpServer({
-  name: "boondmanager-mcp-server",
-  version: "1.0.0",
-});
+type TransportKind = "stdio" | "http";
 
-// Register all domain tools
-registerCandidateTools(server);
-registerResourceTools(server);
-registerContactTools(server);
-registerCompanyTools(server);
-registerOpportunityTools(server);
-registerActionTools(server);
-registerTimesheetTools(server);
-registerProjectTools(server);
-registerInvoiceTools(server);
-registerOrderTools(server);
-registerDeliveryTools(server);
-registerAbsenceTools(server);
-registerExpenseTools(server);
-registerProductTools(server);
-registerPositioningTools(server);
-registerPaymentTools(server);
-registerAdvantageTools(server);
-registerApplicationTools(server);
-registerContractTools(server);
-registerPurchaseTools(server);
-registerProviderInvoiceTools(server);
-registerAccountTools(server);
-registerAgencyTools(server);
-registerBusinessUnitTools(server);
-registerRoleTools(server);
-registerLogTools(server);
-registerNotificationTools(server);
-registerThreadTools(server);
-registerTodolistTools(server);
-registerFlagTools(server);
-registerCalendarTools(server);
-registerWebhookTools(server);
-registerValidationTools(server);
-registerPoleTools(server);
-registerReportingTools(server);
-registerPlanningAbsenceTools(server);
+function resolveTransport(): TransportKind {
+  const raw = (process.env["MCP_TRANSPORT"] ?? "").toLowerCase().trim();
+  if (raw === "http" || raw === "streamable-http" || raw === "streamablehttp") return "http";
+  return "stdio";
+}
 
-// Initialize and run
 async function main(): Promise<void> {
   try {
     initClient();
@@ -93,10 +20,31 @@ async function main(): Promise<void> {
     console.error("The server will start but API calls will fail without proper credentials.");
   }
 
+  const kind = resolveTransport();
+
+  if (kind === "http") {
+    const options = resolveHttpOptions();
+    const handle = await startHttpTransport(createMcpServer, options);
+    console.error("🚀 BoondManager MCP Server running (streamable HTTP transport)");
+    console.error(`📡 Endpoint: http://${handle.address.host}:${handle.address.port}${handle.address.path}`);
+    console.error(`🔑 Mode: ${options.stateless ? "stateless" : "stateful"}${options.bearerToken ? " (bearer auth)" : ""}`);
+    console.error(`📦 Domains: ${REGISTERED_DOMAINS.join(", ")}`);
+
+    const shutdown = async (signal: string): Promise<void> => {
+      console.error(`\n🛑 Received ${signal}, shutting down...`);
+      await handle.close();
+      process.exit(0);
+    };
+    process.on("SIGINT", () => void shutdown("SIGINT"));
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+    return;
+  }
+
+  const server = createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("🚀 BoondManager MCP Server running (stdio transport)");
-  console.error("📦 Domains: candidates, resources, contacts, companies, opportunities, actions, timesheets, projects, invoices, orders, deliveries, absences, expenses, products, positionings, payments, advantages, application, contracts, purchases, provider-invoices, accounts, agencies, business-units, roles, logs, notifications, threads, todolists, flags, calendars, webhooks, validations, poles, reporting, planning-absences");
+  console.error(`📦 Domains: ${REGISTERED_DOMAINS.join(", ")}`);
 }
 
 main().catch((error) => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { createMcpServer, REGISTERED_DOMAINS, SERVER_NAME } from "./server.js";
+
+describe("createMcpServer", () => {
+  it("returns an McpServer instance with the expected name", () => {
+    const server = createMcpServer();
+    expect(server).toBeDefined();
+    expect(SERVER_NAME).toBe("boondmanager-mcp-server");
+  });
+
+  it("exposes a non-empty list of registered domains", () => {
+    expect(REGISTERED_DOMAINS.length).toBeGreaterThan(30);
+    expect(REGISTERED_DOMAINS).toContain("candidates");
+    expect(REGISTERED_DOMAINS).toContain("resources");
+    expect(REGISTERED_DOMAINS).toContain("application");
+    expect(REGISTERED_DOMAINS).toContain("reporting");
+  });
+
+  it("can be instantiated multiple times without throwing", () => {
+    expect(() => createMcpServer()).not.toThrow();
+    expect(() => createMcpServer()).not.toThrow();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,98 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  registerCandidateTools,
+  registerResourceTools,
+  registerContactTools,
+  registerCompanyTools,
+  registerOpportunityTools,
+  registerActionTools,
+  registerTimesheetTools,
+  registerProjectTools,
+  registerInvoiceTools,
+  registerOrderTools,
+  registerDeliveryTools,
+  registerAbsenceTools,
+  registerExpenseTools,
+  registerProductTools,
+  registerPositioningTools,
+  registerPaymentTools,
+  registerAdvantageTools,
+  registerApplicationTools,
+  registerContractTools,
+  registerPurchaseTools,
+  registerProviderInvoiceTools,
+  registerAccountTools,
+  registerAgencyTools,
+  registerBusinessUnitTools,
+  registerRoleTools,
+  registerLogTools,
+  registerNotificationTools,
+  registerThreadTools,
+  registerTodolistTools,
+  registerFlagTools,
+  registerCalendarTools,
+  registerWebhookTools,
+  registerValidationTools,
+  registerPoleTools,
+  registerReportingTools,
+  registerPlanningAbsenceTools,
+} from "./tools/index.js";
+
+export const SERVER_NAME = "boondmanager-mcp-server";
+export const SERVER_VERSION = "1.0.0";
+
+export const REGISTERED_DOMAINS = [
+  "candidates", "resources", "contacts", "companies", "opportunities", "actions",
+  "timesheets", "projects", "invoices", "orders", "deliveries", "absences",
+  "expenses", "products", "positionings", "payments", "advantages", "application",
+  "contracts", "purchases", "provider-invoices", "accounts", "agencies",
+  "business-units", "roles", "logs", "notifications", "threads", "todolists",
+  "flags", "calendars", "webhooks", "validations", "poles", "reporting",
+  "planning-absences",
+] as const;
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+  });
+
+  registerCandidateTools(server);
+  registerResourceTools(server);
+  registerContactTools(server);
+  registerCompanyTools(server);
+  registerOpportunityTools(server);
+  registerActionTools(server);
+  registerTimesheetTools(server);
+  registerProjectTools(server);
+  registerInvoiceTools(server);
+  registerOrderTools(server);
+  registerDeliveryTools(server);
+  registerAbsenceTools(server);
+  registerExpenseTools(server);
+  registerProductTools(server);
+  registerPositioningTools(server);
+  registerPaymentTools(server);
+  registerAdvantageTools(server);
+  registerApplicationTools(server);
+  registerContractTools(server);
+  registerPurchaseTools(server);
+  registerProviderInvoiceTools(server);
+  registerAccountTools(server);
+  registerAgencyTools(server);
+  registerBusinessUnitTools(server);
+  registerRoleTools(server);
+  registerLogTools(server);
+  registerNotificationTools(server);
+  registerThreadTools(server);
+  registerTodolistTools(server);
+  registerFlagTools(server);
+  registerCalendarTools(server);
+  registerWebhookTools(server);
+  registerValidationTools(server);
+  registerPoleTools(server);
+  registerReportingTools(server);
+  registerPlanningAbsenceTools(server);
+
+  return server;
+}

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveHttpOptions, startHttpTransport, type HttpServerHandle } from "./http.js";
+import { createMcpServer } from "../server.js";
+
+const ENV_KEYS = [
+  "MCP_HTTP_PORT",
+  "MCP_HTTP_HOST",
+  "MCP_HTTP_PATH",
+  "MCP_HTTP_STATEFUL",
+  "MCP_HTTP_BEARER_TOKEN",
+  "MCP_HTTP_JSON_RESPONSE",
+];
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+describe("resolveHttpOptions", () => {
+  beforeEach(() => clearEnv());
+  afterEach(() => clearEnv());
+
+  it("returns sensible defaults when no env vars are set", () => {
+    const opts = resolveHttpOptions();
+    expect(opts.host).toBe("127.0.0.1");
+    expect(opts.port).toBe(3000);
+    expect(opts.path).toBe("/mcp");
+    expect(opts.stateless).toBe(true);
+    expect(opts.enableJsonResponse).toBe(false);
+    expect(opts.bearerToken).toBeUndefined();
+  });
+
+  it("reads configuration from environment variables", () => {
+    process.env["MCP_HTTP_PORT"] = "4242";
+    process.env["MCP_HTTP_HOST"] = "0.0.0.0";
+    process.env["MCP_HTTP_PATH"] = "/api/mcp";
+    process.env["MCP_HTTP_STATEFUL"] = "true";
+    process.env["MCP_HTTP_BEARER_TOKEN"] = "sekret";
+    process.env["MCP_HTTP_JSON_RESPONSE"] = "true";
+
+    const opts = resolveHttpOptions();
+    expect(opts.port).toBe(4242);
+    expect(opts.host).toBe("0.0.0.0");
+    expect(opts.path).toBe("/api/mcp");
+    expect(opts.stateless).toBe(false);
+    expect(opts.bearerToken).toBe("sekret");
+    expect(opts.enableJsonResponse).toBe(true);
+  });
+
+  it("ignores unresolved ${...} placeholders", () => {
+    process.env["MCP_HTTP_HOST"] = "${user_config.host}";
+    const opts = resolveHttpOptions();
+    expect(opts.host).toBe("127.0.0.1");
+  });
+
+  it("throws on an invalid port value", () => {
+    process.env["MCP_HTTP_PORT"] = "not-a-port";
+    expect(() => resolveHttpOptions()).toThrow(/Invalid MCP_HTTP_PORT/);
+  });
+});
+
+describe("startHttpTransport (integration)", () => {
+  let handle: HttpServerHandle | undefined;
+
+  afterEach(async () => {
+    if (handle) await handle.close();
+    handle = undefined;
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34567,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/not-mcp`);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects GET in stateless mode with 405", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34568,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`);
+    expect(res.status).toBe(405);
+  });
+
+  it("rejects unauthorized requests when a bearer token is configured", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34569,
+      path: "/mcp",
+      stateless: true,
+      bearerToken: "sekret",
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toBe("Bearer");
+  });
+
+  it("responds to an MCP initialize request in stateless mode", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34570,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "vitest", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      result?: { serverInfo?: { name?: string } };
+    };
+    expect(json.result?.serverInfo?.name).toBe("boondmanager-mcp-server");
+  });
+});

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,0 +1,184 @@
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export interface HttpTransportOptions {
+  host: string;
+  port: number;
+  path: string;
+  stateless: boolean;
+  bearerToken?: string;
+  enableJsonResponse: boolean;
+}
+
+export interface HttpServerHandle {
+  close: () => Promise<void>;
+  address: { host: string; port: number; path: string };
+}
+
+function readEnv(key: string): string | undefined {
+  const v = process.env[key];
+  if (!v || v.startsWith("${")) return undefined;
+  return v;
+}
+
+export function resolveHttpOptions(): HttpTransportOptions {
+  const portRaw = readEnv("MCP_HTTP_PORT");
+  const port = portRaw ? Number.parseInt(portRaw, 10) : 3000;
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid MCP_HTTP_PORT: ${portRaw}`);
+  }
+
+  const stateless = (readEnv("MCP_HTTP_STATEFUL") ?? "false").toLowerCase() !== "true";
+  const enableJsonResponse = (readEnv("MCP_HTTP_JSON_RESPONSE") ?? "false").toLowerCase() === "true";
+
+  return {
+    host: readEnv("MCP_HTTP_HOST") ?? "127.0.0.1",
+    port,
+    path: readEnv("MCP_HTTP_PATH") ?? "/mcp",
+    stateless,
+    bearerToken: readEnv("MCP_HTTP_BEARER_TOKEN"),
+    enableJsonResponse,
+  };
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeJsonRpcError(res: ServerResponse, status: number, message: string): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32000, message },
+      id: null,
+    })
+  );
+}
+
+export async function startHttpTransport(
+  createServerFactory: () => McpServer,
+  options: HttpTransportOptions
+): Promise<HttpServerHandle> {
+  const sessions = new Map<string, StreamableHTTPServerTransport>();
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+
+      if (url.pathname !== options.path) {
+        res.statusCode = 404;
+        res.end("Not found");
+        return;
+      }
+
+      if (options.bearerToken) {
+        const auth = req.headers["authorization"];
+        if (auth !== `Bearer ${options.bearerToken}`) {
+          res.statusCode = 401;
+          res.setHeader("WWW-Authenticate", "Bearer");
+          res.end("Unauthorized");
+          return;
+        }
+      }
+
+      if (options.stateless) {
+        if (req.method !== "POST") {
+          writeJsonRpcError(res, 405, "Only POST is supported in stateless mode");
+          return;
+        }
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse: options.enableJsonResponse,
+        });
+        const server = createServerFactory();
+        res.on("close", () => {
+          void transport.close();
+          void server.close();
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      // Stateful mode: route by Mcp-Session-Id header
+      const sessionIdHeader = req.headers["mcp-session-id"];
+      const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+      if (sessionId && sessions.has(sessionId)) {
+        await sessions.get(sessionId)!.handleRequest(req, res);
+        return;
+      }
+
+      if (req.method !== "POST") {
+        writeJsonRpcError(res, 400, "Missing or invalid session ID");
+        return;
+      }
+
+      // Parse body to detect initialization
+      const body = await readJsonBody(req);
+      if (!isInitializeRequest(body)) {
+        writeJsonRpcError(res, 400, "First request must be an MCP initialize message");
+        return;
+      }
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        enableJsonResponse: options.enableJsonResponse,
+        onsessioninitialized: (id) => {
+          sessions.set(id, transport);
+        },
+        onsessionclosed: (id) => {
+          sessions.delete(id);
+        },
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) sessions.delete(transport.sessionId);
+      };
+
+      const server = createServerFactory();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (error) {
+      console.error("HTTP transport error:", error);
+      if (!res.headersSent) {
+        writeJsonRpcError(res, 500, "Internal server error");
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(options.port, options.host, () => {
+      httpServer.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    address: { host: options.host, port: options.port, path: options.path },
+    close: async () => {
+      await Promise.all(Array.from(sessions.values()).map((t) => t.close()));
+      sessions.clear();
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}


### PR DESCRIPTION
fix #26

Introduce a Streamable HTTP transport and refactor server initialization. Adds src/transports/http.ts (startHttpTransport, resolveHttpOptions) with stateless/stateful modes, bearer-token auth, JSON-response toggle and session handling. Extract tool registration into src/server.ts with createMcpServer, SERVER_NAME and REGISTERED_DOMAINS; index.ts now chooses transport (stdio or http) and starts the HTTP server when configured. Add integration/unit tests for the server and HTTP transport (src/server.test.ts, src/transports/http.test.ts). Update README.md and CLAUDE.md to document the new transport and environment variables.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
