### PR TITLE
Add MCP prompts, tests and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ Les entites principales disposent d'outils dedies par onglet pour un acces cible
 | Opportunites | information, actions, positionings, projects, simulation |
 | Projets | information, actions, simulation, deliveries-groupments, orders, purchases, productivity |
 
+## Prompts pre-orchestres
+
+En plus des outils, le serveur expose des **prompts MCP** (templates pre-cables) qui orchestrent les bons appels d'outils dans le bon ordre pour les workflows recurrents. Visibles dans les clients qui supportent les prompts (slash command ou menu).
+
+| Prompt | Usage |
+|--------|-------|
+| `synthese_equipe` | Etat d'une equipe : qui fait quoi, qui est absent, qui est dispo (par defaut : mon equipe). |
+| `pipeline_commercial` | Opportunites avec closing dans une periode : repartition par etat, CA pondere, top 10. |
+| `factures_a_relancer` | Factures impayees dont l'echeance est depassee, regroupees par societe. |
+| `candidats_pour_opportunite` | A partir d'une opportunite, propose les candidats actifs qui matchent (outils, expertise, mobilite, dispo). |
+| `fiche_consultant` | Vue 360 d'une ressource : info + technique + positionnements + absences + CRA recents. |
+| `recap_hebdo` | Recap hebdomadaire : pipeline qui a bouge, equipe absente, projets actifs, actions a mener. |
+
 ## Prerequis
 
 - Node.js >= 20

