### PR TITLE
Add client-side token-bucket rate limiter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,7 @@ Configured via environment variables (never hardcoded), in priority order:
 - `BOOND_HTTP_TIMEOUT_MS` (optional, defaults to `30000`) — per-request timeout for the BoondManager HTTP client. Non-numeric / non-positive values fall back to the default. A timeout surfaces as an `Error` whose message includes the configured value and the failing endpoint.
 - `BOOND_HTTP_MAX_RETRIES` (optional, defaults to `2`) — number of additional attempts after the first failure. Set to `0` to disable retries. Retry policy: GET retries on 5xx / 429 / network / timeout; non-GET retries only on 429 (idempotency safety). `Retry-After` is honoured.
 - `BOOND_HTTP_RETRY_BASE_MS` / `BOOND_HTTP_RETRY_MAX_MS` (optional, defaults `200` / `5000`) — full-jitter exponential backoff: `random(0, min(maxMs, baseMs * 2^attempt))`.
+- `BOOND_HTTP_RATE_LIMIT_RPS` / `BOOND_HTTP_RATE_LIMIT_BURST` (optional, defaults `10` / `20`) — client-side token bucket guarding the BoondManager API. Each attempt (including retries) consumes one token. Set RPS to `0` to disable. Implementation in `src/services/rate-limiter.ts`; tests can swap the bucket via the exported `resetRateLimiterForTests()`.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,15 @@ Le client HTTP retente automatiquement les erreurs **transitoires** avec un back
 | `BOOND_HTTP_RETRY_BASE_MS` | `200` | Delai de base utilise pour le backoff exponentiel (`base * 2^attempt`, avec jitter). |
 | `BOOND_HTTP_RETRY_MAX_MS` | `5000` | Plafond du delai entre deux tentatives. |
 
