### PR TITLE
Add structured search schemas and query support

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -9,6 +9,144 @@ export const SearchSchema = z.object({
     .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
 }).strict();
 
+// ---- Reusable filter field helpers ----
+// Keep descriptions short here; the tool description guides the LLM on usage.
+const pageField = z.number().int().min(1).default(1).describe("Numéro de page (défaut: 1)");
+const pageSizeField = z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
+  .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`);
+const sortField = z.string().optional().describe("Champ de tri (ex: lastName, createdAt)");
+const orderField = z.enum(["asc", "desc"]).optional().describe("Ordre de tri : 'asc' ou 'desc'");
+const idArray = (doc: string) => z.array(z.string()).optional().describe(doc);
+const intArray = (doc: string) => z.array(z.number().int()).optional().describe(doc);
+const strArray = (doc: string) => z.array(z.string()).optional().describe(doc);
+
+// ---- Resource search schema ----
+// Filtres les plus utiles de /resources. Inclut mainManagers (clé pour hiérarchie N-1/N-2).
+export const ResourceSearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (nom, prénom, email, compétences libres)"),
+  mainManagers: idArray("ID(s) du/des managers principaux. Les ressources retournées ont ce(s) manager(s) comme N+1. CLÉ pour les requêtes hiérarchiques (mes N-1, N-2...)."),
+  states: intArray("États de ressource à inclure (voir dictionnaire 'states/resources')"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  skills: strArray("Compétences techniques (ex: ['Java', 'React'])"),
+  tools: strArray("Outils / technologies"),
+  activityAreas: strArray("Secteurs d'activité"),
+  languages: strArray("Langues"),
+  typeOf: strArray("Types de ressource (interne, sous-traitant...)"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée (remplace les autres filtres)"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
+// ---- Candidate search schema ----
+export const CandidateSearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (nom, prénom, email, compétences libres)"),
+  mainManagers: idArray("ID(s) du/des managers principaux (responsables des candidats)"),
+  states: intArray("États de candidat (voir dictionnaire 'states/candidates')"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  skills: strArray("Compétences techniques"),
+  tools: strArray("Outils / technologies"),
+  activityAreas: strArray("Secteurs d'activité"),
+  languages: strArray("Langues"),
+  qualifications: strArray("Qualifications / diplômes"),
+  mobilityAreas: strArray("Zones de mobilité"),
+  typeOf: strArray("Types de candidat"),
+  origins: idArray("IDs d'origines (source de recrutement)"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
+// ---- Contact search schema ----
+export const ContactSearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (nom, email, société...)"),
+  mainManagers: idArray("ID(s) du/des managers principaux (responsables commerciaux des contacts)"),
+  states: intArray("États de contact"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  company: z.string().optional().describe("ID d'une société : filtre les contacts rattachés à cette société"),
+  typeOf: strArray("Types de contact"),
+  origins: idArray("IDs d'origines"),
+  activityAreas: strArray("Secteurs d'activité"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
+// ---- Company search schema ----
+export const CompanySearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (nom, SIRET, email...)"),
+  mainManagers: idArray("ID(s) du/des managers principaux (responsables commerciaux)"),
+  states: intArray("États de société"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  typeOf: strArray("Types de société (client, prospect, fournisseur...)"),
+  activityAreas: strArray("Secteurs d'activité"),
+  origins: idArray("IDs d'origines"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
+// ---- Opportunity search schema ----
+export const OpportunitySearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (titre, société, contact...)"),
+  mainManagers: idArray("ID(s) du/des managers principaux (commerciaux en charge)"),
+  states: intArray("États d'opportunité (voir dictionnaire 'states/opportunities')"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  company: z.string().optional().describe("ID d'une société cliente"),
+  contact: z.string().optional().describe("ID d'un contact"),
+  activityAreas: strArray("Secteurs d'activité"),
+  origins: idArray("IDs d'origines"),
+  period: z.enum(["creation", "update", "startDate", "endDate"]).optional()
+    .describe("Champ date sur lequel appliquer startDate/endDate"),
+  startDate: z.string().optional().describe("Début de période (YYYY-MM-DD), à utiliser avec `period`"),
+  endDate: z.string().optional().describe("Fin de période (YYYY-MM-DD), à utiliser avec `period`"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
+// ---- Project search schema ----
+export const ProjectSearchSchema = z.object({
+  keywords: z.string().optional().describe("Mots-clés (nom du projet, société, contact...)"),
+  mainManagers: idArray("ID(s) du/des managers principaux (responsables du projet)"),
+  states: intArray("États de projet (voir dictionnaire 'states/projects')"),
+  agencies: idArray("IDs d'agences"),
+  poles: idArray("IDs de pôles"),
+  businessUnits: idArray("IDs de business units"),
+  company: z.string().optional().describe("ID d'une société cliente"),
+  contact: z.string().optional().describe("ID d'un contact"),
+  typeOf: strArray("Types de projet (régie, forfait, produit...)"),
+  activityAreas: strArray("Secteurs d'activité"),
+  period: z.enum(["creation", "update", "startDate", "endDate"]).optional()
+    .describe("Champ date sur lequel appliquer startDate/endDate"),
+  startDate: z.string().optional().describe("Début de période (YYYY-MM-DD)"),
+  endDate: z.string().optional().describe("Fin de période (YYYY-MM-DD)"),
+  saved: z.string().optional().describe("ID d'une recherche enregistrée"),
+  sort: sortField,
+  order: orderField,
+  page: pageField,
+  pageSize: pageSizeField,
+}).strict();
+
 // ID param schema
 export const IdSchema = z.object({
   id: z.string().min(1).describe("Identifiant unique de l'entité BoondManager"),
@@ -422,6 +560,12 @@ export const DictionaryGetSchema = z.object({
 }).strict();
 
 export type SearchInput = z.infer<typeof SearchSchema>;
+export type ResourceSearchInput = z.infer<typeof ResourceSearchSchema>;
+export type CandidateSearchInput = z.infer<typeof CandidateSearchSchema>;
+export type ContactSearchInput = z.infer<typeof ContactSearchSchema>;
+export type CompanySearchInput = z.infer<typeof CompanySearchSchema>;
+export type OpportunitySearchInput = z.infer<typeof OpportunitySearchSchema>;
+export type ProjectSearchInput = z.infer<typeof ProjectSearchSchema>;
 export type IdInput = z.infer<typeof IdSchema>;
 export type IdTabInput = z.infer<typeof IdTabSchema>;
 export type ResourceTimesheetInput = z.infer<typeof ResourceTimesheetSchema>;

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -65,11 +65,13 @@ function getConfig(): BoondConfig {
   return config!;
 }
 
+export type QueryValue = string | number | Array<string | number> | undefined;
+
 export async function apiRequest(
   path: string,
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" = "GET",
   body?: unknown,
-  queryParams?: Record<string, string | number | undefined>
+  queryParams?: Record<string, QueryValue>
 ): Promise<JsonApiResponse> {
   const { baseUrl, authHeader } = getConfig();
 
@@ -77,7 +79,16 @@ export async function apiRequest(
 
   if (queryParams) {
     for (const [key, value] of Object.entries(queryParams)) {
-      if (value !== undefined && value !== null) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        // BoondManager expects repeated bracket notation: key[]=v1&key[]=v2
+        const bracketKey = key.endsWith("[]") ? key : `${key}[]`;
+        for (const v of value) {
+          if (v !== undefined && v !== null && v !== "") {
+            url.searchParams.append(bracketKey, String(v));
+          }
+        }
+      } else {
         url.searchParams.set(key, String(value));
       }
     }
@@ -113,16 +124,23 @@ export async function apiRequest(
   return (await response.json()) as JsonApiResponse;
 }
 
-export function buildSearchQuery(params: SearchParams): Record<string, string | number | undefined> {
-  const query: Record<string, string | number | undefined> = {};
+export function buildSearchQuery(params: SearchParams): Record<string, QueryValue> {
+  const query: Record<string, QueryValue> = {};
 
   if (params.keywords) query["keywords"] = params.keywords;
   if (params.page !== undefined) query["page"] = params.page;
   if (params.pageSize !== undefined) query["maxResults"] = params.pageSize;
 
-  // Forward any additional filter params
+  // Forward any additional filter params (strings, numbers, or arrays)
   for (const [key, value] of Object.entries(params)) {
-    if (!["keywords", "page", "pageSize"].includes(key) && value !== undefined) {
+    if (["keywords", "page", "pageSize"].includes(key)) continue;
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      // Pass arrays through so apiRequest emits repeated bracket notation
+      query[key] = value as Array<string | number>;
+    } else if (typeof value === "string" || typeof value === "number") {
+      query[key] = value;
+    } else {
       query[key] = String(value);
     }
   }

--- a/src/tools/candidates.ts
+++ b/src/tools/candidates.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CandidateCreateSchema, CandidateUpdateSchema, IdSchema } from "../schemas/index.js";
+import { CandidateCreateSchema, CandidateUpdateSchema, CandidateSearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -90,8 +90,27 @@ Returns: Liste des positionnements du candidat.`,
   },
 ];
 
