### PR TITLE
Parse and format Boond API errors

### DIFF
--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -7,6 +7,8 @@ import {
   initClient,
   buildJwt,
   apiRequest,
+  parseBoondErrorBody,
+  formatApiError,
 } from "./boond-client.js";
 import { CHARACTER_LIMIT } from "../constants.js";
 
@@ -360,7 +362,23 @@ describe("apiRequest", () => {
       })
     );
 
-    await expect(apiRequest("/candidates/999")).rejects.toThrow("BoondManager API error 404");
+    await expect(apiRequest("/candidates/999")).rejects.toThrow("BoondManager API 404");
+  });
+
+  it("should surface Boond errors[].detail when present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: "Unprocessable Entity",
+        text: () => Promise.resolve(JSON.stringify({
+          errors: [{ status: "422", code: "422", detail: "422 - password mismatch" }],
+        })),
+      })
+    );
+
+    await expect(apiRequest("/resources")).rejects.toThrow("422 - password mismatch");
   });
 
   it("should include query params in URL", async () => {
@@ -396,5 +414,76 @@ describe("apiRequest", () => {
     const fetchCall = vi.mocked(fetch).mock.calls[0];
     const url = fetchCall[0] as string;
     expect(url).not.toContain("empty");
+  });
+});
+
+describe("parseBoondErrorBody", () => {
+  it("returns the detail of a single error", () => {
+    expect(parseBoondErrorBody(JSON.stringify({
+      errors: [{ status: "422", detail: "422 - password mismatch" }],
+    }))).toBe("422 - password mismatch");
+  });
+
+  it("joins multiple errors with a separator", () => {
+    expect(parseBoondErrorBody(JSON.stringify({
+      errors: [
+        { detail: "first thing wrong" },
+        { detail: "second thing wrong" },
+      ],
+    }))).toBe("first thing wrong | second thing wrong");
+  });
+
+  it("includes title when distinct from detail", () => {
+    expect(parseBoondErrorBody(JSON.stringify({
+      errors: [{ title: "Forbidden", detail: "user cannot access this scope" }],
+    }))).toBe("Forbidden: user cannot access this scope");
+  });
+
+  it("falls back to code when detail is missing", () => {
+    expect(parseBoondErrorBody(JSON.stringify({
+      errors: [{ code: "503" }],
+    }))).toBe("code 503");
+  });
+
+  it("returns null on non-JSON body", () => {
+    expect(parseBoondErrorBody("Internal Server Error")).toBeNull();
+  });
+
+  it("returns null when there are no errors[]", () => {
+    expect(parseBoondErrorBody(JSON.stringify({ meta: {} }))).toBeNull();
+  });
+
+  it("returns null on empty input", () => {
+    expect(parseBoondErrorBody("")).toBeNull();
+  });
+});
+
+describe("formatApiError", () => {
+  it("uses the parsed Boond detail in the headline and skips the raw body", () => {
+    const body = JSON.stringify({ errors: [{ detail: "422 - password mismatch" }] });
+    const msg = formatApiError(422, "Unprocessable Entity", "GET", "/resources", body);
+    expect(msg).toContain("BoondManager API 422 Unprocessable Entity: 422 - password mismatch");
+    expect(msg).toContain("Endpoint: GET /resources");
+    expect(msg).toContain("Hint:");
+    // raw body must not be repeated when we have a structured detail
+    expect(msg).not.toContain(body);
+  });
+
+  it("falls back to a (truncated) raw body when JSON parsing fails", () => {
+    const body = "x".repeat(800);
+    const msg = formatApiError(500, "Server Error", "GET", "/resources", body);
+    expect(msg).toContain("BoondManager API 500 Server Error");
+    expect(msg).toContain("Body: " + "x".repeat(500) + "…");
+    expect(msg).toContain("Hint:");
+  });
+
+  it("emits a 401-specific hint", () => {
+    const msg = formatApiError(401, "Unauthorized", "GET", "/resources", "");
+    expect(msg).toContain("Authentication failed");
+  });
+
+  it("emits a 5xx-specific hint", () => {
+    const msg = formatApiError(503, "Service Unavailable", "GET", "/resources", "");
+    expect(msg).toContain("BoondManager-side error");
   });
 });

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -67,6 +67,83 @@ function getConfig(): BoondConfig {
 
 export type QueryValue = string | number | Array<string | number> | undefined;
 
+/**
+ * Pull the human-readable bits out of a BoondManager error body.
+ *
+ * Boond returns JSON:API errors of the form:
+ *   { "errors": [ { "status": "422", "code": "422", "detail": "...", "title": "..." } ] }
+ *
+ * Surfacing `detail` (and `title` when present) gives the model a focused
+ * message like `422 - password mismatch` instead of the full ~500-char body
+ * dump that previously made it hard for the LLM to reason about the failure.
+ *
+ * Exported for unit testing.
+ */
+export function parseBoondErrorBody(body: string): string | null {
+  if (!body) return null;
+  try {
+    const parsed = JSON.parse(body) as { errors?: Array<{ detail?: string; title?: string; code?: string }> };
+    const errors = Array.isArray(parsed.errors) ? parsed.errors : [];
+    const messages = errors
+      .map((e) => {
+        const parts: string[] = [];
+        if (e.title && e.title !== e.detail) parts.push(e.title);
+        if (e.detail) parts.push(e.detail);
+        else if (e.code) parts.push(`code ${e.code}`);
+        return parts.join(": ").trim();
+      })
+      .filter((m) => m.length > 0);
+    if (messages.length === 0) return null;
+    return messages.join(" | ");
+  } catch {
+    return null;
+  }
+}
+
+/** Status-specific hint to help the LLM (or human) recover from common failures. */
+function hintForStatus(status: number): string {
+  switch (status) {
+    case 400:
+      return "Check the request body or query parameters — likely a malformed field.";
+    case 401:
+      return "Authentication failed. Verify BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY (or BOOND_API_TOKEN, or BOOND_USER + BOOND_PASSWORD).";
+    case 403:
+      return "Authenticated, but the user lacks permission for this endpoint or scope.";
+    case 404:
+      return "Endpoint or entity not found. Double-check the id and the API path.";
+    case 422:
+      return "Unprocessable: typically wrong credentials (the API returns 422 for password mismatch) or a query parameter the API rejects.";
+    case 429:
+      return "Rate-limited. Back off and retry after a few seconds.";
+    default:
+      if (status >= 500) return "BoondManager-side error. Retrying after a short delay usually helps.";
+      return "Check your credentials and permissions for this endpoint.";
+  }
+}
+
+/** Build the Error message for a non-2xx HTTP response. Exported for testing. */
+export function formatApiError(
+  status: number,
+  statusText: string,
+  method: string,
+  path: string,
+  body: string
+): string {
+  const detail = parseBoondErrorBody(body);
+  const headline = detail
+    ? `BoondManager API ${status} ${statusText}: ${detail}`
+    : `BoondManager API ${status} ${statusText}`;
+  const lines = [headline, `Endpoint: ${method} ${path}`];
+  // Only attach the raw body when we couldn't extract a structured detail —
+  // otherwise it's noise that buries the useful message.
+  if (!detail && body) {
+    const trimmed = body.length > 500 ? body.slice(0, 500) + "…" : body;
+    lines.push(`Body: ${trimmed}`);
+  }
+  lines.push(`Hint: ${hintForStatus(status)}`);
+  return lines.join("\n");
+}
+
 export async function apiRequest(
   path: string,
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" = "GET",
@@ -108,12 +185,8 @@ export async function apiRequest(
   const response = await fetch(url.toString(), fetchOptions);
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
-    throw new Error(
-      `BoondManager API error ${response.status} ${response.statusText}: ${errorText}\n` +
-      `Endpoint: ${method} ${path}\n` +
-      `Suggestion: Check your credentials and permissions for this endpoint.`
-    );
+    const errorText = await response.text().catch(() => "");
+    throw new Error(formatApiError(response.status, response.statusText, method, path, errorText));
   }
 
   // DELETE may return empty body


### PR DESCRIPTION
Add parseBoondErrorBody and formatApiError helpers to extract human-readable messages from BoondManager JSON:API error bodies and to build status-specific error messages with helpful hints. Introduce hintForStatus for targeted guidance (e.g. auth and 5xx hints) and trim raw bodies when parsing fails. Switch apiRequest to use the new formatter instead of dumping the full response body. Add unit tests covering parsing, formatting, and error surfacing behavior.

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
