### PR TITLE
Add HTTP session TTL and idle-sweep support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,8 +286,10 @@ HTTP env vars (see `src/transports/http.ts::resolveHttpOptions`):
 | `MCP_HTTP_STATEFUL` | `false` | `true` to enable session mode (`Mcp-Session-Id`) |
 | `MCP_HTTP_BEARER_TOKEN` | — | Require `Authorization: Bearer <token>` on every request |
 | `MCP_HTTP_JSON_RESPONSE` | `false` | `true` to return JSON instead of SSE streams |
+| `MCP_HTTP_SESSION_TTL_MS` | `1800000` (30 min) | Stateful only: idle window before a session is closed |
+| `MCP_HTTP_SESSION_SWEEP_INTERVAL_MS` | `300000` (5 min) | Stateful only: how often to scan for idle sessions |
 
-Stateless mode spins up a fresh `McpServer`+`StreamableHTTPServerTransport` per POST. Stateful mode keeps a `sessionId → transport` map and expects the client to echo `Mcp-Session-Id`.
+Stateless mode spins up a fresh `McpServer`+`StreamableHTTPServerTransport` per POST. Stateful mode keeps a `sessionId → { transport, server, lastActivityAt }` map; a periodic sweep closes idle sessions (transport + McpServer) so a buggy client that disconnects without `onsessionclosed` cannot leak resources. The sweep timer is `unref()`'d so it never blocks shutdown. The handle exposes `sessionCount()` and `sweepIdleSessions()` for observability/tests.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ npx boondmanager-mcp-server
 | `MCP_HTTP_STATEFUL` | `false` | `true` pour activer le mode stateful (session `Mcp-Session-Id`) |
 | `MCP_HTTP_BEARER_TOKEN` | _(vide)_ | Si defini, le serveur exige `Authorization: Bearer <token>` |
 | `MCP_HTTP_JSON_RESPONSE` | `false` | `true` pour forcer des reponses JSON (sans SSE) |