+const CANDIDATE_SEARCH_DESCRIPTION = `Recherche des candidats dans BoondManager avec filtres avancés.
+
+⚠️ Privilégier les filtres structurés plutôt que de paginer toute la base.
+
+Filtres utiles :
+• \`mainManagers\` : ID(s) des responsables des candidats (utile pour "mes candidats" → passer votre userId obtenu via \`boond_application_current_user\`).
+• \`states\` : états de candidat (voir \`boond_application_dictionary\` avec \`states/candidates\`).
+• \`skills\` / \`tools\` / \`languages\` / \`qualifications\` : filtrer par profil technique.
+• \`activityAreas\` : secteurs d'activité visés.
+• \`agencies\`, \`poles\`, \`businessUnits\` : périmètre organisationnel.
+• \`keywords\` : recherche plein texte (nom, email) — en complément, pas en remplacement.
+
+Les filtres multivalués acceptent un tableau (un seul ID entre crochets est valide).
+
+Returns : liste paginée des candidats. Utiliser \`boond_candidates_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerCandidateTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: CandidateSearchSchema,
+    description: CANDIDATE_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, CandidateCreateSchema, (params) => {

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CompanyCreateSchema, CompanyUpdateSchema, IdSchema } from "../schemas/index.js";
+import { CompanyCreateSchema, CompanyUpdateSchema, CompanySearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -134,8 +134,26 @@ Returns: Liste des factures fournisseur de la société.`,
   },
 ];
 
