### PR TITLE
Add Smithery config and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ npm install
 npm run build
 ```
 
+### Smithery
+
+Le serveur est aussi disponible sur [Smithery](https://smithery.ai/server/@fauguste/boondmanager-mcp-server). La configuration est dans `smithery.yaml` à la racine du repo : Smithery propose une UI avec les champs d'authentification (JWT auto / JWT pré-construit / BasicAuth) et installe le serveur via `npx`.
+
 ### LobeChat / LobeHub
 
 Le serveur est listé sur le [marketplace MCP de LobeHub](https://lobehub.com/mcp/fauguste-boondmanager-mcp-server). Dans LobeChat (auto-hebergé ou cloud), ajouter le MCP via **Reglages > Plugins > MCP > Ajouter** avec :

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,60 @@
+# Smithery configuration — https://smithery.ai/docs/build/project-config
+# Lets smithery.ai (and aggregators that mirror it) install this MCP server
+# with one click and surface the BoondManager auth knobs in their UI.
+startCommand:
+  type: stdio
+  # JSON Schema describing the user-supplied config. Three auth options are
+  # offered (in priority order, matching src/services/boond-client.ts):
+  #   1. JWT auto: BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY
+  #   2. Pre-built JWT: BOOND_API_TOKEN
+  #   3. BasicAuth: BOOND_USER + BOOND_PASSWORD
+  # All fields are optional in the schema so the user can pick one path; the
+  # server will refuse to start if no complete auth combo is provided.
+  configSchema:
+    type: object
+    properties:
+      boondBaseUrl:
+        type: string
+        title: BoondManager base URL
+        description: API base URL. Leave blank for the default (https://ui.boondmanager.com/api).
+        default: https://ui.boondmanager.com/api
+      boondUserToken:
+        type: string
+        title: User Token (JWT auto, option 1)
+        description: BoondManager user token. Mon compte > Informations de connexion > Clé d'API.
+      boondClientToken:
+        type: string
+        title: Client Token (JWT auto, option 1)
+        description: BoondManager client token. Administration > Espace Développeur > API / Sandbox.
+      boondClientKey:
+        type: string
+        title: Client Key (JWT auto, option 1)
+        description: BoondManager client secret key. Administration > Espace Développeur > API / Sandbox.
+      boondApiToken:
+        type: string
+        title: Pre-built JWT (option 2)
+        description: A BoondManager JWT already constructed elsewhere. Alternative to option 1.
+      boondUser:
+        type: string
+        title: BasicAuth user (option 3)
+        description: BoondManager username for HTTP BasicAuth.
+      boondPassword:
+        type: string
+        title: BasicAuth password (option 3)
+        description: BoondManager password for HTTP BasicAuth.
+  # Smithery invokes commandFunction(config) to build the launch command.
+  # We forward the form fields to the env vars the server reads at startup.
+  commandFunction: |-
+    config => ({
+      command: 'npx',
+      args: ['-y', 'boondmanager-mcp-server'],
+      env: {
+        ...(config.boondBaseUrl ? { BOOND_BASE_URL: config.boondBaseUrl } : {}),
+        ...(config.boondUserToken ? { BOOND_USER_TOKEN: config.boondUserToken } : {}),
+        ...(config.boondClientToken ? { BOOND_CLIENT_TOKEN: config.boondClientToken } : {}),
+        ...(config.boondClientKey ? { BOOND_CLIENT_KEY: config.boondClientKey } : {}),
+        ...(config.boondApiToken ? { BOOND_API_TOKEN: config.boondApiToken } : {}),
+        ...(config.boondUser ? { BOOND_USER: config.boondUser } : {}),
+        ...(config.boondPassword ? { BOOND_PASSWORD: config.boondPassword } : {}),
+      },
+    })


### PR DESCRIPTION
Add smithery.yaml to enable one-click install via Smithery and surface BoondManager auth fields in a UI. Update README to mention Smithery and point to the new config. The Smithery config exposes three auth options (JWT auto: BOOND_USER_TOKEN / BOOND_CLIENT_TOKEN / BOOND_CLIENT_KEY; pre-built JWT: BOOND_API_TOKEN; BasicAuth: BOOND_USER / BOOND_PASSWORD), forwards chosen fields to environment variables, and launches the server with `npx boondmanager-mcp-server`.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [x] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
