### PR TITLE
Add tools catalog generator, TOOLS.md & CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
         if: matrix.node-version == 22
         run: npx @anthropic-ai/mcpb validate .
 
+      - name: Check tool catalogue is up to date
+        # If a tool/prompt/resource was added or renamed, TOOLS.md must be
+        # regenerated and committed. This step fails if it drifts.
+        if: matrix.node-version == 22
+        run: node scripts/generate-tools-catalog.mjs --check
+
       - name: Verify version consistency
         if: matrix.node-version == 22
         run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claude (Desktop, Cowork, Code) de rechercher, consulter, creer et modifier des enregistrements dans votre instance BoondManager.
 
-**158 outils** couvrant **36 domaines** de l'API BoondManager.
+**158 outils** couvrant **36 domaines** de l'API BoondManager. Voir [TOOLS.md](./TOOLS.md) pour le catalogue auto-généré (outils + prompts + ressources).
 
 ## Domaines couverts
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,386 @@
+# Tool Catalogue
+
+> Auto-generated from the server registrations. Do not edit by hand.
+> Regenerate with `npm run docs:tools` (CI fails if this file is stale).
+
+**156 tools** across **36 domains** · **6 prompts** · **20 resources**.
+
+Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
+
+## Tools
+
+### absences (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_absences_create` | Créer une absence | write |
+| `boond_absences_delete` | Supprimer une absence | delete |
+| `boond_absences_get` | Détails d'une absence | read · idempotent |
+| `boond_absences_search` | Rechercher des absences | read · idempotent · open-world |
+| `boond_absences_update` | Modifier une absence | write · idempotent |
+
+### accounts (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_accounts_get` | Détails d'un compte utilisateur | read · idempotent |
+| `boond_accounts_search` | Rechercher des comptes utilisateurs | read · idempotent · open-world |
+
+### actions (4)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_actions_create` | Créer une action | write |
+| `boond_actions_delete` | Supprimer une action | delete |
+| `boond_actions_get` | Détails d'une action | read · idempotent |
+| `boond_actions_search` | Rechercher des actions | read · idempotent · open-world |
+
+### advantages (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_advantages_get` | Détails d'un avantage | read · idempotent |
+| `boond_advantages_search` | Rechercher des avantages | read · idempotent · open-world |
+
+### agencies (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_agencies_get` | Détails d'une agence | read · idempotent |
+| `boond_agencies_search` | Rechercher des agences | read · idempotent · open-world |
+
+### application (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_application_current_user` | Utilisateur courant BoondManager | read · idempotent |
+| `boond_application_dictionary` | Récupérer un dictionnaire BoondManager | read · idempotent |
+
+### business_units (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_business_units_get` | Détails d'une business unit | read · idempotent |
+| `boond_business_units_search` | Rechercher des business units | read · idempotent · open-world |
+
+### calendars (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_calendars_get` | Détails d'un calendrier | read · idempotent |
+| `boond_calendars_search` | Rechercher des calendriers | read · idempotent · open-world |
+
+### candidates (10)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_candidates_actions` | Actions liées à un candidat | read · idempotent |
+| `boond_candidates_administrative` | Données administratives d'un candidat | read · idempotent |
+| `boond_candidates_create` | Créer un(e) candidat | write |
+| `boond_candidates_delete` | Supprimer un(e) candidat | delete |
+| `boond_candidates_get` | Détails d'un(e) candidat | read · idempotent |
+| `boond_candidates_information` | Informations générales d'un candidat | read · idempotent |
+| `boond_candidates_positionings` | Positionnements d'un candidat | read · idempotent |
+| `boond_candidates_search` | Rechercher des candidats | read · idempotent · open-world |
+| `boond_candidates_technical_data` | Compétences techniques d'un candidat | read · idempotent |
+| `boond_candidates_update` | Modifier un(e) candidat | write · idempotent |
+
+### companies (14)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_companies_actions` | Actions liées à une société | read · idempotent |
+| `boond_companies_contacts` | Contacts d'une société | read · idempotent |
+| `boond_companies_create` | Créer un(e) société | write |
+| `boond_companies_delete` | Supprimer un(e) société | delete |
+| `boond_companies_get` | Détails d'un(e) société | read · idempotent |
+| `boond_companies_information` | Informations générales d'une société | read · idempotent |
+| `boond_companies_invoices` | Factures d'une société | read · idempotent |
+| `boond_companies_opportunities` | Opportunités d'une société | read · idempotent |
+| `boond_companies_orders` | Bons de commande d'une société | read · idempotent |
+| `boond_companies_projects` | Projets d'une société | read · idempotent |
+| `boond_companies_provider_invoices` | Factures fournisseur d'une société | read · idempotent |
+| `boond_companies_purchases` | Achats d'une société | read · idempotent |
+| `boond_companies_search` | Rechercher des sociétés | read · idempotent · open-world |
+| `boond_companies_update` | Modifier un(e) société | write · idempotent |
+
+### contacts (11)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_contacts_actions` | Actions liées à un contact | read · idempotent |
+| `boond_contacts_create` | Créer un(e) contact | write |
+| `boond_contacts_delete` | Supprimer un(e) contact | delete |
+| `boond_contacts_get` | Détails d'un(e) contact | read · idempotent |
+| `boond_contacts_information` | Informations générales d'un contact | read · idempotent |
+| `boond_contacts_invoices` | Factures d'un contact | read · idempotent |
+| `boond_contacts_opportunities` | Opportunités d'un contact | read · idempotent |
+| `boond_contacts_orders` | Bons de commande d'un contact | read · idempotent |
+| `boond_contacts_projects` | Projets d'un contact | read · idempotent |
+| `boond_contacts_search` | Rechercher des contacts | read · idempotent · open-world |
+| `boond_contacts_update` | Modifier un(e) contact | write · idempotent |
+
+### contracts (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_contracts_create` | Créer un contrat | write |
+| `boond_contracts_get` | Détails d'un contrat | read · idempotent |
+
+### deliveries (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_deliveries_get` | Détails d'une livraison / CRA | read · idempotent |
+| `boond_deliveries_search` | Rechercher des livraisons / CRA | read · idempotent · open-world |
+
+### expenses (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_expenses_create` | Créer une note de frais | write |
+| `boond_expenses_delete` | Supprimer une note de frais | delete |
+| `boond_expenses_get` | Détails d'une note de frais | read · idempotent |
+| `boond_expenses_search` | Rechercher des notes de frais | read · idempotent · open-world |
+| `boond_expenses_update` | Modifier une note de frais | write · idempotent |
+
+### flags (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_flags_get` | Détails d'un drapeau/étiquette | read · idempotent |
+| `boond_flags_search` | Rechercher des drapeaux/étiquettes | read · idempotent · open-world |
+
+### invoices (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_invoices_create` | Créer une facture | write |
+| `boond_invoices_delete` | Supprimer une facture | delete |
+| `boond_invoices_get` | Détails d'une facture | read · idempotent |
+| `boond_invoices_search` | Rechercher des factures | read · idempotent · open-world |
+| `boond_invoices_update` | Modifier une facture | write · idempotent |
+
+### logs (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_logs_get` | Détails d'un log d'audit | read · idempotent |
+| `boond_logs_search` | Rechercher des logs d'audit | read · idempotent · open-world |
+
+### notifications (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_notifications_get` | Détails d'une notification | read · idempotent |
+| `boond_notifications_search` | Rechercher des notifications | read · idempotent · open-world |
+
+### opportunities (10)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_opportunities_actions` | Actions liées à une opportunité | read · idempotent |
+| `boond_opportunities_create` | Créer un(e) opportunité | write |
+| `boond_opportunities_delete` | Supprimer un(e) opportunité | delete |
+| `boond_opportunities_get` | Détails d'un(e) opportunité | read · idempotent |
+| `boond_opportunities_information` | Informations générales d'une opportunité | read · idempotent |
+| `boond_opportunities_positionings` | Positionnements d'une opportunité | read · idempotent |
+| `boond_opportunities_projects` | Projets liés à une opportunité | read · idempotent |
+| `boond_opportunities_search` | Rechercher des opportunités | read · idempotent · open-world |
+| `boond_opportunities_simulation` | Simulation financière d'une opportunité | read · idempotent |
+| `boond_opportunities_update` | Modifier un(e) opportunité | write · idempotent |
+
+### orders (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_orders_create` | Créer un bon de commande | write |
+| `boond_orders_delete` | Supprimer un bon de commande | delete |
+| `boond_orders_get` | Détails d'un bon de commande | read · idempotent |
+| `boond_orders_search` | Rechercher des bons de commande | read · idempotent · open-world |
+| `boond_orders_update` | Modifier un bon de commande | write · idempotent |
+
+### payments (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_payments_get` | Détails d'un paiement | read · idempotent |
+| `boond_payments_search` | Rechercher des paiements | read · idempotent · open-world |
+
+### planning_absences (1)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_planning_absences_search` | Rechercher le planning des absences | read · idempotent · open-world |
+
+### poles (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_poles_get` | Détails d'un pôle | read · idempotent |
+| `boond_poles_search` | Rechercher des pôles | read · idempotent · open-world |
+
+### positionings (4)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_positionings_create` | Créer un positionnement | write |
+| `boond_positionings_delete` | Supprimer un positionnement | delete |
+| `boond_positionings_get` | Détails d'un positionnement | read · idempotent |
+| `boond_positionings_search` | Rechercher des positionnements | read · idempotent · open-world |
+
+### products (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_products_create` | Créer un(e) produit | write |
+| `boond_products_delete` | Supprimer un(e) produit | delete |
+| `boond_products_get` | Détails d'un(e) produit | read · idempotent |
+| `boond_products_search` | Rechercher des produits | read · idempotent · open-world |
+| `boond_products_update` | Modifier un(e) produit | write · idempotent |
+
+### projects (12)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_projects_actions` | Actions liées à un projet | read · idempotent |
+| `boond_projects_create` | Créer un(e) projet | write |
+| `boond_projects_delete` | Supprimer un(e) projet | delete |
+| `boond_projects_deliveries_groupments` | Livraisons d'un projet | read · idempotent |
+| `boond_projects_get` | Détails d'un(e) projet | read · idempotent |
+| `boond_projects_information` | Informations générales d'un projet | read · idempotent |
+| `boond_projects_orders` | Bons de commande d'un projet | read · idempotent |
+| `boond_projects_productivity` | Productivité d'un projet | read · idempotent |
+| `boond_projects_purchases` | Achats/sous-traitance d'un projet | read · idempotent |
+| `boond_projects_search` | Rechercher des projets | read · idempotent · open-world |
+| `boond_projects_simulation` | Simulation financière d'un projet | read · idempotent |
+| `boond_projects_update` | Modifier un(e) projet | write · idempotent |
+
+### provider_invoices (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_provider_invoices_get` | Détails d'une facture fournisseur | read · idempotent |
+| `boond_provider_invoices_search` | Rechercher des factures fournisseur | read · idempotent · open-world |
+
+### purchases (4)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_purchases_create` | Créer un achat/sous-traitance | write |
+| `boond_purchases_delete` | Supprimer un achat/sous-traitance | delete |
+| `boond_purchases_get` | Détails d'un achat/sous-traitance | read · idempotent |
+| `boond_purchases_search` | Rechercher des achats/sous-traitance | read · idempotent · open-world |
+
+### reporting (5)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_reporting_companies` | Reporting sociétés | read · idempotent · open-world |
+| `boond_reporting_production_plans` | Reporting plans de production | read · idempotent · open-world |
+| `boond_reporting_projects` | Reporting projets | read · idempotent · open-world |
+| `boond_reporting_resources` | Reporting ressources | read · idempotent · open-world |
+| `boond_reporting_synthesis` | Reporting synthèse | read · idempotent · open-world |
+
+### resources (16)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_resources_absences_reports` | Demandes d'absences d'une ressource | read · idempotent |
+| `boond_resources_actions` | Actions liées à une ressource | read · idempotent |
+| `boond_resources_administrative` | Données administratives d'une ressource | read · idempotent |
+| `boond_resources_advantages` | Avantages d'une ressource | read · idempotent |
+| `boond_resources_create` | Créer un(e) ressource | write |
+| `boond_resources_delete` | Supprimer un(e) ressource | delete |
+| `boond_resources_expenses_reports` | Notes de frais d'une ressource | read · idempotent |
+| `boond_resources_get` | Détails d'un(e) ressource | read · idempotent |
+| `boond_resources_information` | Informations générales d'une ressource | read · idempotent |
+| `boond_resources_positionings` | Positionnements d'une ressource | read · idempotent |
+| `boond_resources_projects` | Projets d'une ressource | read · idempotent |
+| `boond_resources_search` | Rechercher des ressources | read · idempotent · open-world |
+| `boond_resources_technical_data` | Compétences techniques d'une ressource | read · idempotent |
+| `boond_resources_times_reports` | Feuilles de temps d'une ressource | read · idempotent |
+| `boond_resources_timesheets` | Feuilles de temps d'une ressource | read · idempotent |
+| `boond_resources_update` | Modifier un(e) ressource | write · idempotent |
+
+### roles (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_roles_get` | Détails d'un rôle | read · idempotent |
+| `boond_roles_search` | Rechercher des rôles | read · idempotent · open-world |
+
+### threads (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_threads_get` | Détails d'un fil de discussion | read · idempotent |
+| `boond_threads_search` | Rechercher des fils de discussion | read · idempotent · open-world |
+
+### timesheets (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_timesheets_get` | Détails d'une feuille de temps | read · idempotent |
+| `boond_timesheets_search` | Rechercher des feuilles de temps | read · idempotent · open-world |
+
+### todolists (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_todolists_get` | Détails d'une liste de tâches | read · idempotent |
+| `boond_todolists_search` | Rechercher des listes de tâches | read · idempotent · open-world |
+
+### validations (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_validations_get` | Détails d'une validation | read · idempotent |
+| `boond_validations_search` | Rechercher des validations | read · idempotent · open-world |
+
+### webhooks (2)
+
+| Tool | Title | Hints |
+|---|---|---|
+| `boond_webhooks_get` | Détails d'un webhook | read · idempotent |
+| `boond_webhooks_search` | Rechercher des webhooks | read · idempotent · open-world |
+
+## Prompts (6)
+
+Pre-orchestrated workflows surfaced via the MCP prompts API.
+
+| Prompt | Title | Args |
+|---|---|---|
+| `candidats_pour_opportunite` | Candidats correspondant à une opportunité | `opportunity_id` |
+| `factures_a_relancer` | Factures impayées à relancer | `society_id?` |
+| `fiche_consultant` | Fiche complète d'un collaborateur | `resource_id` |
+| `pipeline_commercial` | Pipeline commercial sur une période | `date_debut` `date_fin` `manager_id?` |
+| `recap_hebdo` | Récap hebdomadaire (moi + mon équipe) | `semaine?` |
+| `synthese_equipe` | Synthèse d'une équipe | `manager_id?` `periode?` |
+
+## Resources (20)
+
+Reference data exposed as MCP resources.
+
+| URI | Title |
+|---|---|
+| `boond://application/current-user` | Utilisateur courant |
+| `boond://dictionary/countries` | Pays |
+| `boond://dictionary/currencies` | Devises |
+| `boond://dictionary/languages` | Langues |
+| `boond://dictionary/states/absences` | États absences |
+| `boond://dictionary/states/candidates` | États candidats |
+| `boond://dictionary/states/companies` | États sociétés |
+| `boond://dictionary/states/contacts` | États contacts |
+| `boond://dictionary/states/invoices` | États factures |
+| `boond://dictionary/states/opportunities` | États opportunités |
+| `boond://dictionary/states/orders` | États bons de commande |
+| `boond://dictionary/states/positionings` | États positionnements |
+| `boond://dictionary/states/projects` | États projets |
+| `boond://dictionary/states/resources` | États ressources |
+| `boond://dictionary/typeOf/absences` | Types absences |
+| `boond://dictionary/typeOf/actions` | Types actions |
+| `boond://dictionary/typeOf/candidates` | Types candidats |
+| `boond://dictionary/typeOf/contacts` | Types contacts |
+| `boond://dictionary/typeOf/projects` | Types projets |
+| `boond://dictionary/typeOf/resources` | Types ressources |

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
+    "docs:tools": "npm run build && node scripts/generate-tools-catalog.mjs",
+    "docs:tools:check": "npm run build && node scripts/generate-tools-catalog.mjs --check",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/generate-tools-catalog.mjs
+++ b/scripts/generate-tools-catalog.mjs
@@ -125,9 +125,15 @@ function describeArgs(argsSchema) {
     .join(" ");
 }
 
