### PR TITLE
Expose Boond dictionaries as MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ Les entites principales disposent d'outils dedies par onglet pour un acces cible
 | Opportunites | information, actions, positionings, projects, simulation |
 | Projets | information, actions, simulation, deliveries-groupments, orders, purchases, productivity |
 
+## Ressources MCP (dictionnaires)
+
+Le serveur expose les dictionnaires de reference Boond comme **ressources MCP** (clients qui en supportent l'affichage : Claude Desktop, MCP Inspector, etc.). Permet au modele de traduire un `state` ou `typeOf` entier en libelle sans appel d'outil supplementaire.
+
+| URI | Contenu |
+|-----|---------|
+| `boond://application/current-user` | Profil de l'utilisateur courant (id, agence, permissions) |
+| `boond://dictionary/states/{entity}` | Etats par entite : `resources`, `candidates`, `contacts`, `companies`, `opportunities`, `projects`, `invoices`, `orders`, `positionings`, `absences` |
+| `boond://dictionary/typeOf/{entity}` | Types par entite : `resources`, `candidates`, `contacts`, `projects`, `actions`, `absences` |
+| `boond://dictionary/countries` | Liste des pays |
+| `boond://dictionary/currencies` | Liste des devises |
+| `boond://dictionary/languages` | Liste des langues |
+
+Pour les dictionnaires hors de cette liste curee, l'outil `boond_application_dictionary` reste disponible.
+
 ## Prompts pre-orchestres
 
 En plus des outils, le serveur expose des **prompts MCP** (templates pre-cables) qui orchestrent les bons appels d'outils dans le bon ordre pour les workflows recurrents. Visibles dans les clients qui supportent les prompts (slash command ou menu).

--- a/src/resources/index.test.ts
+++ b/src/resources/index.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllResources, REGISTERED_RESOURCES } from "./index.js";
+import * as boondClient from "../services/boond-client.js";
+
+function createMockServer() {
+  return { registerResource: vi.fn() } as unknown as McpServer;
+}
+
+describe("registerAllResources", () => {
+  let server: McpServer;
+  beforeEach(() => {
+    server = createMockServer();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly the resources declared in REGISTERED_RESOURCES", () => {
+    registerAllResources(server);
+    expect(server.registerResource).toHaveBeenCalledTimes(REGISTERED_RESOURCES.length);
+  });
+
+  it("each resource has a unique URI", () => {
+    const uris = REGISTERED_RESOURCES.map((r) => r.uri);
+    expect(new Set(uris).size).toBe(uris.length);
+  });
+
+  it("every dictionary URI uses the boond:// scheme under /dictionary/", () => {
+    const dicts = REGISTERED_RESOURCES.filter((r) => r.name.startsWith("dictionary/"));
+    expect(dicts.length).toBeGreaterThan(10);
+    for (const r of dicts) {
+      expect(r.uri).toMatch(/^boond:\/\/dictionary\/[a-zA-Z]+\/[a-zA-Z]+$|^boond:\/\/dictionary\/[a-zA-Z]+$/);
+    }
+  });
+
+  it("exposes the current-user resource", () => {
+    expect(REGISTERED_RESOURCES.find((r) => r.uri === "boond://application/current-user")).toBeDefined();
+  });
+
+  it("exposes the search-tool dictionaries the prompts depend on", () => {
+    // Prompts in src/prompts/index.ts and the tool descriptions reference
+    // these dict slugs — make sure they're all surfaced as resources so the
+    // model can resolve state/typeOf integers without a tool call.
+    const slugs = REGISTERED_RESOURCES.map((r) => r.uri.replace(/^boond:\/\/dictionary\//, ""));
+    expect(slugs).toEqual(expect.arrayContaining([
+      "states/resources",
+      "states/candidates",
+      "states/contacts",
+      "states/companies",
+      "states/opportunities",
+      "states/projects",
+      "states/invoices",
+      "typeOf/resources",
+      "typeOf/candidates",
+      "typeOf/projects",
+      "typeOf/actions",
+    ]));
+  });
+
+  it("declares JSON mime type and a non-empty title/description on every resource", () => {
+    registerAllResources(server);
+    for (const call of vi.mocked(server.registerResource).mock.calls) {
+      const [name, uri, config] = call;
+      expect(typeof name).toBe("string");
+      expect(typeof uri).toBe("string");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const meta = config as any;
+      expect(meta.mimeType).toBe("application/json");
+      expect(meta.title).toBeTruthy();
+      expect(meta.description).toBeTruthy();
+    }
+  });
+
+  it("dictionary read callback hits /application/dictionaries/<slug>", async () => {
+    const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+      data: [{ id: "1", type: "dictionary", attributes: { value: "Actif" } }],
+    });
+    registerAllResources(server);
+    const call = vi.mocked(server.registerResource).mock.calls.find((c) => c[0] === "dictionary/states/resources");
+    expect(call).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![3] as any;
+    const result = await cb(new URL("boond://dictionary/states/resources"));
+    expect(apiSpy).toHaveBeenCalledWith("/application/dictionaries/states/resources");
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].uri).toBe("boond://dictionary/states/resources");
+    expect(result.contents[0].mimeType).toBe("application/json");
+    expect(JSON.parse(result.contents[0].text).data[0].attributes.value).toBe("Actif");
+  });
+
+  it("current-user read callback hits /application/current-user", async () => {
+    const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+      data: { id: "18081", type: "resource", attributes: { firstName: "Frédéric" } },
+    });
+    registerAllResources(server);
+    const call = vi.mocked(server.registerResource).mock.calls.find((c) => c[0] === "application/current-user");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![3] as any;
+    const result = await cb(new URL("boond://application/current-user"));
+    expect(apiSpy).toHaveBeenCalledWith("/application/current-user");
+    expect(JSON.parse(result.contents[0].text).data.attributes.firstName).toBe("Frédéric");
+  });
+});

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,135 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { apiRequest } from "../services/boond-client.js";
+
+/**
+ * MCP resources for BoondManager reference data.
+ *
+ * Why expose these as resources rather than relying on the
+ * `boond_application_dictionary` tool alone:
+ * - Clients (Claude Desktop, LobeChat, MCP Inspector…) display resources in
+ *   a browseable list. The user (or the model) discovers what's available
+ *   without trial-and-error tool calls.
+ * - The model can read a resource silently when it needs to translate an
+ *   integer state id into a human label, instead of explaining a tool call.
+ * - Read access is idempotent and cache-friendly: many MCP hosts cache the
+ *   resource body for the duration of a conversation.
+ *
+ * The set below covers the dictionaries our search tools refer to most
+ * (states + typeOf for the six search domains, plus the global ones used in
+ * formatting like countries / currencies / languages). Anything beyond this
+ * fixed set is still reachable via the `boond_application_dictionary` tool.
+ */
+
+interface DictionaryEntry {
+  /** URI suffix, e.g. "states/resources". Joined with "boond://dictionary/". */
+  slug: string;
+  /** Human title shown to the user / model in the resource list. */
+  title: string;
+  /** One-line description. */
+  description: string;
+}
+
+/**
+ * Well-known Boond dictionaries surfaced as static MCP resources. We keep
+ * this list deliberately curated — better to expose the dozen the search
+ * tools actually depend on than the hundreds of obscure config dicts.
+ */
+const DICTIONARIES: DictionaryEntry[] = [
+  // states/* — used to translate the integer `state` attribute on entities
+  { slug: "states/resources",     title: "États ressources",     description: "Libellés des états de ressource (collaborateur)." },
+  { slug: "states/candidates",    title: "États candidats",      description: "Libellés des états de candidat." },
+  { slug: "states/contacts",      title: "États contacts",       description: "Libellés des états de contact." },
+  { slug: "states/companies",     title: "États sociétés",       description: "Libellés des états de société." },
+  { slug: "states/opportunities", title: "États opportunités",   description: "Libellés des états d'opportunité commerciale." },
+  { slug: "states/projects",      title: "États projets",        description: "Libellés des états de projet/mission." },
+  { slug: "states/invoices",      title: "États factures",       description: "Libellés des états de facture client." },
+  { slug: "states/orders",        title: "États bons de commande", description: "Libellés des états de bon de commande." },
+  { slug: "states/positionings",  title: "États positionnements", description: "Libellés des états de positionnement." },
+  { slug: "states/absences",      title: "États absences",       description: "Libellés des états des demandes d'absence." },
+  // typeOf/* — used to translate the integer `typeOf` attribute on entities
+  { slug: "typeOf/resources",     title: "Types ressources",     description: "Types de ressource (interne, sous-traitant, freelance...)." },
+  { slug: "typeOf/candidates",    title: "Types candidats",      description: "Types de candidat." },
+  { slug: "typeOf/contacts",      title: "Types contacts",       description: "Types de contact." },
+  { slug: "typeOf/projects",      title: "Types projets",        description: "Types de projet (régie, forfait, produit...)." },
+  { slug: "typeOf/actions",       title: "Types actions",        description: "Types d'action (appel, email, RDV, note...)." },
+  { slug: "typeOf/absences",      title: "Types absences",       description: "Types d'absence (CP, RTT, maladie, sans solde...)." },
+  // Global lookups
+  { slug: "countries",            title: "Pays",                 description: "Liste des pays (codes ISO + libellés)." },
+  { slug: "currencies",           title: "Devises",              description: "Liste des devises supportées." },
+  { slug: "languages",            title: "Langues",              description: "Liste des langues parlées." },
+];
+
+/** URI prefix under which all dictionaries are exposed. */
+const DICTIONARY_URI_PREFIX = "boond://dictionary/";
+/** URI of the cached identity resource. */
+const CURRENT_USER_URI = "boond://application/current-user";
+
+function buildResourceUri(slug: string): string {
+  return `${DICTIONARY_URI_PREFIX}${slug}`;
+}
+
+/** Exposed for tests; lets us assert the catalog without booting a server. */
+export const REGISTERED_RESOURCES = [
+  ...DICTIONARIES.map((d) => ({
+    name: `dictionary/${d.slug}`,
+    uri: buildResourceUri(d.slug),
+    title: d.title,
+  })),
+  { name: "application/current-user", uri: CURRENT_USER_URI, title: "Utilisateur courant" },
+];
+
+export function registerAllResources(server: McpServer): void {
+  for (const dict of DICTIONARIES) {
+    const uri = buildResourceUri(dict.slug);
+    server.registerResource(
+      `dictionary/${dict.slug}`,
+      uri,
+      {
+        title: dict.title,
+        description: dict.description,
+        mimeType: "application/json",
+      },
+      async () => {
+        // Mirror the path used by the boond_application_dictionary tool so
+        // both read paths stay in sync if the upstream API moves.
+        const response = await apiRequest(`/application/dictionaries/${dict.slug}`);
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify(response, null, 2),
+            },
+          ],
+        };
+      }
+    );
+  }
+
+  // The current-user resource is a convenience for prompts/tools that need
+  // the caller's userId without first issuing a tool call. The body is the
+  // full /application/current-user payload.
+  server.registerResource(
+    "application/current-user",
+    CURRENT_USER_URI,
+    {
+      title: "Utilisateur courant",
+      description:
+        "Profil de l'utilisateur authentifié auprès de l'API BoondManager (id, agence, permissions). "
+        + "Utile pour résoudre 'mon ID' avant un appel filtré par perimeterManagers.",
+      mimeType: "application/json",
+    },
+    async () => {
+      const response = await apiRequest("/application/current-user");
+      return {
+        contents: [
+          {
+            uri: CURRENT_USER_URI,
+            mimeType: "application/json",
+            text: JSON.stringify(response, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import {
   registerPlanningAbsenceTools,
 } from "./tools/index.js";
 import { registerAllPrompts } from "./prompts/index.js";
+import { registerAllResources } from "./resources/index.js";
 
 export const SERVER_NAME = "boondmanager-mcp-server";
 export const SERVER_VERSION = "1.0.0";
@@ -96,6 +97,7 @@ export function createMcpServer(): McpServer {
   registerPlanningAbsenceTools(server);
 
   registerAllPrompts(server);
+  registerAllResources(server);
 
   return server;
 }


### PR DESCRIPTION
Add a new resources module that exposes selected BoondManager dictionaries and the current-user payload as MCP resources (boond://dictionary/... and boond://application/current-user). Register the resources on server startup and document them in the README. Includes comprehensive tests (src/resources/index.test.ts) that verify URIs, mime types, uniqueness, cataloged slugs and that read callbacks call the correct Boond API endpoints.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
