### PR TITLE
Add MAX_SEARCH_PAGE and cap search pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,14 @@ state/typeOf integers to labels via a resource read instead of a tool
 call. Arbitrary dictionary types still go through the
 `boond_application_dictionary` tool.
 
+## Search Pagination Limits
+
+All search tools enforce a **maximum page number of 100** (configurable via `MAX_SEARCH_PAGE` in `src/constants.ts`). At 500 results/page, page 100 = 50,000 records — well beyond typical interactive exploration.
+
+**Rationale:** MCP search tools are flagged `openWorldHint: true`, meaning the model can iterate indefinitely. Without a ceiling, a vague query can spiral into hundreds of pages before the model realizes the result set is too broad. The cap forces refinement (add filters, narrow perimeter) rather than brute-force pagination.
+
+**Enforcement:** Zod schemas reject `page > MAX_SEARCH_PAGE` at input validation (before the API call). The model sees a clear schema error mentioning the limit, not a silent clamp or a cryptic API 400.
+
 ## Tool Naming Convention
 
 All tool names follow: `boond_{domain}_{operation}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,11 @@ export const CHARACTER_LIMIT = 50000;
 export const DEFAULT_PAGE_SIZE = 30;
 export const MAX_PAGE_SIZE = 500;
 
+// Cap the page number on search tools (openWorldHint) to prevent runaway
+// iterations. At 500 results/page, page 100 = 50k records — well beyond
+// typical interactive exploration. The model can refine filters instead.
+export const MAX_SEARCH_PAGE = 100;
+
 // HTTP client defaults
 // Timeout applied to every BoondManager API request. Overridable via
 // BOOND_HTTP_TIMEOUT_MS to handle slow tenants or long reporting queries.

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "../constants.js";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
 
 // Common search schema
 export const SearchSchema = z.object({
   keywords: z.string().optional().describe("Mots-clés de recherche (nom, email, compétences...)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page (défaut: 1)"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
     .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
 }).strict();
@@ -13,7 +13,7 @@ export const SearchSchema = z.object({
 // IMPORTANT: input field names below MUST match the BoondManager API query parameter names
 // exactly (e.g., perimeterManagers, resourceStates, opportunityStates). buildSearchQuery
 // passes them through as `key[]=value` for arrays. See https://doc.boondmanager.com/api-externe/
-const pageField = z.number().int().min(1).default(1).describe("Numéro de page (défaut: 1)");
+const pageField = z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`);
 const pageSizeField = z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
   .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`);
 const sortField = z.string().optional().describe("Champ de tri (ex: lastName, firstName, updateDate)");
@@ -476,7 +476,7 @@ export const ActionSearchSchema = z.object({
   resourceId: z.string().optional().describe("Filtrer par ID ressource"),
   contactId: z.string().optional().describe("Filtrer par ID contact"),
   companyId: z.string().optional().describe("Filtrer par ID société"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -503,7 +503,7 @@ export const ResourceTimesheetSchema = z.object({
 export const TimesheetSearchSchema = z.object({
   startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page (défaut: 1)"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
     .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
 }).strict();
@@ -566,7 +566,7 @@ export const InvoiceSearchSchema = z.object({
   startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
   period: z.string().optional().describe("Type de période (created, updated, expectedPayment, performedPayment, period)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -595,7 +595,7 @@ export const OrderSearchSchema = z.object({
   keywords: z.string().optional().describe("Mots-clés de recherche"),
   companyId: z.string().optional().describe("Filtrer par ID société"),
   projectId: z.string().optional().describe("Filtrer par ID projet"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -607,7 +607,7 @@ export const DeliverySearchSchema = z.object({
   companyId: z.string().optional().describe("Filtrer par ID société"),
   startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -635,7 +635,7 @@ export const AbsenceSearchSchema = z.object({
   resourceId: z.string().optional().describe("Filtrer par ID ressource"),
   startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -665,7 +665,7 @@ export const ExpenseSearchSchema = z.object({
   projectId: z.string().optional().describe("Filtrer par ID projet"),
   startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -709,7 +709,7 @@ export const PositioningSearchSchema = z.object({
   resourceId: z.string().optional().describe("Filtrer par ID ressource"),
   projectId: z.string().optional().describe("Filtrer par ID projet"),
   opportunityId: z.string().optional().describe("Filtrer par ID opportunité"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -721,7 +721,7 @@ export const PaymentSearchSchema = z.object({
   companyId: z.string().optional().describe("Filtrer par ID société"),
   startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
   endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 
@@ -730,7 +730,7 @@ export const PaymentSearchSchema = z.object({
 export const AdvantageSearchSchema = z.object({
   keywords: z.string().optional().describe("Mots-clés de recherche"),
   resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 

--- a/src/tools/provider-invoices.ts
+++ b/src/tools/provider-invoices.ts
@@ -2,12 +2,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 import { z } from "zod";
-import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "../constants.js";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
 
 const ProviderInvoiceSearchSchema = z.object({
   keywords: z.string().optional().describe("Mots-clés de recherche"),
   companyId: z.string().optional().describe("Filtrer par ID société fournisseur"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 

--- a/src/tools/purchases.ts
+++ b/src/tools/purchases.ts
@@ -3,13 +3,13 @@ import { IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 import { buildJsonApiBody } from "./crud-factory.js";
 import { z } from "zod";
-import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "../constants.js";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
 
 const PurchaseSearchSchema = z.object({
   keywords: z.string().optional().describe("Mots-clés de recherche"),
   companyId: z.string().optional().describe("Filtrer par ID société"),
   projectId: z.string().optional().describe("Filtrer par ID projet"),
-  page: z.number().int().min(1).default(1).describe("Numéro de page"),
+  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
   pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
 }).strict();
 


### PR DESCRIPTION
Introduce MAX_SEARCH_PAGE (100) in src/constants.ts and enforce it across search inputs to prevent runaway pagination. Updated src/schemas/index.ts to add .max(MAX_SEARCH_PAGE) and descriptive messages on page fields for multiple search schemas, and updated src/tools/provider-invoices.ts and src/tools/purchases.ts to use the new constant. Also documented the new limit, rationale and enforcement behavior in CLAUDE.md. Validation now rejects page > MAX_SEARCH_PAGE via Zod before API calls so callers receive a clear schema error.

## Description

<!-- Breve description des changements -->

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`)
- [x] J'ai mis a jour la documentation si necessaire
