### PR TITLE
Add HTTP retry policy to Boond client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,8 @@ Configured via environment variables (never hardcoded), in priority order:
 3. **BasicAuth**: `BOOND_USER` + `BOOND_PASSWORD` (base64-encoded)
 - `BOOND_BASE_URL` (optional, defaults to `https://ui.boondmanager.com/api`)
 - `BOOND_HTTP_TIMEOUT_MS` (optional, defaults to `30000`) — per-request timeout for the BoondManager HTTP client. Non-numeric / non-positive values fall back to the default. A timeout surfaces as an `Error` whose message includes the configured value and the failing endpoint.
+- `BOOND_HTTP_MAX_RETRIES` (optional, defaults to `2`) — number of additional attempts after the first failure. Set to `0` to disable retries. Retry policy: GET retries on 5xx / 429 / network / timeout; non-GET retries only on 429 (idempotency safety). `Retry-After` is honoured.
+- `BOOND_HTTP_RETRY_BASE_MS` / `BOOND_HTTP_RETRY_MAX_MS` (optional, defaults `200` / `5000`) — full-jitter exponential backoff: `random(0, min(maxMs, baseMs * 2^attempt))`.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ export BOOND_HTTP_TIMEOUT_MS=60000   # 60 s
 
 Si une requete depasse le delai, le serveur renvoie une erreur explicite mentionnant `BOOND_HTTP_TIMEOUT_MS` plutot que de rester bloque indefiniment.
 
+### Tentatives en cas d'echec transitoire
+
+Le client HTTP retente automatiquement les erreurs **transitoires** avec un backoff exponentiel + jitter :
+
+- **GET** : retry sur `5xx`, `429`, erreurs reseau (`ECONNRESET`, etc.) et timeouts (GET etant idempotent).
+- **POST / PUT / PATCH / DELETE** : retry **uniquement sur `429`** afin d'eviter de dupliquer une ecriture cote serveur. Les `5xx` et erreurs reseau remontent immediatement.
+- L'en-tete `Retry-After` (en secondes ou en HTTP-date) est honore et plafonne a `BOOND_HTTP_RETRY_MAX_MS`.
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `BOOND_HTTP_MAX_RETRIES` | `2` | Nombre maximal de tentatives supplementaires (3 essais au total). `0` desactive entierement les retries. |
+| `BOOND_HTTP_RETRY_BASE_MS` | `200` | Delai de base utilise pour le backoff exponentiel (`base * 2^attempt`, avec jitter). |
+| `BOOND_HTTP_RETRY_MAX_MS` | `5000` | Plafond du delai entre deux tentatives. |
+
 ## Transports
 
 Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,13 @@ export const MAX_PAGE_SIZE = 500;
 // BOOND_HTTP_TIMEOUT_MS to handle slow tenants or long reporting queries.
 export const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
 
