### PR TITLE
Add configurable HTTP timeout for Boond client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Configured via environment variables (never hardcoded), in priority order:
 2. **Pre-built JWT**: `BOOND_API_TOKEN` (JWT Bearer)
 3. **BasicAuth**: `BOOND_USER` + `BOOND_PASSWORD` (base64-encoded)
 - `BOOND_BASE_URL` (optional, defaults to `https://ui.boondmanager.com/api`)
+- `BOOND_HTTP_TIMEOUT_MS` (optional, defaults to `30000`) — per-request timeout for the BoondManager HTTP client. Non-numeric / non-positive values fall back to the default. A timeout surfaces as an `Error` whose message includes the configured value and the failing endpoint.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,16 @@ export BOOND_BASE_URL="https://votre-instance.boondmanager.com/api"
 
 Par defaut, l'URL est `https://ui.boondmanager.com/api`.
 
+### Delai d'expiration HTTP
+
+Chaque requete vers l'API BoondManager expire au bout de **30 secondes** par defaut. Pour les tenants lents ou des rapports volumineux, augmenter via :
+
+```bash
+export BOOND_HTTP_TIMEOUT_MS=60000   # 60 s
+```
+
+Si une requete depasse le delai, le serveur renvoie une erreur explicite mentionnant `BOOND_HTTP_TIMEOUT_MS` plutot que de rester bloque indefiniment.
+
 ## Transports
 
 Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,11 @@ export const CHARACTER_LIMIT = 50000;
 export const DEFAULT_PAGE_SIZE = 30;
 export const MAX_PAGE_SIZE = 500;
 
