### PR TITLE
Use package.json for SERVER_VERSION

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { createMcpServer, REGISTERED_DOMAINS, SERVER_NAME } from "./server.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createMcpServer, REGISTERED_DOMAINS, SERVER_NAME, SERVER_VERSION } from "./server.js";
 
 describe("createMcpServer", () => {
   it("returns an McpServer instance with the expected name", () => {
@@ -19,5 +22,19 @@ describe("createMcpServer", () => {
   it("can be instantiated multiple times without throwing", () => {
     expect(() => createMcpServer()).not.toThrow();
     expect(() => createMcpServer()).not.toThrow();
+  });
+});
+
+describe("SERVER_VERSION", () => {
+  it("matches the package.json version", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = resolve(here, "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+    expect(SERVER_VERSION).toBe(pkg.version);
+  });
+
+  it("is not the legacy hardcoded placeholder", () => {
+    expect(SERVER_VERSION).not.toBe("1.0.0");
+    expect(SERVER_VERSION).not.toBe("0.0.0-unknown");
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   registerCandidateTools,
@@ -41,7 +44,30 @@ import { registerAllPrompts } from "./prompts/index.js";
 import { registerAllResources } from "./resources/index.js";
 
 export const SERVER_NAME = "boondmanager-mcp-server";
-export const SERVER_VERSION = "1.0.0";
+
+/**
+ * Read the package version from `package.json` so the value advertised over
+ * MCP `initialize` always matches the published artefact. CI already enforces
+ * version parity between `package.json`, `manifest.json`, and `server.json`,
+ * so resolving from `package.json` is sufficient.
+ *
+ * The compiled file lives at `dist/server.js`, mirroring `src/server.ts`,
+ * so `../package.json` is correct in both layouts.
+ */
+function readPackageVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = resolve(here, "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: unknown };
+    if (typeof pkg.version === "string" && pkg.version.length > 0) return pkg.version;
+  } catch {
+    // Fall through to the placeholder — surface a recognisable value rather
+    // than crashing the server on a missing package.json.
+  }
+  return "0.0.0-unknown";
+}
+
+export const SERVER_VERSION = readPackageVersion();
 
 export const REGISTERED_DOMAINS = [
   "candidates", "resources", "contacts", "companies", "opportunities", "actions",


### PR DESCRIPTION
Read package.json at runtime to set SERVER_VERSION instead of a hardcoded string. server.ts now loads the package version (with a safe fallback of "0.0.0-unknown" on error) and adds node:fs/node:url/node:path imports; server.test.ts gains tests to assert SERVER_VERSION matches package.json and is not the legacy placeholder. This ensures the advertised MCP server version stays in sync with the published package and avoids crashing when package.json is missing.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [x] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