+| `MCP_HTTP_SESSION_TTL_MS` | `1800000` (30 min) | En mode stateful, duree d'inactivite au-dela de laquelle une session est fermee. |
+| `MCP_HTTP_SESSION_SWEEP_INTERVAL_MS` | `300000` (5 min) | Frequence de balayage des sessions inactives. |
 
 **Stateless (defaut)** : chaque requete HTTP POST est independante, idealement adapte a un gateway qui multiplexe plusieurs serveurs MCP. Aucune session n'est conservee cote serveur.
 

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -9,6 +9,8 @@ const ENV_KEYS = [
   "MCP_HTTP_STATEFUL",
   "MCP_HTTP_BEARER_TOKEN",
   "MCP_HTTP_JSON_RESPONSE",
+  "MCP_HTTP_SESSION_TTL_MS",
+  "MCP_HTTP_SESSION_SWEEP_INTERVAL_MS",
 ];
 
 function clearEnv(): void {
@@ -27,6 +29,24 @@ describe("resolveHttpOptions", () => {
     expect(opts.stateless).toBe(true);
     expect(opts.enableJsonResponse).toBe(false);
     expect(opts.bearerToken).toBeUndefined();
+    expect(opts.sessionTtlMs).toBe(30 * 60_000);
+    expect(opts.sessionSweepIntervalMs).toBe(5 * 60_000);
+  });
+
+  it("reads session lifecycle knobs from env", () => {
+    process.env["MCP_HTTP_SESSION_TTL_MS"] = "60000";
+    process.env["MCP_HTTP_SESSION_SWEEP_INTERVAL_MS"] = "10000";
+    const opts = resolveHttpOptions();
+    expect(opts.sessionTtlMs).toBe(60_000);
+    expect(opts.sessionSweepIntervalMs).toBe(10_000);
+  });
+
+  it("falls back to defaults on bad session lifecycle values", () => {
+    process.env["MCP_HTTP_SESSION_TTL_MS"] = "0";
+    process.env["MCP_HTTP_SESSION_SWEEP_INTERVAL_MS"] = "lots";
+    const opts = resolveHttpOptions();
+    expect(opts.sessionTtlMs).toBe(30 * 60_000);
+    expect(opts.sessionSweepIntervalMs).toBe(5 * 60_000);
   });
 
   it("reads configuration from environment variables", () => {
@@ -105,6 +125,51 @@ describe("startHttpTransport (integration)", () => {
     });
     expect(res.status).toBe(401);
     expect(res.headers.get("www-authenticate")).toBe("Bearer");
+  });
+
+  it("reaps idle stateful sessions on sweep", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34571,
+      path: "/mcp",
+      stateless: false,
+      enableJsonResponse: true,
+      sessionTtlMs: 50,
+      // Big sweep interval so the periodic timer never fires during this
+      // test — we drive the sweep explicitly via the handle.
+      sessionSweepIntervalMs: 60_000,
+    });
+
+    const initRes = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "vitest", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(initRes.status).toBe(200);
+    await initRes.text();
+
+    expect(handle.sessionCount()).toBe(1);
+
+    // A fresh session should not be reaped — last activity is now-ish.
+    expect(await handle.sweepIdleSessions()).toBe(0);
+    expect(handle.sessionCount()).toBe(1);
+
+    // Wait past the TTL, then a sweep should reap the idle session.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(await handle.sweepIdleSessions()).toBe(1);
+    expect(handle.sessionCount()).toBe(0);
   });
 
   it("responds to an MCP initialize request in stateless mode", async () => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -11,17 +11,38 @@ export interface HttpTransportOptions {
   stateless: boolean;
   bearerToken?: string;
   enableJsonResponse: boolean;
+  /** Idle timeout for stateful sessions, in ms. Defaults to 30 min. */
+  sessionTtlMs?: number;
+  /** How often to sweep idle sessions, in ms. Defaults to 5 min. */
+  sessionSweepIntervalMs?: number;
 }
 
 export interface HttpServerHandle {
   close: () => Promise<void>;
   address: { host: string; port: number; path: string };
+  /** Current count of live stateful sessions (always 0 in stateless mode). */
+  sessionCount: () => number;
+  /** Manually trigger an idle sweep; returns the number of sessions reaped. */
+  sweepIdleSessions: () => Promise<number>;
 }
+
+// Defaults: a half-hour idle window matches typical MCP gateway behaviour, and
+// a 5-minute sweep keeps memory bounded without hammering the event loop.
+const DEFAULT_SESSION_TTL_MS = 30 * 60_000;
+const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60_000;
 
 function readEnv(key: string): string | undefined {
   const v = process.env[key];
   if (!v || v.startsWith("${")) return undefined;
   return v;
+}
+
+function readPositiveInt(key: string, fallback: number): number {
+  const raw = readEnv(key);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
 }
 
 export function resolveHttpOptions(): HttpTransportOptions {
@@ -41,6 +62,11 @@ export function resolveHttpOptions(): HttpTransportOptions {
     stateless,
     bearerToken: readEnv("MCP_HTTP_BEARER_TOKEN"),
     enableJsonResponse,
+    sessionTtlMs: readPositiveInt("MCP_HTTP_SESSION_TTL_MS", DEFAULT_SESSION_TTL_MS),
+    sessionSweepIntervalMs: readPositiveInt(
+      "MCP_HTTP_SESSION_SWEEP_INTERVAL_MS",
+      DEFAULT_SESSION_SWEEP_INTERVAL_MS
+    ),
   };
 }
 
@@ -70,11 +96,53 @@ function writeJsonRpcError(res: ServerResponse, status: number, message: string)
   );
 }
 
