### PR TITLE
Add Dockerfile, .dockerignore and GHCR publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Docker build context filter — keep the build small and avoid leaking
+# anything sensitive (.env) or unrelated to the runtime image.
+
+# Build outputs and dev artefacts (rebuilt inside the image)
+node_modules
+dist
+coverage
+*.log
+*.mcpb
+
+# VCS / editor / OS noise
+.git
+.gitignore
+.github
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Tests, examples, docs that aren't needed at runtime
+**/*.test.ts
+**/*.spec.ts
+test-*.mjs
+
+# Local secrets — must never enter the image
+.env
+.env.*
+!.env.example
+
+# Other tool configs not needed in the image
+eslint.config.*
+.prettierrc*
+vitest.config.*
+.editorconfig
+CHANGELOG.md
+SECURITY.md
+CONTRIBUTING.md
+NOTICE
+LICENSE
+*.md
+!README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   release:
@@ -114,3 +115,54 @@ jobs:
         run: |
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
+
+      # ---- Docker image (HTTP gateway mode) ----
+      # Multi-arch image so it runs on both x86 servers and Apple-Silicon /
+      # Graviton hosts. Pushed to GHCR alongside the npm/MCP Registry artifacts
+      # so users running LobeChat or a custom MCP gateway can `docker pull`
+      # the same version they would `npm install`.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: image_tags
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          MAJOR_MINOR="$(echo "$TAG_VERSION" | awk -F. '{print $1"."$2}')"
+          MAJOR="$(echo "$TAG_VERSION" | awk -F. '{print $1}')"
+          # On every release we publish four moving tags:
+          #   :<exact>   pinned, the only tag we recommend in production manifests
+          #   :<X.Y>     latest patch of a minor (auto-update inside a minor)
+          #   :<X>       latest minor of a major (broader, opt-in to new features)
+          #   :latest    bleeding edge — convenient for demos, never for prod
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${TAG_VERSION}"
+            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${MAJOR_MINOR}"
+            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${MAJOR}"
+            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:latest"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image_tags.outputs.tags }}
+          # OCI image annotations — fed by docker/metadata-action would be
+          # nicer, but the labels in the Dockerfile already cover the
+          # essentials and we keep this step minimal.
+          provenance: true
+          sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for the BoondManager MCP server.
+# The runtime image starts the Streamable HTTP transport, suitable for use as
+# an MCP gateway (LobeChat, custom MCP host, etc.). For stdio usage, prefer
+# `npx boondmanager-mcp-server` directly on the host — Docker's stdio mapping
+# is awkward and you don't gain anything by containerising it.
+
+# ---- builder ----
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Install only what's needed to build, with cache-friendly layering.
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# Drop dev dependencies for the final image.
+RUN npm prune --omit=dev
+
+
+# ---- runtime ----
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+# OCI image annotations — make the image discoverable in registries.
+LABEL org.opencontainers.image.title="boondmanager-mcp-server" \
+      org.opencontainers.image.description="MCP server for the BoondManager API (HTTP gateway mode)" \
+      org.opencontainers.image.source="https://github.com/fauguste/boondmanager-mcp-server" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Silamir"
+
+# Run unprivileged. node:alpine ships a uid 1000 `node` user we can reuse.
+USER node
+
+COPY --chown=node:node --from=builder /app/node_modules ./node_modules
+COPY --chown=node:node --from=builder /app/dist ./dist
+COPY --chown=node:node --from=builder /app/package.json ./package.json
+
+# HTTP transport defaults — override at run time as needed.
+# MCP_HTTP_HOST=0.0.0.0 is required inside the container so the port is
+# reachable from the host (the server defaults to 127.0.0.1 for stdio safety).
+ENV NODE_ENV=production \
+    MCP_TRANSPORT=http \
+    MCP_HTTP_HOST=0.0.0.0 \
+    MCP_HTTP_PORT=3000 \
+    MCP_HTTP_PATH=/mcp
+
+EXPOSE 3000
+
+# Lightweight liveness check — confirms the HTTP listener is up. We use
+# Node's bundled fetch to avoid pulling curl/wget into the image. A 4xx
+# (e.g. 405 if the path is POST-only) still proves the listener is alive.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:'+process.env.MCP_HTTP_PORT+process.env.MCP_HTTP_PATH).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -389,7 +389,22 @@ claude mcp add --transport http \
 }
 ```
 
-#### Exemple : Docker
+#### Exemple : Docker (image officielle GHCR)
+
+Une image Docker prete a l'emploi est publiee a chaque release sur GitHub Container Registry, multi-arch (`linux/amd64` + `linux/arm64`). Elle demarre par defaut en transport HTTP, sur le port 3000, sur l'interface `0.0.0.0`.
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e MCP_HTTP_BEARER_TOKEN=$(openssl rand -hex 32) \
+  -e BOOND_API_TOKEN=$BOOND_API_TOKEN \
+  ghcr.io/fauguste/boondmanager-mcp-server:latest
+```
+
+Tags disponibles : `:latest`, `:1`, `:1.5`, `:1.5.1` (la version exacte est recommandee pour la prod). Variables d'environnement supportees : voir [Configuration](#configuration) et [Transports](#transports).
+
+#### Exemple : Docker (image ad-hoc via npx)
+
+Si vous preferez ne pas utiliser l'image GHCR, le serveur peut tourner dans une image Node generique :
 
 ```bash
 docker run --rm -p 3000:3000 \
@@ -397,7 +412,7 @@ docker run --rm -p 3000:3000 \
   -e MCP_HTTP_HOST=0.0.0.0 \
   -e MCP_HTTP_BEARER_TOKEN=$(openssl rand -hex 32) \
   -e BOOND_API_TOKEN=$BOOND_API_TOKEN \
-  node:20-alpine \
+  node:22-alpine \
   npx -y boondmanager-mcp-server
 ```
 


### PR DESCRIPTION
Introduce a multi-stage Dockerfile for a production runtime (node:22-alpine) with healthcheck, default HTTP transport envs and reduced final image footprint. Add .dockerignore to keep build contexts small and avoid leaking secrets. Extend the release GitHub Actions workflow to set packages: write and build/push a multi-arch Docker image to GHCR (qemu, buildx, login, tag computation, SBOM/provenance). Update README with GHCR usage example and bump the example Node base image to 22-alpine.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