+// HTTP client defaults
+// Timeout applied to every BoondManager API request. Overridable via
+// BOOND_HTTP_TIMEOUT_MS to handle slow tenants or long reporting queries.
+export const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
+
 // API paths
 export const API_PATHS = {
   candidates: "/candidates",

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -9,8 +9,9 @@ import {
   apiRequest,
   parseBoondErrorBody,
   formatApiError,
+  resolveTimeoutMs,
 } from "./boond-client.js";
-import { CHARACTER_LIMIT } from "../constants.js";
+import { CHARACTER_LIMIT, DEFAULT_HTTP_TIMEOUT_MS } from "../constants.js";
 
 describe("buildSearchQuery", () => {
   it("should map keywords, page, and pageSize correctly", () => {
@@ -414,6 +415,74 @@ describe("apiRequest", () => {
     const fetchCall = vi.mocked(fetch).mock.calls[0];
     const url = fetchCall[0] as string;
     expect(url).not.toContain("empty");
+  });
+
+  it("should pass an AbortSignal with a timeout to fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-length": "10" }),
+        json: () => Promise.resolve({ data: [] }),
+      })
+    );
+
+    await apiRequest("/candidates");
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const options = fetchCall[1] as RequestInit;
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("should surface a clear timeout error when the request is aborted", async () => {
+    process.env.BOOND_HTTP_TIMEOUT_MS = "1234";
+    const abortErr = new Error("The operation was aborted due to timeout");
+    abortErr.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortErr));
+
+    await expect(apiRequest("/candidates")).rejects.toThrow(/timed out after 1234ms/);
+    await expect(apiRequest("/candidates")).rejects.toThrow(/BOOND_HTTP_TIMEOUT_MS/);
+
+    delete process.env.BOOND_HTTP_TIMEOUT_MS;
+  });
+
+  it("should rethrow unrelated fetch errors as-is", async () => {
+    const networkErr = new Error("ECONNREFUSED");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkErr));
+
+    await expect(apiRequest("/candidates")).rejects.toThrow("ECONNREFUSED");
+  });
+});
+
+describe("resolveTimeoutMs", () => {
+  afterEach(() => {
+    delete process.env.BOOND_HTTP_TIMEOUT_MS;
+  });
+
+  it("returns the default when the env var is unset", () => {
+    expect(resolveTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+  });
+
+  it("honours a positive integer override", () => {
+    process.env.BOOND_HTTP_TIMEOUT_MS = "5000";
+    expect(resolveTimeoutMs()).toBe(5000);
+  });
+
+  it("falls back to the default on non-numeric values", () => {
+    process.env.BOOND_HTTP_TIMEOUT_MS = "not-a-number";
+    expect(resolveTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+  });
+
+  it("falls back to the default on zero or negative values", () => {
+    process.env.BOOND_HTTP_TIMEOUT_MS = "0";
+    expect(resolveTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+    process.env.BOOND_HTTP_TIMEOUT_MS = "-100";
+    expect(resolveTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+  });
+
+  it("ignores unresolved template placeholders", () => {
+    process.env.BOOND_HTTP_TIMEOUT_MS = "${user_config.timeout}";
+    expect(resolveTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
   });
 });
 

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "crypto";
-import { DEFAULT_BASE_URL, CHARACTER_LIMIT } from "../constants.js";
+import { DEFAULT_BASE_URL, CHARACTER_LIMIT, DEFAULT_HTTP_TIMEOUT_MS } from "../constants.js";
 import type { BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
 
 let config: BoondConfig | null = null;
@@ -100,6 +100,32 @@ export function parseBoondErrorBody(body: string): string | null {
   }
 }
 
+/**
+ * Resolve the per-request HTTP timeout in milliseconds.
+ *
+ * Reads BOOND_HTTP_TIMEOUT_MS at call time so tests / runtime overrides take
+ * effect without restarting the process. Falls back to the default for
+ * unset, non-numeric, or non-positive values.
+ *
+ * Exported for unit testing.
+ */
+export function resolveTimeoutMs(): number {
+  const raw = envOrUndefined("BOOND_HTTP_TIMEOUT_MS");
+  if (!raw) return DEFAULT_HTTP_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_HTTP_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
+/** True when an error from fetch() came from an AbortSignal firing. */
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // AbortSignal.timeout() rejects with a DOMException whose name is "TimeoutError";
+  // generic aborts surface as "AbortError". Both indicate the request never
+  // completed end-to-end and should be reported as a timeout.
+  return err.name === "TimeoutError" || err.name === "AbortError";
+}
+
 /** Status-specific hint to help the LLM (or human) recover from common failures. */
 function hintForStatus(status: number): string {
   switch (status) {
@@ -177,12 +203,32 @@ export async function apiRequest(
     "Content-Type": "application/json",
   };
 
-  const fetchOptions: RequestInit = { method, headers };
+  const timeoutMs = resolveTimeoutMs();
+  const fetchOptions: RequestInit = {
+    method,
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  };
   if (body && (method === "POST" || method === "PUT" || method === "PATCH")) {
     fetchOptions.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url.toString(), fetchOptions);
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), fetchOptions);
+  } catch (err) {
+    if (isAbortError(err)) {
+      throw new Error(
+        [
+          `BoondManager API request timed out after ${timeoutMs}ms`,
+          `Endpoint: ${method} ${path}`,
+          "Hint: Increase BOOND_HTTP_TIMEOUT_MS or check connectivity to the BoondManager API.",
+        ].join("\n"),
+        { cause: err }
+      );
+    }
+    throw err;
+  }
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "");


### PR DESCRIPTION
Introduce a per-request HTTP timeout for the BoondManager client configurable via BOOND_HTTP_TIMEOUT_MS (defaults to 30000ms).

Changes:
- Add DEFAULT_HTTP_TIMEOUT_MS constant and document BOOND_HTTP_TIMEOUT_MS in README and CLAUDE.md.
- Implement resolveTimeoutMs() to read and validate the env var (falls back on unset, non-numeric, or non-positive values).
- Use AbortSignal.timeout(timeoutMs) in apiRequest and surface a clear timeout error that includes the configured value and endpoint; unrelated fetch errors are rethrown unchanged.
- Add isAbortError helper and unit tests for apiRequest and resolveTimeoutMs covering abort/timeouts, env parsing, and error propagation.

This makes the client resilient to slow tenants and long reports while providing a clear error message and an override for operators.

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