+const COMPANY_SEARCH_DESCRIPTION = `Recherche des sociétés (clients, prospects, fournisseurs...) dans BoondManager avec filtres avancés.
+
+⚠️ Privilégier les filtres structurés plutôt que de paginer toute la base.
+
+Filtres utiles :
+• \`mainManagers\` : ID(s) des commerciaux responsables (utile pour "mes comptes" → passer votre userId via \`boond_application_current_user\`).
+• \`states\` : états de société.
+• \`typeOf\` : types de société (client, prospect, fournisseur...).
+• \`activityAreas\` : secteurs d'activité.
+• \`origins\` : sources / origines.
+• \`agencies\`, \`poles\`, \`businessUnits\` : périmètre organisationnel.
+• \`keywords\` : recherche plein texte (nom, SIRET, email), en complément.
+
+Returns : liste paginée des sociétés. Utiliser \`boond_companies_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerCompanyTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: CompanySearchSchema,
+    description: COMPANY_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, CompanyCreateSchema, (params) => {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ContactCreateSchema, ContactUpdateSchema, IdSchema } from "../schemas/index.js";
+import { ContactCreateSchema, ContactUpdateSchema, ContactSearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -101,8 +101,26 @@ Returns: Liste des factures du contact.`,
   },
 ];
 
