### PR TITLE
Add staffing & skills prompts and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Pour les dictionnaires hors de cette liste curee, l'outil `boond_application_dic
 
 ## Prompts pre-orchestres
 
-En plus des outils, le serveur expose des **prompts MCP** (templates pre-cables) qui orchestrent les bons appels d'outils dans le bon ordre pour les workflows recurrents. Visibles dans les clients qui supportent les prompts (slash command ou menu).
+En plus des outils, le serveur expose des **prompts MCP** (templates pre-cables) qui orchestrent les bons appels d'outils dans le bon ordre pour les workflows recurrents. Visibles dans les clients qui supportent les prompts (Claude Desktop, **Cowork**, Claude Code, MCP Inspector...) sous forme de slash-commands ou de menu.
+
+### Workflows transverses
 
 | Prompt | Usage |
 |--------|-------|
@@ -130,6 +132,62 @@ En plus des outils, le serveur expose des **prompts MCP** (templates pre-cables)
 | `candidats_pour_opportunite` | A partir d'une opportunite, propose les candidats actifs qui matchent (outils, expertise, mobilite, dispo). |
 | `fiche_consultant` | Vue 360 d'une ressource : info + technique + positionnements + absences + CRA recents. |
 | `recap_hebdo` | Recap hebdomadaire : pipeline qui a bouge, equipe absente, projets actifs, actions a mener. |