+interface SessionEntry {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  lastActivityAt: number;
+}
+
+async function destroySession(entry: SessionEntry): Promise<void> {
+  // Close transport and server independently so a failure in one still lets
+  // the other release its resources. We swallow errors because the caller
+  // already lost interest in this session.
+  await Promise.allSettled([
+    Promise.resolve().then(() => entry.transport.close()),
+    Promise.resolve().then(() => entry.server.close()),
+  ]);
+}
+
 export async function startHttpTransport(
   createServerFactory: () => McpServer,
   options: HttpTransportOptions
 ): Promise<HttpServerHandle> {
-  const sessions = new Map<string, StreamableHTTPServerTransport>();
+  const sessions = new Map<string, SessionEntry>();
+  const sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+  const sessionSweepIntervalMs =
+    options.sessionSweepIntervalMs ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
+
+  const sweepIdleSessions = async (): Promise<number> => {
+    const cutoff = Date.now() - sessionTtlMs;
+    const expired: Array<[string, SessionEntry]> = [];
+    for (const [id, entry] of sessions) {
+      if (entry.lastActivityAt < cutoff) {
+        expired.push([id, entry]);
+      }
+    }
+    for (const [id] of expired) sessions.delete(id);
+    await Promise.all(expired.map(([, entry]) => destroySession(entry)));
+    return expired.length;
+  };
+
+  // Periodic sweep — only meaningful in stateful mode. `unref()` lets the
+  // process exit naturally even when the timer is pending.
+  let sweepTimer: NodeJS.Timeout | undefined;
+  if (!options.stateless) {
+    sweepTimer = setInterval(() => {
+      void sweepIdleSessions();
+    }, sessionSweepIntervalMs);
+    sweepTimer.unref?.();
+  }
 
   const httpServer = createServer(async (req, res) => {
     try {
@@ -120,7 +188,9 @@ export async function startHttpTransport(
       const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
 
       if (sessionId && sessions.has(sessionId)) {
-        await sessions.get(sessionId)!.handleRequest(req, res);
+        const entry = sessions.get(sessionId)!;
+        entry.lastActivityAt = Date.now();
+        await entry.transport.handleRequest(req, res);
         return;
       }
 
@@ -140,14 +210,26 @@ export async function startHttpTransport(
         sessionIdGenerator: () => randomUUID(),
         enableJsonResponse: options.enableJsonResponse,
         onsessioninitialized: (id) => {
-          sessions.set(id, transport);
+          sessions.set(id, { transport, server, lastActivityAt: Date.now() });
         },
         onsessionclosed: (id) => {
-          sessions.delete(id);
+          const entry = sessions.get(id);
+          if (entry) {
+            sessions.delete(id);
+            void destroySession(entry);
+          }
         },
       });
       transport.onclose = () => {
-        if (transport.sessionId) sessions.delete(transport.sessionId);
+        const id = transport.sessionId;
+        if (!id) return;
+        const entry = sessions.get(id);
+        if (entry) {
+          sessions.delete(id);
+          // Server is closed by destroySession — but if the transport's own
+          // close path already disposed it, the second call is a no-op.
+          void entry.server.close().catch(() => undefined);
+        }
       };
 
       const server = createServerFactory();
@@ -173,9 +255,13 @@ export async function startHttpTransport(
 
   return {
     address: { host: options.host, port: options.port, path: options.path },
+    sessionCount: () => sessions.size,
+    sweepIdleSessions,
     close: async () => {
-      await Promise.all(Array.from(sessions.values()).map((t) => t.close()));
+      if (sweepTimer) clearInterval(sweepTimer);
+      const entries = Array.from(sessions.values());
       sessions.clear();
+      await Promise.all(entries.map((e) => destroySession(e)));
       await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => (err ? reject(err) : resolve()));
       });


### PR DESCRIPTION
Introduce configurable session lifecycle for the HTTP transport to avoid leaking resources from disconnected/buggy clients. Added two env knobs (MCP_HTTP_SESSION_TTL_MS, MCP_HTTP_SESSION_SWEEP_INTERVAL_MS) with sane defaults (30min TTL, 5min sweep), parsing with fallbacks in resolveHttpOptions. Stateful sessions now store {transport, server, lastActivityAt}; new APIs on the server handle expose sessionCount() and sweepIdleSessions(), and a periodic sweep (unref()'d) reaps idle sessions by closing transports and servers. Added destroySession helper and updated session bookkeeping on initialize/close/requests. Tests were added/updated to cover env parsing and reaping behavior, and documentation (CLAUDE.md, README.md) updated to document the new env vars.

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