+const CONTACT_SEARCH_DESCRIPTION = `Recherche des contacts (interlocuteurs clients / prospects) dans BoondManager avec filtres avancés.
+
+⚠️ Privilégier les filtres structurés plutôt que de paginer toute la base.
+
+Filtres utiles :
+• \`mainManagers\` : ID(s) des commerciaux responsables (utile pour "mes contacts" → passer votre userId via \`boond_application_current_user\`).
+• \`company\` : tous les contacts d'une société donnée (ID unique).
+• \`states\` : états de contact.
+• \`typeOf\` : types de contact.
+• \`origins\` : sources / origines.
+• \`agencies\`, \`poles\`, \`businessUnits\` : périmètre organisationnel.
+• \`keywords\` : recherche plein texte, en complément.
+
+Returns : liste paginée des contacts. Utiliser \`boond_contacts_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerContactTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: ContactSearchSchema,
+    description: CONTACT_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, ContactCreateSchema, (params) => {

--- a/src/tools/crud-factory.ts
+++ b/src/tools/crud-factory.ts
@@ -11,20 +11,34 @@ interface CrudToolOptions {
   prefix: string;             // ex: "boond_candidates"
 }
 
-export function registerSearchTool(server: McpServer, opts: CrudToolOptions): void {
-  server.registerTool(
-    `${opts.prefix}_search`,
-    {
-      title: `Rechercher des ${opts.entityNamePlural}`,
-      description: `Recherche des ${opts.entityNamePlural} dans BoondManager par mots-clés avec pagination.
+interface SearchToolOverrides {
+  schema?: z.ZodType;
+  title?: string;
+  description?: string;
+}
+
+export function registerSearchTool(
+  server: McpServer,
+  opts: CrudToolOptions,
+  overrides: SearchToolOverrides = {}
+): void {
+  const schema = overrides.schema ?? SearchSchema;
+  const title = overrides.title ?? `Rechercher des ${opts.entityNamePlural}`;
+  const description = overrides.description ?? `Recherche des ${opts.entityNamePlural} dans BoondManager par mots-clés avec pagination.
 
 Args:
   - keywords (string, optional): Termes de recherche (nom, email, compétences...)
   - page (number): Numéro de page (défaut: 1)
   - pageSize (number): Résultats par page (défaut: 20, max: 100)
 
-Returns: Liste des ${opts.entityNamePlural} correspondants avec leur ID, nom et détails principaux.`,
-      inputSchema: SearchSchema,
+Returns: Liste des ${opts.entityNamePlural} correspondants avec leur ID, nom et détails principaux.`;
+
+  server.registerTool(
+    `${opts.prefix}_search`,
+    {
+      title,
+      description,
+      inputSchema: schema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -32,8 +46,8 @@ Returns: Liste des ${opts.entityNamePlural} correspondants avec leur ID, nom et 
         openWorldHint: true,
       },
     },
-    async (params: SearchInput) => {
-      const query = buildSearchQuery(params);
+    async (params: unknown) => {
+      const query = buildSearchQuery(params as SearchInput);
       const response = await apiRequest(opts.apiPath, "GET", undefined, query);
       const text = formatListResponse(response, opts.entityName);
       return {

--- a/src/tools/opportunities.ts
+++ b/src/tools/opportunities.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { OpportunityCreateSchema, OpportunityUpdateSchema, IdSchema } from "../schemas/index.js";
+import { OpportunityCreateSchema, OpportunityUpdateSchema, OpportunitySearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -90,8 +90,25 @@ Returns: Données de simulation financière de l'opportunité.`,
   },
 ];
 
+const OPPORTUNITY_SEARCH_DESCRIPTION = `Recherche des opportunités commerciales dans BoondManager avec filtres avancés.
+
+⚠️ Privilégier les filtres structurés plutôt que de paginer toute la base.
+
+Filtres utiles :
+• \`mainManagers\` : ID(s) des commerciaux en charge (utile pour "mes opportunités" → passer votre userId via \`boond_application_current_user\`).
+• \`states\` : états de l'opportunité (voir \`boond_application_dictionary\` avec \`states/opportunities\`).
+• \`company\` / \`contact\` : filtrer par société cliente ou contact (ID unique chacun).
+• \`period\` + \`startDate\`/\`endDate\` : filtrer sur une période (creation, update, startDate, endDate).
+• \`activityAreas\`, \`origins\` : segmentation métier.
+• \`agencies\`, \`poles\`, \`businessUnits\` : périmètre organisationnel.
+
+Returns : liste paginée des opportunités. Utiliser \`boond_opportunities_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerOpportunityTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: OpportunitySearchSchema,
+    description: OPPORTUNITY_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, OpportunityCreateSchema, (params) => {

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ProjectCreateSchema, ProjectUpdateSchema, IdSchema } from "../schemas/index.js";
+import { ProjectCreateSchema, ProjectUpdateSchema, ProjectSearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -112,8 +112,25 @@ Returns: Données de productivité du projet.`,
   },
 ];
 