+// Retry policy for transient failures. Override via BOOND_HTTP_MAX_RETRIES,
+// BOOND_HTTP_RETRY_BASE_MS, BOOND_HTTP_RETRY_MAX_MS. Set MAX_RETRIES to 0 to
+// disable retries entirely.
+export const DEFAULT_HTTP_MAX_RETRIES = 2;
+export const DEFAULT_HTTP_RETRY_BASE_MS = 200;
+export const DEFAULT_HTTP_RETRY_MAX_MS = 5_000;
+
 // API paths
 export const API_PATHS = {
   candidates: "/candidates",

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -10,8 +10,18 @@ import {
   parseBoondErrorBody,
   formatApiError,
   resolveTimeoutMs,
+  resolveRetryConfig,
+  isRetryable,
+  parseRetryAfter,
+  computeBackoffMs,
 } from "./boond-client.js";
-import { CHARACTER_LIMIT, DEFAULT_HTTP_TIMEOUT_MS } from "../constants.js";
+import {
+  CHARACTER_LIMIT,
+  DEFAULT_HTTP_TIMEOUT_MS,
+  DEFAULT_HTTP_MAX_RETRIES,
+  DEFAULT_HTTP_RETRY_BASE_MS,
+  DEFAULT_HTTP_RETRY_MAX_MS,
+} from "../constants.js";
 
 describe("buildSearchQuery", () => {
   it("should map keywords, page, and pageSize correctly", () => {
@@ -294,12 +304,16 @@ describe("buildJwt", () => {
 describe("apiRequest", () => {
   beforeEach(() => {
     process.env.BOOND_API_TOKEN = "test-token";
+    // Disable retries for the legacy apiRequest tests so a single mock value
+    // produces a single fetch call, keeping assertions deterministic.
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
     initClient();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
   });
 
   it("should make a GET request and return JSON", async () => {
@@ -554,5 +568,256 @@ describe("formatApiError", () => {
   it("emits a 5xx-specific hint", () => {
     const msg = formatApiError(503, "Service Unavailable", "GET", "/resources", "");
     expect(msg).toContain("BoondManager-side error");
+  });
+});
+
+describe("resolveRetryConfig", () => {
+  afterEach(() => {
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RETRY_BASE_MS;
+    delete process.env.BOOND_HTTP_RETRY_MAX_MS;
+  });
+
+  it("returns defaults when nothing is set", () => {
+    expect(resolveRetryConfig()).toEqual({
+      maxRetries: DEFAULT_HTTP_MAX_RETRIES,
+      baseDelayMs: DEFAULT_HTTP_RETRY_BASE_MS,
+      maxDelayMs: DEFAULT_HTTP_RETRY_MAX_MS,
+    });
+  });
+
+  it("honours numeric overrides", () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "5";
+    process.env.BOOND_HTTP_RETRY_BASE_MS = "50";
+    process.env.BOOND_HTTP_RETRY_MAX_MS = "1000";
+    expect(resolveRetryConfig()).toEqual({ maxRetries: 5, baseDelayMs: 50, maxDelayMs: 1000 });
+  });
+
+  it("allows BOOND_HTTP_MAX_RETRIES=0 to disable retries", () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    expect(resolveRetryConfig().maxRetries).toBe(0);
+  });
+
+  it("rejects 0 / negative for delay knobs and falls back to defaults", () => {
+    process.env.BOOND_HTTP_RETRY_BASE_MS = "0";
+    process.env.BOOND_HTTP_RETRY_MAX_MS = "-1";
+    const cfg = resolveRetryConfig();
+    expect(cfg.baseDelayMs).toBe(DEFAULT_HTTP_RETRY_BASE_MS);
+    expect(cfg.maxDelayMs).toBe(DEFAULT_HTTP_RETRY_MAX_MS);
+  });
+
+  it("ignores non-numeric values", () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "lots";
+    expect(resolveRetryConfig().maxRetries).toBe(DEFAULT_HTTP_MAX_RETRIES);
+  });
+});
+
+describe("isRetryable", () => {
+  it("retries 429 for any verb", () => {
+    expect(isRetryable("GET", 429, false)).toBe(true);
+    expect(isRetryable("POST", 429, false)).toBe(true);
+    expect(isRetryable("DELETE", 429, false)).toBe(true);
+  });
+
+  it("retries 5xx only for GET", () => {
+    expect(isRetryable("GET", 503, false)).toBe(true);
+    expect(isRetryable("POST", 503, false)).toBe(false);
+    expect(isRetryable("PATCH", 502, false)).toBe(false);
+  });
+
+  it("retries network/timeout errors only for GET", () => {
+    expect(isRetryable("GET", undefined, true)).toBe(true);
+    expect(isRetryable("POST", undefined, true)).toBe(false);
+  });
+
+  it("never retries 4xx other than 429", () => {
+    expect(isRetryable("GET", 400, false)).toBe(false);
+    expect(isRetryable("GET", 404, false)).toBe(false);
+    expect(isRetryable("GET", 422, false)).toBe(false);
+  });
+
+  it("never retries 2xx/3xx", () => {
+    expect(isRetryable("GET", 200, false)).toBe(false);
+    expect(isRetryable("GET", 304, false)).toBe(false);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("returns null on missing or empty values", () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter("")).toBeNull();
+    expect(parseRetryAfter("   ")).toBeNull();
+  });
+
+  it("parses a numeric seconds value", () => {
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("5")).toBe(5000);
+    expect(parseRetryAfter("2.5")).toBe(2500);
+  });
+
+  it("parses an HTTP-date relative to now", () => {
+    const now = Date.parse("2024-01-01T00:00:00Z");
+    const future = new Date(now + 3000).toUTCString();
+    expect(parseRetryAfter(future, now)).toBe(3000);
+  });
+
+  it("clamps past dates to 0", () => {
+    const now = Date.parse("2024-01-01T00:00:00Z");
+    const past = new Date(now - 5000).toUTCString();
+    expect(parseRetryAfter(past, now)).toBe(0);
+  });
+
+  it("returns null for unparseable values", () => {
+    expect(parseRetryAfter("not-a-date")).toBeNull();
+  });
+
+  it("returns null for negative seconds", () => {
+    expect(parseRetryAfter("-1")).toBeNull();
+  });
+});
+
+describe("computeBackoffMs", () => {
+  it("returns a value within [0, baseMs * 2^attempt] when below cap", () => {
+    expect(computeBackoffMs(0, 100, 10_000, () => 0)).toBe(0);
+    expect(computeBackoffMs(0, 100, 10_000, () => 0.999)).toBe(99);
+    expect(computeBackoffMs(2, 100, 10_000, () => 0.999)).toBe(399); // 100 * 4 = 400
+  });
+
+  it("clamps to maxMs", () => {
+    expect(computeBackoffMs(20, 100, 500, () => 0.999)).toBe(499);
+  });
+
+  it("uses Math.random by default", () => {
+    const v = computeBackoffMs(1, 100, 10_000);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("apiRequest retries", () => {
+  beforeEach(() => {
+    process.env.BOOND_API_TOKEN = "test-token";
+    process.env.BOOND_HTTP_RETRY_BASE_MS = "1";
+    process.env.BOOND_HTTP_RETRY_MAX_MS = "1";
+    initClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RETRY_BASE_MS;
+    delete process.env.BOOND_HTTP_RETRY_MAX_MS;
+  });
+
+  function okResponse(data: unknown = { data: [] }) {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "10" }),
+      json: () => Promise.resolve(data),
+    };
+  }
+
+  function errResponse(status: number, statusText = "Error", retryAfter?: string) {
+    const headers = new Headers();
+    if (retryAfter !== undefined) headers.set("retry-after", retryAfter);
+    return {
+      ok: false,
+      status,
+      statusText,
+      headers,
+      text: () => Promise.resolve(""),
+    };
+  }
+
+  it("retries GET on 503 and eventually succeeds", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "2";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errResponse(503, "Service Unavailable"))
+      .mockResolvedValueOnce(errResponse(503, "Service Unavailable"))
+      .mockResolvedValueOnce(okResponse({ data: [{ id: "1", type: "candidate", attributes: {} }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiRequest("/candidates");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(Array.isArray(result.data) ? result.data[0].id : "").toBe("1");
+  });
+
+  it("does not retry GET on 4xx (other than 429)", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "3";
+    const fetchMock = vi.fn().mockResolvedValue(errResponse(404, "Not Found"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates/999")).rejects.toThrow("BoondManager API 404");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries 429 even on POST and honours Retry-After (seconds)", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "2";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errResponse(429, "Too Many Requests", "0"))
+      .mockResolvedValueOnce(okResponse({ data: { id: "1", type: "candidate", attributes: {} } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiRequest("/candidates", "POST", { foo: "bar" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(Array.isArray(result.data) ? "" : result.data.id).toBe("1");
+  });
+
+  it("does not retry 5xx on POST (write idempotency safety)", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "3";
+    const fetchMock = vi.fn().mockResolvedValue(errResponse(503, "Service Unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates", "POST", { foo: "bar" })).rejects.toThrow(
+      "BoondManager API 503"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries network errors on GET and gives up after maxRetries", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "2";
+    const netErr = new Error("ECONNRESET");
+    const fetchMock = vi.fn().mockRejectedValue(netErr);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates")).rejects.toThrow("ECONNRESET");
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("retries timeouts on GET", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "1";
+    const abortErr = new Error("aborted");
+    abortErr.name = "TimeoutError";
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(abortErr)
+      .mockResolvedValueOnce(okResponse({ data: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates")).resolves.toEqual({ data: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry network errors on POST", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "3";
+    const netErr = new Error("ECONNRESET");
+    const fetchMock = vi.fn().mockRejectedValue(netErr);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates", "POST", { foo: "bar" })).rejects.toThrow("ECONNRESET");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("BOOND_HTTP_MAX_RETRIES=0 disables retries on 503", async () => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    const fetchMock = vi.fn().mockResolvedValue(errResponse(503, "Service Unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/candidates")).rejects.toThrow("BoondManager API 503");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -1,5 +1,12 @@
 import { createHmac } from "crypto";
-import { DEFAULT_BASE_URL, CHARACTER_LIMIT, DEFAULT_HTTP_TIMEOUT_MS } from "../constants.js";
+import {
+  DEFAULT_BASE_URL,
+  CHARACTER_LIMIT,
+  DEFAULT_HTTP_TIMEOUT_MS,
+  DEFAULT_HTTP_MAX_RETRIES,
+  DEFAULT_HTTP_RETRY_BASE_MS,
+  DEFAULT_HTTP_RETRY_MAX_MS,
+} from "../constants.js";
 import type { BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
 
 let config: BoondConfig | null = null;
@@ -126,6 +133,104 @@ function isAbortError(err: unknown): boolean {
   return err.name === "TimeoutError" || err.name === "AbortError";
 }
 
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+function readPositiveInt(name: string, fallback: number, allowZero = false): number {
+  const raw = envOrUndefined(name);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < 0) return fallback;
+  if (parsed === 0 && !allowZero) return fallback;
+  return Math.floor(parsed);
+}
+
+/** Resolve retry configuration from env, with safe fallbacks. Exported for tests. */
+export function resolveRetryConfig(): RetryConfig {
+  return {
+    maxRetries: readPositiveInt("BOOND_HTTP_MAX_RETRIES", DEFAULT_HTTP_MAX_RETRIES, true),
+    baseDelayMs: readPositiveInt("BOOND_HTTP_RETRY_BASE_MS", DEFAULT_HTTP_RETRY_BASE_MS),
+    maxDelayMs: readPositiveInt("BOOND_HTTP_RETRY_MAX_MS", DEFAULT_HTTP_RETRY_MAX_MS),
+  };
+}
+
+/**
+ * Decide whether a failed attempt is worth retrying.
+ *
+ * Retry policy is intentionally conservative for non-idempotent verbs to avoid
+ * silently duplicating writes when the server's response was lost or delayed:
+ *   - 429 (Too Many Requests) is always retried — the server explicitly
+ *     rejected the request before processing it, so it is safe regardless of
+ *     verb.
+ *   - For GET only, 5xx responses, network failures, and timeouts are retried
+ *     because GET is idempotent.
+ *   - 4xx responses (other than 429) are never retried — the client must change
+ *     the request before another attempt makes sense.
+ *
+ * Exported for unit testing.
+ */
+export function isRetryable(
+  method: string,
+  status: number | undefined,
+  isNetworkOrTimeout: boolean
+): boolean {
+  if (status === 429) return true;
+  if (method !== "GET") return false;
+  if (isNetworkOrTimeout) return true;
+  if (status !== undefined && status >= 500 && status < 600) return true;
+  return false;
+}
+
+/**
+ * Parse a `Retry-After` header value into milliseconds.
+ *
+ * Accepts either a non-negative number of seconds or an HTTP-date. Returns
+ * null when the value is absent or unparseable. Negative computed delays are
+ * clamped to 0. Exported for unit testing.
+ */
+export function parseRetryAfter(value: string | null, now: number = Date.now()): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds)) {
+    // Numeric form is authoritative once we recognise it as a number — falling
+    // through to Date.parse on a negative/odd numeric would silently produce
+    // weird timestamps (e.g. Date.parse("-1") → year -1).
+    return seconds >= 0 ? Math.floor(seconds * 1000) : null;
+  }
+  const date = Date.parse(trimmed);
+  if (!Number.isNaN(date)) return Math.max(0, date - now);
+  return null;
+}
+
+/**
+ * Compute the next backoff delay using full jitter:
+ *   delay = random(0, min(maxMs, baseMs * 2^attempt))
+ *
+ * Full jitter (vs. exponential-only) reduces thundering-herd risk when many
+ * clients retry in lockstep. Exported for unit testing.
+ */
+export function computeBackoffMs(
+  attempt: number,
+  baseMs: number,
+  maxMs: number,
+  random: () => number = Math.random
+): number {
+  const exp = baseMs * 2 ** attempt;
+  const capped = Math.min(maxMs, exp);
+  return Math.floor(random() * capped);
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** Status-specific hint to help the LLM (or human) recover from common failures. */
 function hintForStatus(status: number): string {
   switch (status) {
@@ -204,43 +309,95 @@ export async function apiRequest(
   };
 
   const timeoutMs = resolveTimeoutMs();
-  const fetchOptions: RequestInit = {
-    method,
-    headers,
-    signal: AbortSignal.timeout(timeoutMs),
-  };
-  if (body && (method === "POST" || method === "PUT" || method === "PATCH")) {
-    fetchOptions.body = JSON.stringify(body);
-  }
+  const retry = resolveRetryConfig();
+  const totalAttempts = retry.maxRetries + 1;
 
-  let response: Response;
-  try {
-    response = await fetch(url.toString(), fetchOptions);
-  } catch (err) {
-    if (isAbortError(err)) {
-      throw new Error(
-        [
-          `BoondManager API request timed out after ${timeoutMs}ms`,
-          `Endpoint: ${method} ${path}`,
-          "Hint: Increase BOOND_HTTP_TIMEOUT_MS or check connectivity to the BoondManager API.",
-        ].join("\n"),
-        { cause: err }
-      );
+  const buildBody = (): string | undefined =>
+    body && (method === "POST" || method === "PUT" || method === "PATCH")
+      ? JSON.stringify(body)
+      : undefined;
+  const serializedBody = buildBody();
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    const fetchOptions: RequestInit = {
+      method,
+      headers,
+      // Each attempt gets its own abort signal — once a signal has fired it
+      // can't be reused for the next try.
+      signal: AbortSignal.timeout(timeoutMs),
+    };
+    if (serializedBody !== undefined) {
+      fetchOptions.body = serializedBody;
     }
-    throw err;
+
+    let response: Response | undefined;
+    let networkError: Error | undefined;
+
+    try {
+      response = await fetch(url.toString(), fetchOptions);
+    } catch (err) {
+      if (isAbortError(err)) {
+        networkError = new Error(
+          [
+            `BoondManager API request timed out after ${timeoutMs}ms`,
+            `Endpoint: ${method} ${path}`,
+            "Hint: Increase BOOND_HTTP_TIMEOUT_MS or check connectivity to the BoondManager API.",
+          ].join("\n"),
+          { cause: err }
+        );
+      } else {
+        networkError = err instanceof Error ? err : new Error(String(err));
+      }
+    }
+
+    if (response && response.ok) {
+      // DELETE may return empty body
+      if (response.status === 204 || response.headers.get("content-length") === "0") {
+        return { data: [] };
+      }
+      return (await response.json()) as JsonApiResponse;
+    }
+
+    let attemptError: Error;
+    let retryAfterMs: number | null = null;
+    let isNetworkOrTimeout = false;
+
+    if (response) {
+      const errorText = await response.text().catch(() => "");
+      attemptError = new Error(
+        formatApiError(response.status, response.statusText, method, path, errorText)
+      );
+    } else {
+      attemptError = networkError!;
+      isNetworkOrTimeout = true;
+    }
+
+    const hasMoreAttempts = attempt < totalAttempts - 1;
+    const retryable = isRetryable(method, response?.status, isNetworkOrTimeout);
+
+    if (!hasMoreAttempts || !retryable) {
+      throw attemptError;
+    }
+
+    // Only inspect Retry-After when we've actually decided to retry — keeps
+    // the fast path off the headers object and matches existing tests that
+    // build minimal Response stubs.
+    if (response) {
+      retryAfterMs = parseRetryAfter(response.headers?.get("retry-after") ?? null);
+    }
+
+    const backoff =
+      retryAfterMs !== null
+        ? Math.min(retry.maxDelayMs, retryAfterMs)
+        : computeBackoffMs(attempt, retry.baseDelayMs, retry.maxDelayMs);
+    await sleep(backoff);
+    lastError = attemptError;
   }
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "");
-    throw new Error(formatApiError(response.status, response.statusText, method, path, errorText));
-  }
-
-  // DELETE may return empty body
-  if (response.status === 204 || response.headers.get("content-length") === "0") {
-    return { data: [] };
-  }
-
-  return (await response.json()) as JsonApiResponse;
+  // Defensive — the loop always returns or throws. If somehow exhausted:
+  throw lastError ?? new Error("BoondManager API request exhausted retries with no recorded error.");
 }
 
 export function buildSearchQuery(params: SearchParams): Record<string, QueryValue> {


### PR DESCRIPTION
Introduce a configurable retry policy for Boond HTTP calls. Adds new environment knobs (BOOND_HTTP_MAX_RETRIES, BOOND_HTTP_RETRY_BASE_MS, BOOND_HTTP_RETRY_MAX_MS) and defaults in constants. Implements retry logic in apiRequest with helper functions (resolveRetryConfig, isRetryable, parseRetryAfter, computeBackoffMs, sleep) using full-jitter exponential backoff and honoring Retry-After. Policy is conservative: 429 is retried for any verb; 5xx, network errors and timeouts are retried only for GET to preserve write idempotency; BOOND_HTTP_MAX_RETRIES=0 disables retries. Updates README and CLAUDE.md to document behavior and adds comprehensive unit tests for config parsing, retry decisions, backoff computation, and end-to-end retry scenarios.

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