+### Limitation de debit (rate limiting)
+
+Pour eviter qu'une boucle d'outils emballee n'inonde l'API (et n'enchaine les `429`), le client applique un **token bucket** local. Defauts : **10 req/s** soutenu, **rafale 20** — invisible en usage interactif normal. Les retentatives consomment aussi un jeton.
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `BOOND_HTTP_RATE_LIMIT_RPS` | `10` | Debit soutenu (requetes/seconde). `0` desactive completement. |
+| `BOOND_HTTP_RATE_LIMIT_BURST` | `20` | Capacite du bucket = taille maximale de rafale immediate. |
+
 ## Transports
 
 Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,13 @@ export const DEFAULT_HTTP_MAX_RETRIES = 2;
 export const DEFAULT_HTTP_RETRY_BASE_MS = 200;
 export const DEFAULT_HTTP_RETRY_MAX_MS = 5_000;
 
+// Client-side rate limit (token bucket). Modest defaults: invisible during
+// interactive use, but cap pathological loops before BoondManager 429s us.
+// Override via BOOND_HTTP_RATE_LIMIT_RPS / BOOND_HTTP_RATE_LIMIT_BURST.
+// Set RPS to 0 to disable rate limiting entirely.
+export const DEFAULT_HTTP_RATE_LIMIT_RPS = 10;
+export const DEFAULT_HTTP_RATE_LIMIT_BURST = 20;
+
 // API paths
 export const API_PATHS = {
   candidates: "/candidates",

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -14,6 +14,8 @@ import {
   isRetryable,
   parseRetryAfter,
   computeBackoffMs,
+  resolveRateLimitConfig,
+  resetRateLimiterForTests,
 } from "./boond-client.js";
 import {
   CHARACTER_LIMIT,
@@ -307,6 +309,10 @@ describe("apiRequest", () => {
     // Disable retries for the legacy apiRequest tests so a single mock value
     // produces a single fetch call, keeping assertions deterministic.
     process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    // Disable rate limiting so the legacy fast-path tests don't accidentally
+    // wait on a token bucket between iterations.
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
     initClient();
   });
 
@@ -314,6 +320,8 @@ describe("apiRequest", () => {
     vi.restoreAllMocks();
     delete process.env.BOOND_API_TOKEN;
     delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
   });
 
   it("should make a GET request and return JSON", async () => {
@@ -699,12 +707,18 @@ describe("apiRequest retries", () => {
     process.env.BOOND_API_TOKEN = "test-token";
     process.env.BOOND_HTTP_RETRY_BASE_MS = "1";
     process.env.BOOND_HTTP_RETRY_MAX_MS = "1";
+    // Rate limiting orthogonal to retry tests — keep it off so retry
+    // counts and timing stay predictable.
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
     initClient();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
     delete process.env.BOOND_HTTP_MAX_RETRIES;
     delete process.env.BOOND_HTTP_RETRY_BASE_MS;
     delete process.env.BOOND_HTTP_RETRY_MAX_MS;
@@ -819,5 +833,107 @@ describe("apiRequest retries", () => {
 
     await expect(apiRequest("/candidates")).rejects.toThrow("BoondManager API 503");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveRateLimitConfig", () => {
+  afterEach(() => {
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_BURST;
+  });
+
+  it("returns the documented defaults when nothing is set", () => {
+    expect(resolveRateLimitConfig()).toEqual({ rps: 10, burst: 20 });
+  });
+
+  it("disables rate limiting when RPS is 0", () => {
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    expect(resolveRateLimitConfig()).toBeNull();
+  });
+
+  it("disables rate limiting on a non-numeric RPS", () => {
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "many";
+    expect(resolveRateLimitConfig()).toBeNull();
+  });
+
+  it("honours an explicit burst override", () => {
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "5";
+    process.env.BOOND_HTTP_RATE_LIMIT_BURST = "30";
+    expect(resolveRateLimitConfig()).toEqual({ rps: 5, burst: 30 });
+  });
+
+  it("derives a sane burst when RPS is overridden but burst is not", () => {
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "5";
+    expect(resolveRateLimitConfig()).toEqual({ rps: 5, burst: 5 });
+  });
+});
+
+describe("apiRequest rate limiting", () => {
+  beforeEach(() => {
+    process.env.BOOND_API_TOKEN = "test-token";
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    resetRateLimiterForTests();
+    initClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_BURST;
+    resetRateLimiterForTests();
+  });
+
+  it("does not throttle when RPS=0", async () => {
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "10" }),
+      json: () => Promise.resolve({ data: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const t0 = Date.now();
+    await apiRequest("/candidates");
+    await apiRequest("/candidates");
+    await apiRequest("/candidates");
+    const elapsed = Date.now() - t0;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // No artificial throttle → should be near-instant.
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("throttles requests beyond the burst capacity", async () => {
+    // 1 token, refill 1000/sec → 1ms wait per request after the first.
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "1000";
+    process.env.BOOND_HTTP_RATE_LIMIT_BURST = "1";
+    resetRateLimiterForTests();
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "10" }),
+      json: () => Promise.resolve({ data: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Fire 5 requests in parallel; serialised acquires force them through one
+    // by one. Sustained refill is fast (1ms), so total wall-time is small but
+    // crucially > 0 — the bucket is acting.
+    const before = vi.mocked(fetchMock).mock.calls.length;
+    await Promise.all([
+      apiRequest("/candidates"),
+      apiRequest("/candidates"),
+      apiRequest("/candidates"),
+      apiRequest("/candidates"),
+      apiRequest("/candidates"),
+    ]);
+    const after = vi.mocked(fetchMock).mock.calls.length;
+
+    expect(after - before).toBe(5);
   });
 });

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -6,8 +6,11 @@ import {
   DEFAULT_HTTP_MAX_RETRIES,
   DEFAULT_HTTP_RETRY_BASE_MS,
   DEFAULT_HTTP_RETRY_MAX_MS,
+  DEFAULT_HTTP_RATE_LIMIT_RPS,
+  DEFAULT_HTTP_RATE_LIMIT_BURST,
 } from "../constants.js";
 import type { BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
+import { TokenBucket } from "./rate-limiter.js";
 
 let config: BoondConfig | null = null;
 
@@ -231,6 +234,51 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export interface RateLimitConfig {
+  rps: number;
+  burst: number;
+}
+
+/**
+ * Read rate-limit env vars. `rps` of 0 (or non-numeric) disables rate
+ * limiting entirely. `burst` falls back to `rps * 2` when unset, mirroring
+ * the documented default behaviour. Exported for unit testing.
+ */
+export function resolveRateLimitConfig(): RateLimitConfig | null {
+  const rpsRaw = envOrUndefined("BOOND_HTTP_RATE_LIMIT_RPS");
+  const rps = rpsRaw === undefined ? DEFAULT_HTTP_RATE_LIMIT_RPS : Number(rpsRaw);
+  if (!Number.isFinite(rps) || rps <= 0) return null;
+  const burstRaw = envOrUndefined("BOOND_HTTP_RATE_LIMIT_BURST");
+  let burst: number;
+  if (burstRaw === undefined) {
+    burst = rpsRaw === undefined ? DEFAULT_HTTP_RATE_LIMIT_BURST : Math.max(1, Math.ceil(rps));
+  } else {
+    const parsed = Number(burstRaw);
+    burst = Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : Math.max(1, Math.ceil(rps));
+  }
+  return { rps, burst };
+}
+
+let rateLimiter: TokenBucket | null = null;
+let rateLimiterInitialised = false;
+
+function getRateLimiter(): TokenBucket | null {
+  if (rateLimiterInitialised) return rateLimiter;
+  const config = resolveRateLimitConfig();
+  rateLimiter = config ? new TokenBucket(config.burst, config.rps) : null;
+  rateLimiterInitialised = true;
+  return rateLimiter;
+}
+
+/**
+ * Reset the cached rate limiter so the next request re-reads env vars.
+ * Intended for tests that toggle `BOOND_HTTP_RATE_LIMIT_*` between cases.
+ */
+export function resetRateLimiterForTests(): void {
+  rateLimiter = null;
+  rateLimiterInitialised = false;
+}
+
 /** Status-specific hint to help the LLM (or human) recover from common failures. */
 function hintForStatus(status: number): string {
   switch (status) {
@@ -320,7 +368,14 @@ export async function apiRequest(
 
   let lastError: Error | undefined;
 
+  const limiter = getRateLimiter();
+
   for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    // Acquire a token before each attempt so retries also count toward the
+    // rate budget — this is what actually protects us from feedback loops
+    // (transient 5xx → retry → transient 5xx → …) saturating the API.
+    if (limiter) await limiter.acquire();
+
     const fetchOptions: RequestInit = {
       method,
       headers,

--- a/src/services/rate-limiter.test.ts
+++ b/src/services/rate-limiter.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { TokenBucket, type Clock } from "./rate-limiter.js";
+
+/** Drain pending microtasks until the queue is quiet enough for assertions. */
+async function flushMicrotasks(rounds = 20) {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
+/**
+ * A test clock that lets us advance time deterministically. `sleep(ms)` does
+ * not actually sleep — it returns a promise that resolves only when the test
+ * advances the clock past the wakeup time.
+ */
+function createFakeClock(): Clock & {
+  advance(ms: number): Promise<void>;
+  current(): number;
+} {
+  let current = 0;
+  type Pending = { wakeAt: number; resolve: () => void };
+  const pending: Pending[] = [];
+
+  return {
+    now: () => current,
+    sleep(ms: number): Promise<void> {
+      if (ms <= 0) return Promise.resolve();
+      return new Promise((resolve) => {
+        pending.push({ wakeAt: current + ms, resolve });
+      });
+    },
+    current: () => current,
+    async advance(ms: number) {
+      current += ms;
+      // Wake any sleepers that should have fired by now, in chronological order.
+      // Process in a loop so cascading sleeps (sleep → consume → sleep again)
+      // also resolve before we return.
+      let progress = true;
+      while (progress) {
+        progress = false;
+        for (let i = 0; i < pending.length; i++) {
+          if (pending[i].wakeAt <= current) {
+            const { resolve } = pending.splice(i, 1)[0];
+            resolve();
+            // Yield to the microtask queue so the awaited continuation runs
+            // and any new sleep() it schedules is registered before we loop.
+            await Promise.resolve();
+            await Promise.resolve();
+            progress = true;
+            break;
+          }
+        }
+      }
+    },
+  };
+}
+
+describe("TokenBucket", () => {
+  it("rejects non-positive capacity / refill", () => {
+    expect(() => new TokenBucket(0, 1)).toThrow();
+    expect(() => new TokenBucket(1, 0)).toThrow();
+    expect(() => new TokenBucket(-1, 1)).toThrow();
+  });
+
+  it("starts full at capacity", () => {
+    const clock = createFakeClock();
+    const b = new TokenBucket(5, 1, clock);
+    expect(b.peek()).toBe(5);
+  });
+
+  it("allows a burst up to capacity without waiting", async () => {
+    const clock = createFakeClock();
+    const b = new TokenBucket(3, 1, clock);
+
+    await b.acquire();
+    await b.acquire();
+    await b.acquire();
+
+    expect(b.peek()).toBeLessThan(1);
+  });
+
+  it("blocks the next acquire until a token refills", async () => {
+    const clock = createFakeClock();
+    const b = new TokenBucket(1, 1, clock); // 1 token, refill 1/sec
+
+    await b.acquire(); // consumes the only token
+
+    let resolved = false;
+    const pending = b.acquire().then(() => {
+      resolved = true;
+    });
+
+    // Without time advance, the second acquire should be parked.
+    await flushMicrotasks();
+    expect(resolved).toBe(false);
+
+    // After 1 second of refill, the bucket has 1 token again.
+    await clock.advance(1000);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+
+  it("serialises concurrent acquires (no double-spend)", async () => {
+    const clock = createFakeClock();
+    const b = new TokenBucket(2, 1, clock); // 2 tokens, refill 1/sec
+
+    // Fire 4 acquires at once. The first 2 should resolve immediately, the
+    // remaining 2 should each wait roughly 1s for a token refill.
+    const order: number[] = [];
+    const promises = [0, 1, 2, 3].map((i) =>
+      b.acquire().then(() => order.push(i))
+    );
+
+    await flushMicrotasks();
+    expect(order).toEqual([0, 1]);
+
+    await clock.advance(1000);
+    await flushMicrotasks();
+    expect(order).toEqual([0, 1, 2]);
+
+    await clock.advance(1000);
+    await flushMicrotasks();
+    expect(order).toEqual([0, 1, 2, 3]);
+
+    await Promise.all(promises);
+  });
+
+  it("refills proportionally to elapsed time, capped at capacity", async () => {
+    const clock = createFakeClock();
+    const b = new TokenBucket(5, 2, clock); // 2 tokens/sec, capacity 5
+
+    // Drain the bucket completely.
+    for (let i = 0; i < 5; i++) await b.acquire();
+    expect(b.peek()).toBeLessThan(1);
+
+    // 1 second → ~2 tokens.
+    await clock.advance(1000);
+    expect(b.peek()).toBeCloseTo(2, 5);
+
+    // 10 more seconds would refill 20, but capacity caps at 5.
+    await clock.advance(10_000);
+    expect(b.peek()).toBe(5);
+  });
+});

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -1,0 +1,81 @@
+/**
+ * Token-bucket rate limiter for the BoondManager HTTP client.
+ *
+ * Why a token bucket rather than a fixed-window counter:
+ *   - Allows short bursts up to `capacity`, smoothing real-world spiky usage
+ *     (the LLM may issue several parallel search tool calls).
+ *   - Sustained throughput converges on `refillPerSec`, giving a predictable
+ *     ceiling regardless of burst.
+ *   - No hard reset boundary that all clients race toward at the same instant.
+ *
+ * Why serialise acquires through a promise chain:
+ *   - Concurrent `acquire()` callers from the same process must not race for
+ *     the same token. The chain forces consume() to run one at a time, so the
+ *     in-memory token count is always consistent.
+ */
+
+export interface Clock {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+}
+
+export const realClock: Clock = {
+  now: () => Date.now(),
+  sleep: (ms) =>
+    ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export class TokenBucket {
+  private tokens: number;
+  private lastRefill: number;
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(
+    public readonly capacity: number,
+    public readonly refillPerSec: number,
+    private readonly clock: Clock = realClock
+  ) {
+    if (!(capacity > 0)) throw new Error("TokenBucket: capacity must be > 0");
+    if (!(refillPerSec > 0)) throw new Error("TokenBucket: refillPerSec must be > 0");
+    this.tokens = capacity;
+    this.lastRefill = clock.now();
+  }
+
+  /** Wait until a token is available, then consume it. */
+  acquire(): Promise<void> {
+    const next = this.chain.then(() => this.consume());
+    // Swallow the rejection on the chain itself so a single failing consume
+    // (which shouldn't happen, but be defensive) does not poison every later
+    // acquire. Callers still see their own promise resolve/reject normally.
+    this.chain = next.catch(() => undefined);
+    return next;
+  }
+
+  /**
+   * Number of currently-available tokens (after refill). Visible for tests
+   * and observability; do not use for control flow.
+   */
+  peek(): number {
+    this.refill();
+    return this.tokens;
+  }
+
+  private async consume(): Promise<void> {
+    this.refill();
+    while (this.tokens < 1) {
+      const deficit = 1 - this.tokens;
+      const waitMs = Math.max(1, Math.ceil((deficit / this.refillPerSec) * 1000));
+      await this.clock.sleep(waitMs);
+      this.refill();
+    }
+    this.tokens -= 1;
+  }
+
+  private refill(): void {
+    const now = this.clock.now();
+    const elapsedSec = Math.max(0, (now - this.lastRefill) / 1000);
+    if (elapsedSec === 0) return;
+    this.tokens = Math.min(this.capacity, this.tokens + elapsedSec * this.refillPerSec);
+    this.lastRefill = now;
+  }
+}


### PR DESCRIPTION
Introduce a TokenBucket rate limiter and wire it into the Boond HTTP client. Adds src/services/rate-limiter.ts (implementation + real/fake clock support) and unit tests (rate-limiter.test.ts). Expose defaults in constants (DEFAULT_HTTP_RATE_LIMIT_RPS/BURST) and add resolveRateLimitConfig(), getRateLimiter(), and resetRateLimiterForTests() in boond-client; acquire a token before each attempt so retries also count. Update boond-client tests to cover config parsing and throttling behavior, and document new env vars (BOOND_HTTP_RATE_LIMIT_RPS / BOOND_HTTP_RATE_LIMIT_BURST) and defaults (10 rps, burst 20) in README.md and CLAUDE.md. Rate limiting can be disabled by setting RPS to 0 (or non-numeric RPS disables it).

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