+const PROJECT_SEARCH_DESCRIPTION = `Recherche des projets / missions dans BoondManager avec filtres avancés.
+
+⚠️ Privilégier les filtres structurés plutôt que de paginer toute la base.
+
+Filtres utiles :
+• \`mainManagers\` : ID(s) des responsables du projet (utile pour "mes projets" → passer votre userId via \`boond_application_current_user\`).
+• \`states\` : états du projet (voir \`boond_application_dictionary\` avec \`states/projects\`).
+• \`company\` / \`contact\` : filtrer par société cliente ou contact (ID unique).
+• \`typeOf\` : types de projet (régie, forfait, produit...).
+• \`period\` + \`startDate\`/\`endDate\` : filtrer sur une période.
+• \`agencies\`, \`poles\`, \`businessUnits\` : périmètre organisationnel.
+
+Returns : liste paginée des projets. Utiliser \`boond_projects_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerProjectTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: ProjectSearchSchema,
+    description: PROJECT_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, ProjectCreateSchema, (params) => {

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ResourceCreateSchema, ResourceUpdateSchema, IdSchema } from "../schemas/index.js";
+import { ResourceCreateSchema, ResourceUpdateSchema, ResourceSearchSchema, IdSchema } from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -145,8 +145,28 @@ Returns: Liste des demandes d'absences de la ressource.`,
   },
 ];
 
+const RESOURCE_SEARCH_DESCRIPTION = `Recherche des ressources (collaborateurs internes) dans BoondManager avec filtres avancés côté serveur.
+
+⚠️ IMPORTANT — utilisez les filtres ci-dessous plutôt que de paginer toute la base. Le filtre \`mainManagers\` est la clé pour toute question hiérarchique (N-1, N-2, équipe d'un manager).
+
+Cas d'usage courants :
+• Mes N-1 (équipe directe) : appeler d'abord \`boond_application_current_user\` pour obtenir votre userId, puis \`mainManagers: ["<monUserId>"]\`.
+• Mes N-2 et au-delà : pour chaque N-1 obtenu, rappeler cet outil avec \`mainManagers: ["<idDuN-1>"]\`. Répéter récursivement pour la hiérarchie descendante.
+• Équipe d'un autre manager : \`mainManagers: ["<idDuManager>"]\`.
+• Collaborateurs actifs uniquement : \`states: [1]\` (consulter \`boond_application_dictionary\` avec \`states/resources\` pour les valeurs exactes).
+• Recherche par compétence : \`skills: ["Java", "AWS"]\`, \`tools: ["Kubernetes"]\`.
+• Périmètre organisationnel : \`agencies\`, \`poles\`, \`businessUnits\`.
+• \`keywords\` reste utile pour une recherche plein texte (nom, email) mais ne remplace pas les filtres structurés ci-dessus.
+
+Les filtres multivalués (\`mainManagers\`, \`states\`, \`skills\`…) acceptent un tableau ; passer un seul ID dans un tableau d'un élément fonctionne également.
+
+Returns : liste paginée des ressources (id, nom, email, ville, état, titre). Utiliser \`boond_resources_get\` ou les outils d'onglets pour le détail.`;
+
 export function registerResourceTools(server: McpServer): void {
-  registerSearchTool(server, OPTS);
+  registerSearchTool(server, OPTS, {
+    schema: ResourceSearchSchema,
+    description: RESOURCE_SEARCH_DESCRIPTION,
+  });
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, ResourceCreateSchema, (params) => {


### PR DESCRIPTION
Introduce dedicated Zod search schemas for resources, candidates, contacts, companies, opportunities and projects, and export their input types. Update API query handling to support string/number/array values (including repeated bracket notation key[] for arrays) via a new QueryValue type. Refactor registerSearchTool to accept schema/title/description overrides and use the provided schema as the tool inputSchema. Wire the new schemas and descriptive help text into the various tool registration files (candidates, companies, contacts, opportunities, projects, resources) and adjust buildSearchQuery to preserve arrays and proper typing.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [ ] Mon code suit les conventions du projet
- [ ] J'ai lance `npm run lint` et `npm run typecheck`
- [ ] J'ai ajoute des tests couvrant mes changements
- [ ] Tous les tests passent (`npm test`)
- [ ] J'ai mis a jour la documentation si necessaire