--- a/src/prompts/index.test.ts
+++ b/src/prompts/index.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllPrompts, REGISTERED_PROMPTS } from "./index.js";
+
+function createMockServer() {
+  return { registerPrompt: vi.fn() } as unknown as McpServer;
+}
+
+describe("registerAllPrompts", () => {
+  let server: McpServer;
+  beforeEach(() => { server = createMockServer(); });
+
+  it("registers exactly the prompts declared in REGISTERED_PROMPTS", () => {
+    registerAllPrompts(server);
+    expect(server.registerPrompt).toHaveBeenCalledTimes(REGISTERED_PROMPTS.length);
+  });
+
+  it("each prompt has a unique name", () => {
+    const names = REGISTERED_PROMPTS.map((p) => p.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("registers the expected workflow prompts", () => {
+    registerAllPrompts(server);
+    const names = vi.mocked(server.registerPrompt).mock.calls.map((c) => c[0]);
+    expect(names).toEqual(expect.arrayContaining([
+      "synthese_equipe",
+      "pipeline_commercial",
+      "factures_a_relancer",
+      "candidats_pour_opportunite",
+      "fiche_consultant",
+      "recap_hebdo",
+    ]));
+  });
+
+  it("every registered prompt declares both a title and a description", () => {
+    registerAllPrompts(server);
+    for (const call of vi.mocked(server.registerPrompt).mock.calls) {
+      const [, config] = call;
+      expect(config.title).toBeTruthy();
+      expect(config.description).toBeTruthy();
+    }
+  });
+
+  it("the callbacks return a single user message with non-empty text", async () => {
+    registerAllPrompts(server);
+    const calls = vi.mocked(server.registerPrompt).mock.calls;
+    for (const [, , cb] of calls) {
+      // Pass empty args — the build functions handle defaults / required-arg notes.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (cb as any)({});
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[0].content.type).toBe("text");
+      expect(result.messages[0].content.text.length).toBeGreaterThan(50);
+    }
+  });
+
+  it("synthese_equipe falls back to current_user when manager_id is omitted", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "synthese_equipe");
+    expect(call).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({});
+    expect(result.messages[0].content.text).toContain("boond_application_current_user");
+  });
+
+  it("synthese_equipe injects an explicit manager_id when provided", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "synthese_equipe");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({ manager_id: "18081" });
+    expect(result.messages[0].content.text).toContain("18081");
+  });
+
+  it("pipeline_commercial uses perimeterManagers when manager_id is given, else perimeterDynamic", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "pipeline_commercial");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const without = await cb({ date_debut: "2026-01-01", date_fin: "2026-12-31" });
+    expect(without.messages[0].content.text).toContain("perimeterDynamic");
+    const withId = await cb({ date_debut: "2026-01-01", date_fin: "2026-12-31", manager_id: "42" });
+    expect(withId.messages[0].content.text).toContain("perimeterManagers: [42]");
+  });
+
+  it("candidats_pour_opportunite references the opportunity_id and matching filters", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "candidats_pour_opportunite");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({ opportunity_id: "12842" });
+    const text = result.messages[0].content.text;
+    expect(text).toContain("12842");
+    expect(text).toContain("boond_opportunities_get");
+    expect(text).toContain("boond_candidates_search");
+    expect(text).toContain("expertiseAreas");
+    expect(text).toContain("mobilityAreas");
+  });
+});

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,243 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+/**
+ * Pre-orchestrated MCP prompts for the most common Boond workflows.
+ *
+ * Why: the search tools alone require the LLM to discover the right filter
+ * combination on its own — it works, but it costs tokens and a few wrong
+ * turns. A prompt names the goal ("synthese_equipe", "pipeline_commercial",
+ * …) and embeds the exact tool sequence + filter names the model should
+ * use. From the user's perspective it's a single command instead of a
+ * multi-turn conversation.
+ *
+ * Each prompt resolves to a user message. We deliberately do NOT execute
+ * the tools server-side here — the LLM still drives, the prompt just gives
+ * it the runbook. This keeps the LLM in control of error handling and
+ * follow-up questions.
+ */
+
+const userMessage = (text: string) => ({
+  messages: [
+    { role: "user" as const, content: { type: "text" as const, text } },
+  ],
+});
+
+interface PromptDefinition {
+  name: string;
+  title: string;
+  description: string;
+  argsSchema: z.ZodRawShape;
+  build: (args: Record<string, string | undefined>) => string;
+}
+
+const PROMPTS: PromptDefinition[] = [
+  {
+    name: "synthese_equipe",
+    title: "Synthèse d'une équipe",
+    description:
+      "Produit un état d'équipe : qui est sur quoi, qui est absent, qui est disponible. "
+      + "Si manager_id est omis, utilise l'utilisateur courant comme manager.",
+    argsSchema: {
+      manager_id: z.string().optional().describe(
+        "ID du manager (ressource Boond). Si absent, l'outil `boond_application_current_user` doit être appelé pour le récupérer."
+      ),
+      periode: z.string().optional().describe(
+        "Période d'analyse libre (ex: 'cette semaine', 'avril 2026'). Défaut: mois en cours."
+      ),
+    },
+    build: ({ manager_id, periode }) => {
+      const periodeText = periode || "le mois en cours";
+      const managerStep = manager_id
+        ? `Le manager ciblé est l'ID ${manager_id}.`
+        : "Commence par appeler `boond_application_current_user` pour obtenir mon ID utilisateur, puis utilise-le comme `manager_id`.";
+      return [
+        `Produis une synthèse de l'équipe pour ${periodeText}.`,
+        "",
+        managerStep,
+        "",
+        "Étapes :",
+        "1. Lister les membres de l'équipe : `boond_resources_search` avec `perimeterManagers: [<manager_id>]` et `resourceStates` pour ne garder que les actifs (récupère les états valides via `boond_application_dictionary` avec `setting.state.resource` si besoin).",
+        "2. Pour chaque ressource retournée, récupérer en parallèle :",
+        "   - `boond_resources_positionings` (qui est sur quel projet)",
+        "   - `boond_resources_absences_reports` (absences validées/à venir)",
+        "   - `boond_resources_times_reports` (CRA récent, pour confirmer l'occupation)",
+        "3. Synthétiser un tableau par personne : nom, projet courant, % occupation, absences sur la période, disponibilité.",
+        "4. Conclure par les signaux faibles (sur-/sous-charge, absences non couvertes, ressources sans positionnement).",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "pipeline_commercial",
+    title: "Pipeline commercial sur une période",
+    description:
+      "Analyse les opportunités commerciales avec closing prévu dans la période donnée : "
+      + "répartition par état, CA pondéré, top opportunités.",
+    argsSchema: {
+      date_debut: z.string().describe("Début de période (YYYY-MM-DD)."),
+      date_fin: z.string().describe("Fin de période (YYYY-MM-DD)."),
+      manager_id: z.string().optional().describe(
+        "ID du commercial. Si absent, scope = équipe de l'utilisateur courant via `perimeterDynamic: ['data']`."
+      ),
+    },
+    build: ({ date_debut, date_fin, manager_id }) => {
+      const scopeFilter = manager_id
+        ? `\`perimeterManagers: [${manager_id}]\``
+        : "`perimeterDynamic: ['data']` (mes opportunités)";
+      return [
+        `Analyse mon pipeline commercial avec closing entre ${date_debut} et ${date_fin}.`,
+        "",
+        `Périmètre : ${scopeFilter}.`,
+        "",
+        "Étapes :",
+        "1. Appeler `boond_opportunities_search` avec :",
+        `   - \`period: "closingDate"\``,
+        `   - \`startDate: "${date_debut}"\`, \`endDate: "${date_fin}"\``,
+        `   - ${scopeFilter}`,
+        "   - `pageSize: 100`",
+        "2. Si plus de 100 résultats, paginer via `page`.",
+        "3. Récupérer le dictionnaire des états via `boond_application_dictionary` avec `setting.state.opportunity` pour traduire les ID en libellés.",
+        "4. Restituer :",
+        "   - Nombre total d'opportunités, par état",
+        "   - CA pondéré total (somme de `turnoverWeightedExcludingTax`)",
+        "   - Top 10 par montant pondéré, avec société/contact/closingDate",
+        "   - Risques : opportunités dont la closingDate est passée mais qui ne sont pas encore en état Gagnée/Perdue.",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "factures_a_relancer",
+    title: "Factures impayées à relancer",
+    description:
+      "Liste les factures impayées avec date d'échéance dépassée, regroupées par société. "
+      + "Optionnellement filtrable sur une société spécifique.",
+    argsSchema: {
+      society_id: z.string().optional().describe("ID d'une société pour cibler la relance."),
+    },
+    build: ({ society_id }) => {
+      return [
+        "Identifie les factures à relancer (impayées dont l'échéance est dépassée).",
+        "",
+        "Étapes :",
+        "1. Appeler `boond_invoices_search` :",
+        society_id ? `   - \`companyId: "${society_id}"\`` : "   - sans filtre société (toutes les factures du périmètre courant)",
+        "   - `pageSize: 100`",
+        "2. Récupérer le dictionnaire `setting.state.invoice` via `boond_application_dictionary` pour identifier les états « payée » / « partiellement payée » / etc.",
+        "3. Filtrer côté agent : ne conserver que les factures dont l'état n'est PAS « payée » ET dont la `dueDate` est strictement antérieure à aujourd'hui.",
+        "4. Pour chaque facture retenue, récupérer le détail via `boond_invoices_get` si nécessaire pour obtenir le contact/email de relance.",
+        "5. Restituer un tableau groupé par société : société | nombre de factures impayées | total HT impayé | facture la plus ancienne (référence + jours de retard) | contact à relancer.",
+        "6. Ajouter une ligne « Total » en bas.",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "candidats_pour_opportunite",
+    title: "Candidats correspondant à une opportunité",
+    description:
+      "À partir d'une opportunité (ses outils, expertise, mobilité), trouve les candidats actifs qui matchent.",
+    argsSchema: {
+      opportunity_id: z.string().describe("ID de l'opportunité à pourvoir."),
+    },
+    build: ({ opportunity_id }) => {
+      return [
+        `Identifie les candidats qui matchent l'opportunité ${opportunity_id}.`,
+        "",
+        "Étapes :",
+        `1. Récupérer le détail de l'opportunité : \`boond_opportunities_get(id="${opportunity_id}")\` puis l'onglet \`information\` pour les attributs détaillés.`,
+        "2. Extraire les critères : `tools`, `expertiseAreas`, `activityAreas`, `places` (mobilité), `durations`, `startDate`/`endDate`.",
+        "3. Appeler `boond_candidates_search` avec :",
+        "   - les `tools` extraits (logique OU par défaut ; si l'opportunité est très exigeante, repasser avec `[\"#AND#\", ...]` pour exiger toutes les compétences)",
+        "   - `expertiseAreas` correspondants",
+        "   - `mobilityAreas` matchant le lieu",
+        "   - `candidateStates` actifs uniquement (consulter `setting.state.candidate` via `boond_application_dictionary`)",
+        "   - `period: \"available\"` + `startDate`/`endDate` calés sur la mission, pour ne garder que les candidats disponibles",
+        "   - `pageSize: 50`",
+        "4. Pour les top 20 candidats retournés, récupérer `boond_candidates_technical_data` pour vérifier l'adéquation fine.",
+        "5. Restituer un classement : nom | titre | dispo | note d'adéquation (sur 10) avec justification 1 ligne.",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "fiche_consultant",
+    title: "Fiche complète d'un collaborateur",
+    description:
+      "Vue 360° d'une ressource : info, profil technique, positionnements, absences, CRA récents.",
+    argsSchema: {
+      resource_id: z.string().describe("ID de la ressource."),
+    },
+    build: ({ resource_id }) => {
+      return [
+        `Produis la fiche complète de la ressource ${resource_id}.`,
+        "",
+        "Étapes (à exécuter en parallèle quand possible) :",
+        `1. \`boond_resources_information(id="${resource_id}")\` — coordonnées et état civil`,
+        `2. \`boond_resources_technical_data(id="${resource_id}")\` — compétences, formations, langues, CV`,
+        `3. \`boond_resources_administrative(id="${resource_id}")\` — données RH (TJM, salaire, contrat) si autorisé`,
+        `4. \`boond_resources_positionings(id="${resource_id}")\` — positionnements actifs et historiques`,
+        `5. \`boond_resources_projects(id="${resource_id}")\` — projets passés/en cours`,
+        `6. \`boond_resources_absences_reports(id="${resource_id}")\` — absences à venir et passées récentes`,
+        `7. \`boond_resources_times_reports(id="${resource_id}")\` — CRA des 3 derniers mois`,
+        "",
+        "Restitution : un document structuré en sections (Identité / Profil technique / Mission actuelle / Historique projets / Disponibilité / RH si pertinent). Mettre en évidence : projet courant, prochaine date de fin de mission, prochaine absence, taux d'occupation moyen sur 3 mois.",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "recap_hebdo",
+    title: "Récap hebdomadaire (moi + mon équipe)",
+    description:
+      "Compile en une vue ce qui s'est passé / va se passer cette semaine pour moi et mon équipe : opportunités, projets, absences, CRA.",
+    argsSchema: {
+      semaine: z.string().optional().describe(
+        "Semaine ciblée (ex: 'cette semaine', 'la semaine prochaine'). Défaut: cette semaine."
+      ),
+    },
+    build: ({ semaine }) => {
+      const semaineText = semaine || "cette semaine";
+      return [
+        `Produis mon récap pour ${semaineText}.`,
+        "",
+        "Étapes :",
+        "1. `boond_application_current_user` pour récupérer mon ID.",
+        "2. En parallèle :",
+        "   a. `boond_opportunities_search` avec `perimeterDynamic: ['data']`, `period: 'updated'` + dates de la semaine — opportunités touchées cette semaine.",
+        "   b. `boond_resources_search` avec `perimeterDynamic: ['managers']` — mon équipe (mes N-1).",
+        "   c. Pour chaque membre d'équipe : `boond_resources_absences_reports` filtré sur la semaine.",
+        "   d. `boond_projects_search` avec `perimeterDynamic: ['data']` et `period: 'running'` + dates de la semaine — mes projets actifs.",
+        "3. Récupérer `setting.state.opportunity` et `setting.state.project` via `boond_application_dictionary` pour libeller les états.",
+        "4. Restituer en 4 sections :",
+        "   - **Pipeline** : opps qui ont bougé (nouvelles, état changé, closing imminent)",
+        "   - **Équipe** : qui est absent cette semaine, qui termine sa mission",
+        "   - **Projets** : projets actifs, dont ceux qui s'arrêtent ou démarrent dans la semaine",
+        "   - **Actions à mener** : 3-5 puces concrètes (relances, validations, repositionnements)",
+      ].join("\n");
+    },
+  },
+];
+
+export function registerAllPrompts(server: McpServer): void {
+  for (const p of PROMPTS) {
+    server.registerPrompt(
+      p.name,
+      {
+        title: p.title,
+        description: p.description,
+        argsSchema: p.argsSchema,
+      },
+      async (args) => userMessage(p.build((args ?? {}) as Record<string, string | undefined>))
+    );
+  }
+}
+
+/** Exposed for tests so we can assert names/coverage without instantiating a server. */
+export const REGISTERED_PROMPTS = PROMPTS.map((p) => ({
+  name: p.name,
+  title: p.title,
+  description: p.description,
+  argKeys: Object.keys(p.argsSchema),
+}));

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import {
   registerReportingTools,
   registerPlanningAbsenceTools,
 } from "./tools/index.js";
+import { registerAllPrompts } from "./prompts/index.js";
 
 export const SERVER_NAME = "boondmanager-mcp-server";
 export const SERVER_VERSION = "1.0.0";
@@ -93,6 +94,8 @@ export function createMcpServer(): McpServer {
   registerPoleTools(server);
   registerReportingTools(server);
   registerPlanningAbsenceTools(server);
+
+  registerAllPrompts(server);
 
   return server;
 }


### PR DESCRIPTION
Introduce a new prompts module that defines pre-orchestrated MCP prompts for common Boond workflows (synthese_equipe, pipeline_commercial, factures_a_relancer, candidats_pour_opportunite, fiche_consultant, recap_hebdo). Export REGISTERED_PROMPTS for test assertions and provide registerAllPrompts(server) to register each prompt with title, description and args schema. Add unit tests (vitest) to validate registration, uniqueness, expected prompts, and generated user messages/behavior. Wire prompt registration into the server startup and update README with a Prompts section describing available prompts and usages.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