-/** Escape pipe characters so a value is safe inside a Markdown table cell. */
+/** Escape characters that have special meaning inside a Markdown table cell.
+ *  We escape `\` BEFORE `|` — otherwise an input like `a\|b` would become
+ *  `a\\|b` which renders as `a\|b` (the `\` was meant literally). Doing the
+ *  backslash pass first guarantees `a\|b` -> `a\\\|b`, rendered as `a\|b`. */
 function md(s) {
-  return String(s ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+  return String(s ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
 }
 
 // ---- Build the catalog -------------------------------------------------

--- a/scripts/generate-tools-catalog.mjs
+++ b/scripts/generate-tools-catalog.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// Auto-generate TOOLS.md from the actual server registrations.
+//
+// Strategy: stub `registerTool` / `registerPrompt` / `registerResource` on a
+// fake McpServer, run the same `register*` functions the real server runs,
+// and snapshot what was registered. This way the catalog cannot drift from
+// the code — if a tool is added/renamed/removed, regenerating the catalog
+// reflects it on the next CI run, and `--check` fails the build if it was
+// not regenerated.
+//
+// Usage:
+//   node scripts/generate-tools-catalog.mjs           # writes TOOLS.md
+//   node scripts/generate-tools-catalog.mjs --check   # fails if TOOLS.md is stale
+//
+// Requires `npm run build` first (we read the compiled output from dist/).
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const OUTPUT_PATH = join(REPO_ROOT, "TOOLS.md");
+const DIST_DIR = join(REPO_ROOT, "dist");
+
+if (!existsSync(DIST_DIR)) {
+  console.error(`ERROR: ${DIST_DIR} does not exist. Run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+// Import everything we need from the compiled output.
+const tools = await import("../dist/tools/index.js");
+const { registerAllPrompts } = await import("../dist/prompts/index.js");
+const { registerAllResources } = await import("../dist/resources/index.js");
+const { REGISTERED_DOMAINS } = await import("../dist/server.js");
+
+// Domains that span more than one underscore segment (e.g. `business_units`).
+// REGISTERED_DOMAINS uses dashes; tool names use underscores. Convert and
+// keep only the multi-word ones — they need a longest-prefix match in
+// `domainOf` so they're not chopped at the first underscore.
+const MULTI_WORD_DOMAINS = REGISTERED_DOMAINS
+  .map((d) => d.replace(/-/g, "_"))
+  .filter((d) => d.includes("_"));
+
+// ---- Capture all registrations against a stub McpServer ----------------
+
+const captured = { tools: [], prompts: [], resources: [] };
+
+const stub = {
+  registerTool: (name, config /*, _cb */) => {
+    captured.tools.push({ name, ...config });
+  },
+  registerPrompt: (name, config /*, _cb */) => {
+    captured.prompts.push({ name, ...config });
+  },
+  registerResource: (name, uri, config /*, _cb */) => {
+    captured.resources.push({ name, uri, ...config });
+  },
+};
+
+// Mirror the order in src/server.ts so the captured set is identical to a
+// real createMcpServer() boot.
+const TOOL_REGISTRARS = [
+  "registerCandidateTools", "registerResourceTools", "registerContactTools",
+  "registerCompanyTools", "registerOpportunityTools", "registerActionTools",
+  "registerTimesheetTools", "registerProjectTools", "registerInvoiceTools",
+  "registerOrderTools", "registerDeliveryTools", "registerAbsenceTools",
+  "registerExpenseTools", "registerProductTools", "registerPositioningTools",
+  "registerPaymentTools", "registerAdvantageTools", "registerApplicationTools",
+  "registerContractTools", "registerPurchaseTools", "registerProviderInvoiceTools",
+  "registerAccountTools", "registerAgencyTools", "registerBusinessUnitTools",
+  "registerRoleTools", "registerLogTools", "registerNotificationTools",
+  "registerThreadTools", "registerTodolistTools", "registerFlagTools",
+  "registerCalendarTools", "registerWebhookTools", "registerValidationTools",
+  "registerPoleTools", "registerReportingTools", "registerPlanningAbsenceTools",
+];
+
+for (const fnName of TOOL_REGISTRARS) {
+  const fn = tools[fnName];
+  if (typeof fn !== "function") {
+    console.error(`ERROR: ${fnName} is not exported from dist/tools/index.js`);
+    process.exit(1);
+  }
+  fn(stub);
+}
+registerAllPrompts(stub);
+registerAllResources(stub);
+
+// ---- Helpers -----------------------------------------------------------
+
+/** Domain bucket for a tool. Matches multi-word domains (e.g. `business_units`)
+ *  before falling back to "first underscore segment". */
+function domainOf(name) {
+  if (!name.startsWith("boond_")) return "other";
+  const rest = name.slice("boond_".length);
+  for (const m of MULTI_WORD_DOMAINS) {
+    if (rest === m || rest.startsWith(m + "_")) return m;
+  }
+  const idx = rest.indexOf("_");
+  return idx === -1 ? rest : rest.slice(0, idx);
+}
+
+/** Compact one-line label of a tool's MCP annotations. */
+function hintsLabel(annotations = {}) {
+  const out = [];
+  if (annotations.readOnlyHint) out.push("read");
+  else if (annotations.destructiveHint) out.push("delete");
+  else out.push("write");
+  if (annotations.idempotentHint) out.push("idempotent");
+  if (annotations.openWorldHint) out.push("open-world");
+  return out.join(" · ");
+}
+
+/** Inspect a Zod raw shape and list arg keys, marking optionals with `?`. */
+function describeArgs(argsSchema) {
+  if (!argsSchema || typeof argsSchema !== "object") return "—";
+  const entries = Object.entries(argsSchema);
+  if (entries.length === 0) return "—";
+  return entries
+    .map(([k, v]) => {
+      // Zod schemas expose isOptional() — duck-type check it.
+      const optional = typeof v?.isOptional === "function" ? v.isOptional() : false;
+      return `\`${k}${optional ? "?" : ""}\``;
+    })
+    .join(" ");
+}
+
+/** Escape pipe characters so a value is safe inside a Markdown table cell. */
+function md(s) {
+  return String(s ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+// ---- Build the catalog -------------------------------------------------
+
+const byDomain = new Map();
+for (const t of captured.tools) {
+  const d = domainOf(t.name);
+  if (!byDomain.has(d)) byDomain.set(d, []);
+  byDomain.get(d).push(t);
+}
+// Deterministic ordering: domains alphabetical, tools alphabetical within.
+const domains = [...byDomain.keys()].sort();
+for (const d of domains) {
+  byDomain.get(d).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const lines = [];
+lines.push("# Tool Catalogue");
+lines.push("");
+lines.push("> Auto-generated from the server registrations. Do not edit by hand.");
+lines.push("> Regenerate with `npm run docs:tools` (CI fails if this file is stale).");
+lines.push("");
+lines.push(`**${captured.tools.length} tools** across **${domains.length} domains** · **${captured.prompts.length} prompts** · **${captured.resources.length} resources**.`);
+lines.push("");
+lines.push("Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).");
+lines.push("");
+
+lines.push("## Tools");
+lines.push("");
+for (const domain of domains) {
+  const items = byDomain.get(domain);
+  lines.push(`### ${domain} (${items.length})`);
+  lines.push("");
+  lines.push("| Tool | Title | Hints |");
+  lines.push("|---|---|---|");
+  for (const t of items) {
+    lines.push(`| \`${t.name}\` | ${md(t.title)} | ${md(hintsLabel(t.annotations))} |`);
+  }
+  lines.push("");
+}
+
+lines.push(`## Prompts (${captured.prompts.length})`);
+lines.push("");
+lines.push("Pre-orchestrated workflows surfaced via the MCP prompts API.");
+lines.push("");
+lines.push("| Prompt | Title | Args |");
+lines.push("|---|---|---|");
+for (const p of [...captured.prompts].sort((a, b) => a.name.localeCompare(b.name))) {
+  lines.push(`| \`${p.name}\` | ${md(p.title)} | ${describeArgs(p.argsSchema)} |`);
+}
+lines.push("");
+
+lines.push(`## Resources (${captured.resources.length})`);
+lines.push("");
+lines.push("Reference data exposed as MCP resources.");
+lines.push("");
+lines.push("| URI | Title |");
+lines.push("|---|---|");
+for (const r of [...captured.resources].sort((a, b) => a.uri.localeCompare(b.uri))) {
+  lines.push(`| \`${r.uri}\` | ${md(r.title)} |`);
+}
+lines.push("");
+
+const generated = lines.join("\n");
+
+// ---- Write or check ---------------------------------------------------
+
+const checkMode = process.argv.includes("--check");
+if (checkMode) {
+  const existing = existsSync(OUTPUT_PATH) ? readFileSync(OUTPUT_PATH, "utf8") : "";
+  // Normalise CRLF → LF on both sides so Windows checkouts don't false-fail.
+  const norm = (s) => s.replace(/\r\n/g, "\n");
+  if (norm(existing) !== norm(generated)) {
+    console.error(`ERROR: ${OUTPUT_PATH} is out of date. Run \`npm run docs:tools\` and commit the result.`);
+    process.exit(1);
+  }
+  console.log(`${OUTPUT_PATH} is up to date.`);
+} else {
+  writeFileSync(OUTPUT_PATH, generated);
+  console.log(`Wrote ${OUTPUT_PATH} — ${captured.tools.length} tools, ${captured.prompts.length} prompts, ${captured.resources.length} resources.`);
+}


### PR DESCRIPTION
Introduce a script to auto-generate a TOOLS.md catalog from the compiled server registrations (scripts/generate-tools-catalog.mjs) and add the generated TOOLS.md file. Add npm scripts (docs:tools, docs:tools:check) to build and produce/check the catalog. Update CI workflow to run the generator in --check mode (Node 22 matrix) so the build fails if TOOLS.md is stale. Also update README to reference the auto-generated TOOLS.md.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