+
+### Ressources, competences & CV
+
+| Prompt | Usage |
+|--------|-------|
+| `staffing_disponible` | Consultants internes disponibles sur une fenetre donnee (filtre optionnel par competences libres et perimetre), tries par dispo croissante avec top 3 prioritaires. |
+| `fin_de_mission` | Anticipation des fins de mission sous N jours (defaut 60). Marque en **urgent** les fins <= 15j sans relais identifie. |
+| `cartographie_competences` | Cartographie des competences d'un perimetre (equipe / agence) : top N, competences rares (bus-factor), saturees, manquantes vs opportunites ouvertes. |
+| `cvs_a_mettre_a_jour` | Audit fraicheur des CV / dossiers techniques (seuil d'obsolescence configurable). Priorise les ressources bientot sur le marche. |
+| `recherche_profil_competences` | Recherche multi-source (ressources internes + candidats) par mix de competences libres, sans opportunite requise. Classe par adequation /10. |
+
+### Comment invoquer un prompt
+
+Les prompts MCP sont des **modeles de message utilisateur** : tu les invoques toi-meme, le LLM execute ensuite le runbook qu'ils contiennent. Aucun filtre BoondManager a connaitre — tout est embarque cote serveur.
+
+**Claude Desktop / Cowork / MCP Inspector** : tape `/` dans la barre de saisie, choisis le prompt dans la liste, remplis les arguments dans le formulaire qui s'affiche, valide.
+
+**Claude Code** : pareil, `/` puis selection ; les arguments sont demandes inline.
+
+**Fallback (clients sans UI dediee aux prompts)** : cite le prompt par son nom dans une demande libre, le client va recuperer la definition via le protocole MCP. Exemple : *"lance le runbook `staffing_disponible` entre le 1er juin et le 1er septembre 2026, competences Java Spring AWS"*.
+
+Exemples d'invocation des prompts ressources / competences / CV :
+
+```
+/staffing_disponible
+  start_date  = 2026-06-01
+  end_date    = 2026-09-01
+  competences = Java Spring AWS Kubernetes
+  manager_id  = (vide -> mon equipe)
+```
+
+```
+/fin_de_mission
+  horizon_jours = 30
+```
+
+```
+/cartographie_competences
+  agency_id = 7
+  top_n     = 15
+```
+
+```
+/cvs_a_mettre_a_jour
+  seuil_mois = 6
+```
+
+```
+/recherche_profil_competences
+  competences        = .NET Azure DevOps
+  experience_min     = 5 ans
+  dispo_avant        = 2026-07-15
+  inclure_candidats  = oui
+```
+
+> Apres modification de la config Claude (`claude_desktop_config.json` etc.), **redemarrer le client** : la liste des prompts MCP n'est pas hot-reloadee.
 
 ## Prerequis
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**156 tools** across **36 domains** · **6 prompts** · **20 resources**.
+**156 tools** across **36 domains** · **11 prompts** · **20 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -345,17 +345,22 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_webhooks_get` | Détails d'un webhook | read · idempotent |
 | `boond_webhooks_search` | Rechercher des webhooks | read · idempotent · open-world |
 
-## Prompts (6)
+## Prompts (11)
 
 Pre-orchestrated workflows surfaced via the MCP prompts API.
 
 | Prompt | Title | Args |
 |---|---|---|
 | `candidats_pour_opportunite` | Candidats correspondant à une opportunité | `opportunity_id` |
+| `cartographie_competences` | Cartographie des compétences d'un périmètre | `manager_id?` `agency_id?` `top_n?` |
+| `cvs_a_mettre_a_jour` | Audit fraîcheur des CV / dossiers techniques | `seuil_mois?` `manager_id?` |
 | `factures_a_relancer` | Factures impayées à relancer | `society_id?` |
 | `fiche_consultant` | Fiche complète d'un collaborateur | `resource_id` |
+| `fin_de_mission` | Anticipation des fins de mission | `horizon_jours?` `manager_id?` |
 | `pipeline_commercial` | Pipeline commercial sur une période | `date_debut` `date_fin` `manager_id?` |
 | `recap_hebdo` | Récap hebdomadaire (moi + mon équipe) | `semaine?` |
+| `recherche_profil_competences` | Recherche multi-source d'un profil par compétences | `competences` `experience_min?` `dispo_avant?` `inclure_candidats?` `manager_id?` |
+| `staffing_disponible` | Consultants disponibles pour un staffing | `start_date` `end_date` `competences?` `manager_id?` |
 | `synthese_equipe` | Synthèse d'une équipe | `manager_id?` `periode?` |
 
 ## Resources (20)

--- a/src/prompts/index.test.ts
+++ b/src/prompts/index.test.ts
@@ -8,7 +8,9 @@ function createMockServer() {
 
 describe("registerAllPrompts", () => {
   let server: McpServer;
-  beforeEach(() => { server = createMockServer(); });
+  beforeEach(() => {
+    server = createMockServer();
+  });
 
   it("registers exactly the prompts declared in REGISTERED_PROMPTS", () => {
     registerAllPrompts(server);
@@ -23,14 +25,21 @@ describe("registerAllPrompts", () => {
   it("registers the expected workflow prompts", () => {
     registerAllPrompts(server);
     const names = vi.mocked(server.registerPrompt).mock.calls.map((c) => c[0]);
-    expect(names).toEqual(expect.arrayContaining([
-      "synthese_equipe",
-      "pipeline_commercial",
-      "factures_a_relancer",
-      "candidats_pour_opportunite",
-      "fiche_consultant",
-      "recap_hebdo",
-    ]));
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "synthese_equipe",
+        "pipeline_commercial",
+        "factures_a_relancer",
+        "candidats_pour_opportunite",
+        "fiche_consultant",
+        "recap_hebdo",
+        "staffing_disponible",
+        "fin_de_mission",
+        "cartographie_competences",
+        "cvs_a_mettre_a_jour",
+        "recherche_profil_competences",
+      ])
+    );
   });
 
   it("every registered prompt declares both a title and a description", () => {
@@ -98,5 +107,119 @@ describe("registerAllPrompts", () => {
     expect(text).toContain("boond_candidates_search");
     expect(text).toContain("expertiseAreas");
     expect(text).toContain("mobilityAreas");
+  });
+
+  it("staffing_disponible uses period=available + dates and references resources_search", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "staffing_disponible");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({ start_date: "2026-05-01", end_date: "2026-08-01" });
+    const text = result.messages[0].content.text;
+    expect(text).toContain("boond_resources_search");
+    expect(text).toContain('period: "available"');
+    expect(text).toContain("2026-05-01");
+    expect(text).toContain("2026-08-01");
+    expect(text).toContain("perimeterDynamic");
+  });
+
+  it("staffing_disponible adds the tools mapping step when competences are provided", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "staffing_disponible");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const without = await cb({ start_date: "2026-05-01", end_date: "2026-08-01" });
+    expect(without.messages[0].content.text).not.toContain("Mapper les compétences");
+    const withSkills = await cb({ start_date: "2026-05-01", end_date: "2026-08-01", competences: "Java Spring" });
+    const text = withSkills.messages[0].content.text;
+    expect(text).toContain("Mapper les compétences");
+    expect(text).toContain("Java Spring");
+    expect(text).toContain("setting.tool");
+    expect(text).toContain("tools: [...]");
+  });
+
+  it("staffing_disponible scopes to perimeterManagers when manager_id is provided", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "staffing_disponible");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({ start_date: "2026-05-01", end_date: "2026-08-01", manager_id: "18081" });
+    expect(result.messages[0].content.text).toContain("perimeterManagers: [18081]");
+  });
+
+  it("fin_de_mission injects the horizon and references resources_search + positionings", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "fin_de_mission");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const defaultResult = await cb({});
+    expect(defaultResult.messages[0].content.text).toContain("60 prochains jours");
+    const result = await cb({ horizon_jours: "30" });
+    const text = result.messages[0].content.text;
+    expect(text).toContain("30 prochains jours");
+    expect(text).toContain("boond_resources_search");
+    expect(text).toContain("boond_resources_positionings");
+    expect(text).toContain('period: "available"');
+  });
+
+  it("cartographie_competences scopes to perimeterAgencies when agency_id is given, else defaults to managers", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "cartographie_competences");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const def = await cb({});
+    expect(def.messages[0].content.text).toContain("perimeterDynamic");
+    expect(def.messages[0].content.text).toContain("Top 20");
+    const withAgency = await cb({ agency_id: "7", top_n: "10" });
+    const text = withAgency.messages[0].content.text;
+    expect(text).toContain("perimeterAgencies: [7]");
+    expect(text).toContain("Top 10");
+    expect(text).toContain("boond_resources_technical_data");
+    expect(text).toContain("setting.tool");
+    expect(text).toContain("boond_opportunities_search");
+  });
+
+  it("cvs_a_mettre_a_jour applies the seuil_mois threshold and references technical_data", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "cvs_a_mettre_a_jour");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const def = await cb({});
+    expect(def.messages[0].content.text).toContain("12 mois");
+    const result = await cb({ seuil_mois: "6", manager_id: "18081" });
+    const text = result.messages[0].content.text;
+    expect(text).toContain("6 mois");
+    expect(text).toContain("perimeterManagers: [18081]");
+    expect(text).toContain("boond_resources_technical_data");
+    expect(text).toContain('period: "available"');
+  });
+
+  it("recherche_profil_competences includes candidates by default and skips them on opt-out", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "recherche_profil_competences");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const def = await cb({ competences: "Java Spring AWS" });
+    const defText = def.messages[0].content.text;
+    expect(defText).toContain("Java Spring AWS");
+    expect(defText).toContain("boond_resources_search");
+    expect(defText).toContain("boond_candidates_search");
+    expect(defText).toContain("setting.tool");
+    expect(defText).toContain("setting.expertiseArea");
+    const internalOnly = await cb({ competences: ".NET Azure", inclure_candidats: "non" });
+    const internalText = internalOnly.messages[0].content.text;
+    expect(internalText).not.toContain("boond_candidates_search");
+    expect(internalText).toContain("Skip");
+  });
+
+  it("recherche_profil_competences applies dispo_avant via period=available + endDate", async () => {
+    registerAllPrompts(server);
+    const call = vi.mocked(server.registerPrompt).mock.calls.find((c) => c[0] === "recherche_profil_competences");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![2] as any;
+    const result = await cb({ competences: "Python", dispo_avant: "2026-06-30" });
+    const text = result.messages[0].content.text;
+    expect(text).toContain('period: "available"');
+    expect(text).toContain("2026-06-30");
   });
 });

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -18,9 +18,7 @@ import { z } from "zod";
  */
 
 const userMessage = (text: string) => ({
-  messages: [
-    { role: "user" as const, content: { type: "text" as const, text } },
-  ],
+  messages: [{ role: "user" as const, content: { type: "text" as const, text } }],
 });
 
 interface PromptDefinition {
@@ -36,15 +34,19 @@ const PROMPTS: PromptDefinition[] = [
     name: "synthese_equipe",
     title: "Synthèse d'une équipe",
     description:
-      "Produit un état d'équipe : qui est sur quoi, qui est absent, qui est disponible. "
-      + "Si manager_id est omis, utilise l'utilisateur courant comme manager.",
+      "Produit un état d'équipe : qui est sur quoi, qui est absent, qui est disponible. " +
+      "Si manager_id est omis, utilise l'utilisateur courant comme manager.",
     argsSchema: {
-      manager_id: z.string().optional().describe(
-        "ID du manager (ressource Boond). Si absent, l'outil `boond_application_current_user` doit être appelé pour le récupérer."
-      ),
-      periode: z.string().optional().describe(
-        "Période d'analyse libre (ex: 'cette semaine', 'avril 2026'). Défaut: mois en cours."
-      ),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID du manager (ressource Boond). Si absent, l'outil `boond_application_current_user` doit être appelé pour le récupérer."
+        ),
+      periode: z
+        .string()
+        .optional()
+        .describe("Période d'analyse libre (ex: 'cette semaine', 'avril 2026'). Défaut: mois en cours."),
     },
     build: ({ manager_id, periode }) => {
       const periodeText = periode || "le mois en cours";
@@ -72,14 +74,17 @@ const PROMPTS: PromptDefinition[] = [
     name: "pipeline_commercial",
     title: "Pipeline commercial sur une période",
     description:
-      "Analyse les opportunités commerciales avec closing prévu dans la période donnée : "
-      + "répartition par état, CA pondéré, top opportunités.",
+      "Analyse les opportunités commerciales avec closing prévu dans la période donnée : " +
+      "répartition par état, CA pondéré, top opportunités.",
     argsSchema: {
       date_debut: z.string().describe("Début de période (YYYY-MM-DD)."),
       date_fin: z.string().describe("Fin de période (YYYY-MM-DD)."),
-      manager_id: z.string().optional().describe(
-        "ID du commercial. Si absent, scope = équipe de l'utilisateur courant via `perimeterDynamic: ['data']`."
-      ),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID du commercial. Si absent, scope = équipe de l'utilisateur courant via `perimeterDynamic: ['data']`."
+        ),
     },
     build: ({ date_debut, date_fin, manager_id }) => {
       const scopeFilter = manager_id
@@ -111,8 +116,8 @@ const PROMPTS: PromptDefinition[] = [
     name: "factures_a_relancer",
     title: "Factures impayées à relancer",
     description:
-      "Liste les factures impayées avec date d'échéance dépassée, regroupées par société. "
-      + "Optionnellement filtrable sur une société spécifique.",
+      "Liste les factures impayées avec date d'échéance dépassée, regroupées par société. " +
+      "Optionnellement filtrable sur une société spécifique.",
     argsSchema: {
       society_id: z.string().optional().describe("ID d'une société pour cibler la relance."),
     },
@@ -122,7 +127,9 @@ const PROMPTS: PromptDefinition[] = [
         "",
         "Étapes :",
         "1. Appeler `boond_invoices_search` :",
-        society_id ? `   - \`companyId: "${society_id}"\`` : "   - sans filtre société (toutes les factures du périmètre courant)",
+        society_id
+          ? `   - \`companyId: "${society_id}"\``
+          : "   - sans filtre société (toutes les factures du périmètre courant)",
         "   - `pageSize: 100`",
         "2. Récupérer le dictionnaire `setting.state.invoice` via `boond_application_dictionary` pour identifier les états « payée » / « partiellement payée » / etc.",
         "3. Filtrer côté agent : ne conserver que les factures dont l'état n'est PAS « payée » ET dont la `dueDate` est strictement antérieure à aujourd'hui.",
@@ -149,11 +156,11 @@ const PROMPTS: PromptDefinition[] = [
         `1. Récupérer le détail de l'opportunité : \`boond_opportunities_get(id="${opportunity_id}")\` puis l'onglet \`information\` pour les attributs détaillés.`,
         "2. Extraire les critères : `tools`, `expertiseAreas`, `activityAreas`, `places` (mobilité), `durations`, `startDate`/`endDate`.",
         "3. Appeler `boond_candidates_search` avec :",
-        "   - les `tools` extraits (logique OU par défaut ; si l'opportunité est très exigeante, repasser avec `[\"#AND#\", ...]` pour exiger toutes les compétences)",
+        '   - les `tools` extraits (logique OU par défaut ; si l\'opportunité est très exigeante, repasser avec `["#AND#", ...]` pour exiger toutes les compétences)',
         "   - `expertiseAreas` correspondants",
         "   - `mobilityAreas` matchant le lieu",
         "   - `candidateStates` actifs uniquement (consulter `setting.state.candidate` via `boond_application_dictionary`)",
-        "   - `period: \"available\"` + `startDate`/`endDate` calés sur la mission, pour ne garder que les candidats disponibles",
+        '   - `period: "available"` + `startDate`/`endDate` calés sur la mission, pour ne garder que les candidats disponibles',
         "   - `pageSize: 50`",
         "4. Pour les top 20 candidats retournés, récupérer `boond_candidates_technical_data` pour vérifier l'adéquation fine.",
         "5. Restituer un classement : nom | titre | dispo | note d'adéquation (sur 10) avec justification 1 ligne.",
@@ -164,8 +171,7 @@ const PROMPTS: PromptDefinition[] = [
   {
     name: "fiche_consultant",
     title: "Fiche complète d'un collaborateur",
-    description:
-      "Vue 360° d'une ressource : info, profil technique, positionnements, absences, CRA récents.",
+    description: "Vue 360° d'une ressource : info, profil technique, positionnements, absences, CRA récents.",
     argsSchema: {
       resource_id: z.string().describe("ID de la ressource."),
     },
@@ -188,14 +194,297 @@ const PROMPTS: PromptDefinition[] = [
   },
 
   {
+    name: "staffing_disponible",
+    title: "Consultants disponibles pour un staffing",
+    description:
+      "Identifie les ressources internes disponibles pour un staffing sur une fenêtre donnée, " +
+      "avec filtres optionnels par compétences (texte libre) et périmètre. " +
+      "Trie par date de disponibilité croissante et propose les profils prioritaires à activer.",
+    argsSchema: {
+      start_date: z.string().describe("Début de fenêtre de staffing (YYYY-MM-DD)."),
+      end_date: z.string().describe("Fin de fenêtre de staffing (YYYY-MM-DD)."),
+      competences: z
+        .string()
+        .optional()
+        .describe(
+          "Compétences recherchées en texte libre (ex: 'Java Spring AWS'). Le modèle les mappera vers `tools` via le dictionnaire."
+        ),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID d'un manager pour restreindre à son équipe. Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
+        ),
+    },
+    build: ({ start_date, end_date, competences, manager_id }) => {
+      const scope = manager_id
+        ? `\`perimeterManagers: [${manager_id}]\``
+        : "`perimeterDynamic: ['managers']` (mon équipe / mes N-1)";
+      const skillsStep = competences
+        ? `1. Mapper les compétences « ${competences} » vers leurs IDs : \`boond_application_dictionary\` avec \`setting.tool\` (et éventuellement \`setting.expertiseArea\`).`
+        : "1. Pas de filtre compétences fourni — passer directement à l'étape 2.";
+      const toolsLine = competences
+        ? "   - `tools: [...]` issus de l'étape 1 (logique OU ; pour exiger toutes les compétences, mettre `'#AND#'` en 1er élément)"
+        : "";
+      return [
+        `Identifie les ressources internes disponibles pour un staffing entre ${start_date} et ${end_date}.`,
+        "",
+        `Périmètre : ${scope}.`,
+        "",
+        "Étapes :",
+        skillsStep,
+        "2. Appeler `boond_resources_search` avec :",
+        `   - \`period: "available"\`, \`startDate: "${start_date}"\`, \`endDate: "${end_date}"\``,
+        `   - ${scope}`,
+        toolsLine,
+        "   - `resourceStates: [...]` filtrés sur les états « actif » uniquement (consulter `setting.state.resource` via `boond_application_dictionary`)",
+        '   - `pageSize: 50`, `sort: "availability"`, `order: "asc"`',
+        "3. Pour les 15 premières ressources retournées (en parallèle) :",
+        "   - `boond_resources_positionings` — vérifier qu'aucun positionnement actif ne couvre déjà la fenêtre",
+        "   - `boond_resources_technical_data` — confirmer compétences clés et niveau d'expérience",
+        "4. Restituer un tableau trié par date de disponibilité : ressource | titre | dispo le | compétences matchées | mobilité | manager | TJM cible.",
+        "5. Conclure par les 3 profils prioritaires à activer + un signal si la pénurie est forte (< 5 résultats — suggérer d'élargir la fenêtre ou les compétences).",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    },
+  },
+
+  {
+    name: "fin_de_mission",
+    title: "Anticipation des fins de mission",
+    description:
+      "Liste les ressources dont la mission se termine dans les prochains jours, " +
+      "pour anticiper le repositionnement. Met en évidence les fins imminentes sans relais identifié.",
+    argsSchema: {
+      horizon_jours: z
+        .string()
+        .optional()
+        .describe("Nombre de jours à anticiper (défaut: 60). Ex: '30' pour ne voir que les fins très proches."),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID d'un manager pour restreindre à son équipe. Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
+        ),
+    },
+    build: ({ horizon_jours, manager_id }) => {
+      const horizon = horizon_jours || "60";
+      const scope = manager_id ? `\`perimeterManagers: [${manager_id}]\`` : "`perimeterDynamic: ['managers']`";
+      return [
+        `Liste les ressources dont la mission se termine dans les ${horizon} prochains jours.`,
+        "",
+        `Périmètre : ${scope}.`,
+        "",
+        "Étapes :",
+        `1. Calculer la fenêtre : aujourd'hui (D) → D + ${horizon} jours (D+H). Conserver ces deux dates au format YYYY-MM-DD.`,
+        "2. Appeler `boond_resources_search` avec :",
+        '   - `period: "available"`, `startDate: D`, `endDate: D+H`',
+        `   - ${scope}`,
+        "   - `resourceStates` filtrés sur les états « actif » (consulter `setting.state.resource`)",
+        '   - `pageSize: 100`, `sort: "availability"`, `order: "asc"`',
+        "   → Cela retourne les ressources qui (re)deviennent disponibles dans la fenêtre — proxy direct pour « fin de mission ».",
+        "3. Pour chaque ressource, en parallèle :",
+        "   - `boond_resources_positionings` — récupérer le positionnement courant (projet + société + date de fin) et détecter d'éventuels positionnements de relais déjà actés",
+        "   - `boond_resources_projects` — historique projet récent pour contexte",
+        "4. Restituer un tableau trié par date de fin croissante : ressource | projet courant | société cliente | date de fin | jours restants | manager | relais déjà identifié (oui/non).",
+        "5. Mettre en évidence en haut du tableau :",
+        "   - **Urgent** : fin dans <= 15 jours sans relais identifié",
+        "   - **À surveiller** : fin entre 15 et 30 jours sans relais",
+        "6. Conclure par 3-5 actions concrètes : relances commerciales, repositionnements internes, etc.",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "cartographie_competences",
+    title: "Cartographie des compétences d'un périmètre",
+    description:
+      "Produit une cartographie des compétences techniques d'un périmètre (équipe, agence, …) : " +
+      "top compétences, compétences rares (risque bus-factor) et compétences manquantes vs opportunités ouvertes.",
+    argsSchema: {
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID d'un manager pour cibler son équipe. Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
+        ),
+      agency_id: z
+        .string()
+        .optional()
+        .describe("ID d'agence pour cartographier toute une agence (alternatif à `manager_id`)."),
+      top_n: z.string().optional().describe("Nombre de compétences à mettre en avant dans le top (défaut: 20)."),
+    },
+    build: ({ manager_id, agency_id, top_n }) => {
+      const top = top_n || "20";
+      const scope = agency_id
+        ? `\`perimeterAgencies: [${agency_id}]\``
+        : manager_id
+          ? `\`perimeterManagers: [${manager_id}]\``
+          : "`perimeterDynamic: ['managers']`";
+      return [
+        "Cartographie les compétences techniques du périmètre.",
+        "",
+        `Périmètre : ${scope}.`,
+        "",
+        "Étapes :",
+        "1. Lister les ressources actives via `boond_resources_search` :",
+        `   - ${scope}`,
+        "   - `resourceStates` filtrés sur les états « actif » (consulter `setting.state.resource` via `boond_application_dictionary`)",
+        "   - `pageSize: 100` (paginer si > 100)",
+        "2. Récupérer le dictionnaire `setting.tool` (et `setting.expertiseArea`, `setting.languageSpoken`) via `boond_application_dictionary` pour traduire les IDs en libellés.",
+        "3. Pour chaque ressource (par batchs parallèles), appeler `boond_resources_technical_data` et extraire `tools`, `expertiseAreas`, `languages`, `experiences`.",
+        "4. Agréger côté agent :",
+        `   - **Top ${top}** : compétences les plus représentées (nb de ressources)`,
+        "   - **Rares** : compétences possédées par 1 ou 2 personnes (risque bus-factor)",
+        "   - **Saturées** : compétences possédées par > 70% de l'équipe (potentielle banalisation)",
+        "5. Croiser avec les opportunités ouvertes via `boond_opportunities_search` (`opportunityStates` actifs, `perimeterDynamic`/`perimeterAgencies` cohérents) et leurs `tools` :",
+        "   - **Manquantes** : compétences demandées sur les opportunités mais absentes du périmètre — alerte recrutement / formation",
+        "6. Restituer en 4 sections :",
+        `   - Top ${top} compétences (tableau : compétence | nb ressources | exemples de noms)`,
+        "   - Compétences rares (avec porteurs nominatifs et nombre d'opportunités demandant cette compétence)",
+        "   - Compétences saturées",
+        "   - Compétences manquantes vs opportunités (recommandations recrutement / formation)",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "cvs_a_mettre_a_jour",
+    title: "Audit fraîcheur des CV / dossiers techniques",
+    description:
+      "Identifie les ressources dont le CV ou le dossier technique est obsolète, incomplet, ou manquant. " +
+      "Priorise celles bientôt sur le marché (en intercontrat ou disponibles à court terme).",
+    argsSchema: {
+      seuil_mois: z
+        .string()
+        .optional()
+        .describe("Un dossier technique non touché depuis plus de N mois est considéré obsolète (défaut: 12)."),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID d'un manager pour cibler son équipe. Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
+        ),
+    },
+    build: ({ seuil_mois, manager_id }) => {
+      const seuil = seuil_mois || "12";
+      const scope = manager_id ? `\`perimeterManagers: [${manager_id}]\`` : "`perimeterDynamic: ['managers']`";
+      return [
+        `Identifie les CV / dossiers techniques à rafraîchir (seuil d'obsolescence : ${seuil} mois).`,
+        "",
+        `Périmètre : ${scope}.`,
+        "",
+        "Étapes :",
+        "1. Lister les ressources actives via `boond_resources_search` :",
+        `   - ${scope}`,
+        "   - `resourceStates` filtrés sur les états « actif » (consulter `setting.state.resource`)",
+        "   - `pageSize: 100` (paginer si nécessaire)",
+        "2. Pour chaque ressource (par batchs parallèles), appeler `boond_resources_technical_data` et lire :",
+        "   - `updateDate` du dossier technique",
+        "   - présence et longueur du CV (`resume`)",
+        "   - nombre de compétences déclarées (`tools`)",
+        "   - nombre d'expériences renseignées",
+        "3. Filtrer côté agent : ne conserver que les ressources dont au moins UN critère est défaillant —",
+        `   - \`updateDate\` antérieure de plus de ${seuil} mois, OU`,
+        "   - CV manquant / vide, OU",
+        "   - moins de 3 compétences (`tools`) déclarées, OU",
+        "   - aucune expérience renseignée.",
+        '4. Croiser avec la disponibilité pour prioriser : `boond_resources_search` avec `period: "available"` + fenêtre des 3 prochains mois, et marquer les ressources concernées comme **prioritaires**.',
+        "5. Restituer un tableau de relance trié par priorité décroissante : ressource | manager | dernière maj DT | jours d'ancienneté | trous (CV manquant / 0 compétences / 0 expérience) | bientôt dispo (oui/non).",
+        "6. Conclure par les 5 ressources à relancer en premier (avec template de message court à envoyer au manager).",
+      ].join("\n");
+    },
+  },
+
+  {
+    name: "recherche_profil_competences",
+    title: "Recherche multi-source d'un profil par compétences",
+    description:
+      "Recherche un profil correspondant à un mix de compétences libres, en croisant ressources internes " +
+      "et candidats. Sortie classée par adéquation. Utile en amont d'un staffing ou d'une opportunité non encore qualifiée.",
+    argsSchema: {
+      competences: z
+        .string()
+        .describe("Compétences recherchées en texte libre (ex: 'Java Spring AWS Kubernetes', '.NET Azure DevOps')."),
+      experience_min: z
+        .string()
+        .optional()
+        .describe(
+          "Niveau d'expérience minimum en texte libre (ex: '5 ans', 'senior'). Le modèle le mappera vers `experiences` via le dictionnaire."
+        ),
+      dispo_avant: z
+        .string()
+        .optional()
+        .describe(
+          "Disponibilité requise au plus tard à cette date (YYYY-MM-DD). Si fourni, applique `period: 'available'` + `endDate`."
+        ),
+      inclure_candidats: z
+        .string()
+        .optional()
+        .describe(
+          "'oui' (défaut) pour inclure aussi les candidats actifs ; 'non' pour ne chercher que dans les ressources internes."
+        ),
+      manager_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID d'un manager pour restreindre le scope ressources internes. Sinon scope ouvert (toute l'organisation accessible)."
+        ),
+    },
+    build: ({ competences, experience_min, dispo_avant, inclure_candidats, manager_id }) => {
+      const includeCandidates = (inclure_candidats || "oui").toLowerCase() !== "non";
+      const scope = manager_id
+        ? `\`perimeterManagers: [${manager_id}]\``
+        : "(pas de filtre périmètre — recherche sur l'ensemble accessible à l'utilisateur)";
+      const dispoLine = dispo_avant
+        ? `   - \`period: "available"\`, \`endDate: "${dispo_avant}"\` (disponible au plus tard à cette date)`
+        : "";
+      const expStep = experience_min
+        ? `2bis. Mapper l'expérience minimum « ${experience_min} » vers les IDs \`experiences\` via \`boond_application_dictionary\` avec \`setting.experience\`.`
+        : "";
+      return [
+        `Recherche un profil correspondant aux compétences : « ${competences} ».`,
+        "",
+        `Scope ressources internes : ${scope}.`,
+        `Inclure les candidats actifs : ${includeCandidates ? "oui" : "non"}.`,
+        "",
+        "Étapes :",
+        "1. Mapper les compétences libres vers leurs IDs :",
+        "   - `boond_application_dictionary` avec `setting.tool` pour les outils / technos",
+        "   - `boond_application_dictionary` avec `setting.expertiseArea` pour les domaines d'expertise",
+        "2. Identifier les compétences indispensables (toutes requises) vs souhaitables, à partir du libellé du besoin.",
+        expStep,
+        "3. Recherche dans les ressources internes via `boond_resources_search` :",
+        '   - `tools: [...]` (si plusieurs compétences indispensables, préfixer par `"#AND#"` pour exiger toutes ; sinon laisser en OU)',
+        "   - `expertiseAreas: [...]` éventuellement",
+        experience_min ? "   - `experiences: [...]` issus de l'étape 2bis" : "",
+        dispoLine,
+        manager_id ? `   - ${scope}` : "",
+        "   - `resourceStates` actifs uniquement (consulter `setting.state.resource`)",
+        "   - `pageSize: 30`",
+        includeCandidates
+          ? "4. En parallèle, recherche dans les candidats via `boond_candidates_search` avec les mêmes filtres + `candidateStates` actifs (consulter `setting.state.candidate`)."
+          : "4. (Skip — recherche limitée aux ressources internes.)",
+        "5. Pour les top 10 résultats combinés, récupérer `technical_data` (`boond_resources_technical_data` ou `boond_candidates_technical_data`) pour vérifier l'adéquation fine.",
+        "6. Restituer un classement unique : type (Ressource interne / Candidat) | nom | titre | compétences matchées | expérience | dispo | localisation/mobilité | note d'adéquation /10 (1 ligne de justification).",
+        "7. Si moins de 5 résultats : suggérer un assouplissement (retirer une compétence secondaire, élargir le périmètre géographique, accepter un junior, sous-traitance).",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    },
+  },
+
+  {
     name: "recap_hebdo",
     title: "Récap hebdomadaire (moi + mon équipe)",
     description:
       "Compile en une vue ce qui s'est passé / va se passer cette semaine pour moi et mon équipe : opportunités, projets, absences, CRA.",
     argsSchema: {
-      semaine: z.string().optional().describe(
-        "Semaine ciblée (ex: 'cette semaine', 'la semaine prochaine'). Défaut: cette semaine."
-      ),
+      semaine: z
+        .string()
+        .optional()
+        .describe("Semaine ciblée (ex: 'cette semaine', 'la semaine prochaine'). Défaut: cette semaine."),
     },
     build: ({ semaine }) => {
       const semaineText = semaine || "cette semaine";


### PR DESCRIPTION
Introduce five new MCP prompts for resource workflows: staffing_disponible, fin_de_mission, cartographie_competences, cvs_a_mettre_a_jour and recherche_profil_competences (implemented in src/prompts/index.ts). Update unit tests (src/prompts/index.test.ts) to validate registration and expected prompt payloads/behaviour. Refresh docs: TOOLS.md prompt count/list updated and README.md extended with prompts section, usage instructions and invocation examples. These additions enable staffing, end-of-mission monitoring, skills cartography, CV freshness audits and multi-source skills searches with manager/agency scoping and availability handling.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [ ] Mon code suit les conventions du projet
- [ ] J'ai lance `npm run lint` et `npm run typecheck`
- [ ] J'ai ajoute des tests couvrant mes changements
- [ ] Tous les tests passent (`npm test`)
- [ ] J'ai mis a jour la documentation si necessaire
