### PR TITLE
fix: dictionary endpoint + in-memory cache (v1.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.7.3] - 2026-05-03
+
+Hotfix critique de l'outil `boond_application_dictionary` et des ressources `boond://dictionary/*` : depuis l'origine, ces deux surfaces appelaient un endpoint qui n'existe pas (`/application/dictionaries/{slug}`, pluriel) et retournaient systématiquement un **404 BoondManager**, ce qui bloquait notamment l'attachement de ressources dans Claude Desktop ("Failed to attach resource"). L'API officielle expose en réalité un endpoint unique `/application/dictionary` (singulier) qui renvoie l'intégralité des dictionnaires en une seule réponse, structurée en `data.setting.*`, `data.country`, `data.languages`.
+
+### Corrigé
+
+- **Endpoint dictionnaire** — le tool `boond_application_dictionary` et toutes les ressources `boond://dictionary/*` appellent désormais `GET /application/dictionary` (cf. `https://doc.boondmanager.com/api-externe/raml-build/resources/application/dictionary.raml`). Le paramètre `dictionaryType` accepte un **chemin dotté** dans la réponse (`setting.state.resource`, `setting.tool`, `country`, …) au lieu de l'ancien slug pluriel inopérant. Un message d'aide explicite est renvoyé si le chemin n'existe pas (avec rappel : "states/resources" → "setting.state.resource").
+- **Ressources MCP recalibrées** — la liste exposée reflète désormais ce qui existe vraiment côté API. Slugs supprimés (404 garanti) : `states/absences`, `typeOf/candidates`, `typeOf/actions`, `typeOf/absences`. Slugs ajoutés (utiles aux prompts staffing/skills) : `tools`, `expertiseAreas`, `experiences`, `activityAreas`, `mobilityAreas`. Total ressources : **21** (vs 20 en 1.7.2).
+
+### Ajouté
+
+- **Cache mémoire du dictionnaire** (`src/services/dictionary.ts`) — la réponse `/application/dictionary` est volumineuse (centaines de Ko) et stable. Elle est désormais récupérée **une seule fois par process** (TTL configurable via `BOOND_DICTIONARY_TTL_MS`, défaut 1h), avec déduplication des appels concurrents (un seul fetch en parallèle pour N reads simultanés au démarrage de session). Erreurs réseau ne polluent pas le cache (le prochain appel re-tente). Tests : `src/services/dictionary.test.ts` couvre cache hit, force-refresh, expiration TTL, dedup concurrent, retry après échec, et résolution de chemin (segments imbriqués, paths inconnus, paths vides). Service exporté `resetDictionaryCacheForTests()` pour les tests qui en ont besoin.
+
+### Aucune rupture
+
+- Les 156 outils, 11 prompts, schémas Zod et endpoints autres que `/application/dictionary` sont strictement inchangés. Côté UX : l'outil `boond_application_dictionary` accepte le même nom de paramètre (`dictionaryType`) — seules les valeurs valides changent (dotté plutôt que slash).
+
 ## [1.7.2] - 2026-05-02
 
 Hotfix critique du bundle `.mcpb` (bloquant depuis la 1.6.0) et amélioration ergonomique des prompts (saisie par nom au lieu de l'ID).

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**156 tools** across **36 domains** · **11 prompts** · **20 resources**.
+**156 tools** across **36 domains** · **11 prompts** · **21 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -363,17 +363,20 @@ Pre-orchestrated workflows surfaced via the MCP prompts API.
 | `staffing_disponible` | Consultants disponibles pour un staffing | `start_date` `end_date` `competences?` `manager_id?` |
 | `synthese_equipe` | Synthèse d'une équipe | `manager_id?` `periode?` |
 
-## Resources (20)
+## Resources (21)
 
 Reference data exposed as MCP resources.
 
 | URI | Title |
 |---|---|
 | `boond://application/current-user` | Utilisateur courant |
+| `boond://dictionary/activityAreas` | Secteurs d'activité |
 | `boond://dictionary/countries` | Pays |
 | `boond://dictionary/currencies` | Devises |
+| `boond://dictionary/experiences` | Niveaux d'expérience |
+| `boond://dictionary/expertiseAreas` | Domaines d'expertise |
 | `boond://dictionary/languages` | Langues |
-| `boond://dictionary/states/absences` | États absences |
+| `boond://dictionary/mobilityAreas` | Mobilités |
 | `boond://dictionary/states/candidates` | États candidats |
 | `boond://dictionary/states/companies` | États sociétés |
 | `boond://dictionary/states/contacts` | États contacts |
@@ -383,9 +386,7 @@ Reference data exposed as MCP resources.
 | `boond://dictionary/states/positionings` | États positionnements |
 | `boond://dictionary/states/projects` | États projets |
 | `boond://dictionary/states/resources` | États ressources |
-| `boond://dictionary/typeOf/absences` | Types absences |
-| `boond://dictionary/typeOf/actions` | Types actions |
-| `boond://dictionary/typeOf/candidates` | Types candidats |
+| `boond://dictionary/tools` | Outils / Technos |
 | `boond://dictionary/typeOf/contacts` | Types contacts |
 | `boond://dictionary/typeOf/projects` | Types projets |
 | `boond://dictionary/typeOf/resources` | Types ressources |

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "1.7.2",
-  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 20 resources (ERP/CRM)",
+  "version": "1.7.3",
+  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",
     "url": "https://github.com/fauguste/boondmanager-mcp-server"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.7.2",
-  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 20 resources (ERP/CRM)",
+  "version": "1.7.3",
+  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
-  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 20 resources (ERP/CRM)",
-  "version": "1.7.2",
+  "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
+  "version": "1.7.3",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.7.2/boondmanager-mcp-server-v1.7.2.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.7.3/boondmanager-mcp-server-v1.7.3.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/resources/index.test.ts
+++ b/src/resources/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerAllResources, REGISTERED_RESOURCES } from "./index.js";
 import * as boondClient from "../services/boond-client.js";
+import * as dictionaryService from "../services/dictionary.js";
 
 function createMockServer() {
   return { registerResource: vi.fn() } as unknown as McpServer;
@@ -12,6 +13,7 @@ describe("registerAllResources", () => {
   beforeEach(() => {
     server = createMockServer();
     vi.restoreAllMocks();
+    dictionaryService.resetDictionaryCacheForTests();
   });
 
   it("registers exactly the resources declared in REGISTERED_RESOURCES", () => {
@@ -28,7 +30,7 @@ describe("registerAllResources", () => {
     const dicts = REGISTERED_RESOURCES.filter((r) => r.name.startsWith("dictionary/"));
     expect(dicts.length).toBeGreaterThan(10);
     for (const r of dicts) {
-      expect(r.uri).toMatch(/^boond:\/\/dictionary\/[a-zA-Z]+\/[a-zA-Z]+$|^boond:\/\/dictionary\/[a-zA-Z]+$/);
+      expect(r.uri).toMatch(/^boond:\/\/dictionary\/[a-zA-Z]+(\/[a-zA-Z]+)?$/);
     }
   });
 
@@ -37,23 +39,34 @@ describe("registerAllResources", () => {
   });
 
   it("exposes the search-tool dictionaries the prompts depend on", () => {
-    // Prompts in src/prompts/index.ts and the tool descriptions reference
-    // these dict slugs — make sure they're all surfaced as resources so the
-    // model can resolve state/typeOf integers without a tool call.
+    // Prompts in src/prompts/index.ts and tool descriptions reference these
+    // dict slugs — make sure they're all surfaced as resources so the model
+    // can resolve state/typeOf integers without a tool call. Slugs that
+    // don't map to a real BoondManager dictionary path (states/absences,
+    // typeOf/candidates, typeOf/actions, typeOf/absences) are intentionally
+    // excluded.
     const slugs = REGISTERED_RESOURCES.map((r) => r.uri.replace(/^boond:\/\/dictionary\//, ""));
-    expect(slugs).toEqual(expect.arrayContaining([
-      "states/resources",
-      "states/candidates",
-      "states/contacts",
-      "states/companies",
-      "states/opportunities",
-      "states/projects",
-      "states/invoices",
-      "typeOf/resources",
-      "typeOf/candidates",
-      "typeOf/projects",
-      "typeOf/actions",
-    ]));
+    expect(slugs).toEqual(
+      expect.arrayContaining([
+        "states/resources",
+        "states/candidates",
+        "states/contacts",
+        "states/companies",
+        "states/opportunities",
+        "states/projects",
+        "states/invoices",
+        "states/orders",
+        "states/positionings",
+        "typeOf/resources",
+        "typeOf/contacts",
+        "typeOf/projects",
+        "tools",
+        "expertiseAreas",
+        "countries",
+        "currencies",
+        "languages",
+      ])
+    );
   });
 
   it("declares JSON mime type and a non-empty title/description on every resource", () => {
@@ -70,21 +83,75 @@ describe("registerAllResources", () => {
     }
   });
 
-  it("dictionary read callback hits /application/dictionaries/<slug>", async () => {
+  it("dictionary read callback resolves the slug → setting path against the cached dictionary", async () => {
+    // Single mocked /application/dictionary response with a setting.state.resource
+    // sub-tree. The resource read callback should fetch the dict once via the
+    // dictionary service and extract the right sub-tree.
     const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
-      data: [{ id: "1", type: "dictionary", attributes: { value: "Actif" } }],
-    });
+      data: {
+        setting: {
+          state: {
+            resource: [
+              { id: 1, value: "Actif" },
+              { id: 2, value: "Inactif" },
+            ],
+          },
+        },
+      },
+    } as never);
     registerAllResources(server);
     const call = vi.mocked(server.registerResource).mock.calls.find((c) => c[0] === "dictionary/states/resources");
     expect(call).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cb = call![3] as any;
     const result = await cb(new URL("boond://dictionary/states/resources"));
-    expect(apiSpy).toHaveBeenCalledWith("/application/dictionaries/states/resources");
-    expect(result.contents).toHaveLength(1);
-    expect(result.contents[0].uri).toBe("boond://dictionary/states/resources");
-    expect(result.contents[0].mimeType).toBe("application/json");
-    expect(JSON.parse(result.contents[0].text).data[0].attributes.value).toBe("Actif");
+    expect(apiSpy).toHaveBeenCalledWith("/application/dictionary", "GET", undefined, { language: "fr" });
+    const body = JSON.parse(result.contents[0].text);
+    expect(body).toEqual([
+      { id: 1, value: "Actif" },
+      { id: 2, value: "Inactif" },
+    ]);
+  });
+
+  it("dictionary callbacks share the cached dictionary across reads (single API call)", async () => {
+    const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+      data: {
+        setting: {
+          state: { resource: [{ id: 1, value: "A" }], candidate: [{ id: 9, value: "Z" }] },
+          tool: [{ id: 42, value: "Java" }],
+        },
+        country: [{ id: "FR", value: "France" }],
+      },
+    } as never);
+    registerAllResources(server);
+    const calls = vi.mocked(server.registerResource).mock.calls;
+    const findCb = (n: string) =>
+      calls.find((c) => c[0] === n)![3] as (uri: URL) => Promise<{ contents: { text: string }[] }>;
+
+    const r1 = await findCb("dictionary/states/resources")(new URL("boond://dictionary/states/resources"));
+    const r2 = await findCb("dictionary/states/candidates")(new URL("boond://dictionary/states/candidates"));
+    const r3 = await findCb("dictionary/tools")(new URL("boond://dictionary/tools"));
+    const r4 = await findCb("dictionary/countries")(new URL("boond://dictionary/countries"));
+
+    expect(apiSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(r1.contents[0].text)).toEqual([{ id: 1, value: "A" }]);
+    expect(JSON.parse(r2.contents[0].text)).toEqual([{ id: 9, value: "Z" }]);
+    expect(JSON.parse(r3.contents[0].text)).toEqual([{ id: 42, value: "Java" }]);
+    expect(JSON.parse(r4.contents[0].text)).toEqual([{ id: "FR", value: "France" }]);
+  });
+
+  it("dictionary callback returns an explicit error body when the path is missing from the API response", async () => {
+    vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+      data: { setting: {} }, // no setting.tool
+    } as never);
+    registerAllResources(server);
+    const call = vi.mocked(server.registerResource).mock.calls.find((c) => c[0] === "dictionary/tools");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = call![3] as any;
+    const result = await cb(new URL("boond://dictionary/tools"));
+    const body = JSON.parse(result.contents[0].text);
+    expect(body).toHaveProperty("error");
+    expect(body.error).toMatch(/setting\.tool/);
   });
 
   it("current-user read callback hits /application/current-user", async () => {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apiRequest } from "../services/boond-client.js";
+import { getDictionary, resolveDictionaryPath } from "../services/dictionary.js";
 
 /**
  * MCP resources for BoondManager reference data.
@@ -14,15 +15,16 @@ import { apiRequest } from "../services/boond-client.js";
  * - Read access is idempotent and cache-friendly: many MCP hosts cache the
  *   resource body for the duration of a conversation.
  *
- * The set below covers the dictionaries our search tools refer to most
- * (states + typeOf for the six search domains, plus the global ones used in
- * formatting like countries / currencies / languages). Anything beyond this
- * fixed set is still reachable via the `boond_application_dictionary` tool.
+ * Backing data: a single `GET /application/dictionary` call returns the whole
+ * payload, which we cache (see `services/dictionary.ts`). Each resource read
+ * extracts a sub-tree via a fixed slug→path mapping.
  */
 
 interface DictionaryEntry {
   /** URI suffix, e.g. "states/resources". Joined with "boond://dictionary/". */
   slug: string;
+  /** Dotted path inside the dictionary `data` object (e.g. "setting.state.resource"). */
+  path: string;
   /** Human title shown to the user / model in the resource list. */
   title: string;
   /** One-line description. */
@@ -30,33 +32,129 @@ interface DictionaryEntry {
 }
 
 /**
- * Well-known Boond dictionaries surfaced as static MCP resources. We keep
- * this list deliberately curated — better to expose the dozen the search
- * tools actually depend on than the hundreds of obscure config dicts.
+ * Curated dictionaries surfaced as static MCP resources. Slugs follow the
+ * historical "kind/entity" naming for backward compatibility with client URIs;
+ * the API path mapping reflects the actual BoondManager `/application/dictionary`
+ * response structure (cf. `data.setting.*`, `data.country`, `data.languages`).
+ *
+ * Slugs that do not map to a real path in the API (e.g. `states/absences`,
+ * `typeOf/candidates`) are intentionally absent.
  */
 const DICTIONARIES: DictionaryEntry[] = [
   // states/* — used to translate the integer `state` attribute on entities
-  { slug: "states/resources",     title: "États ressources",     description: "Libellés des états de ressource (collaborateur)." },
-  { slug: "states/candidates",    title: "États candidats",      description: "Libellés des états de candidat." },
-  { slug: "states/contacts",      title: "États contacts",       description: "Libellés des états de contact." },
-  { slug: "states/companies",     title: "États sociétés",       description: "Libellés des états de société." },
-  { slug: "states/opportunities", title: "États opportunités",   description: "Libellés des états d'opportunité commerciale." },
-  { slug: "states/projects",      title: "États projets",        description: "Libellés des états de projet/mission." },
-  { slug: "states/invoices",      title: "États factures",       description: "Libellés des états de facture client." },
-  { slug: "states/orders",        title: "États bons de commande", description: "Libellés des états de bon de commande." },
-  { slug: "states/positionings",  title: "États positionnements", description: "Libellés des états de positionnement." },
-  { slug: "states/absences",      title: "États absences",       description: "Libellés des états des demandes d'absence." },
+  {
+    slug: "states/resources",
+    path: "setting.state.resource",
+    title: "États ressources",
+    description: "Libellés des états de ressource (collaborateur).",
+  },
+  {
+    slug: "states/candidates",
+    path: "setting.state.candidate",
+    title: "États candidats",
+    description: "Libellés des états de candidat.",
+  },
+  {
+    slug: "states/contacts",
+    path: "setting.state.contact",
+    title: "États contacts",
+    description: "Libellés des états de contact.",
+  },
+  {
+    slug: "states/companies",
+    path: "setting.state.company",
+    title: "États sociétés",
+    description: "Libellés des états de société.",
+  },
+  {
+    slug: "states/opportunities",
+    path: "setting.state.opportunity",
+    title: "États opportunités",
+    description: "Libellés des états d'opportunité commerciale.",
+  },
+  {
+    slug: "states/projects",
+    path: "setting.state.project",
+    title: "États projets",
+    description: "Libellés des états de projet/mission.",
+  },
+  {
+    slug: "states/invoices",
+    path: "setting.state.invoice",
+    title: "États factures",
+    description: "Libellés des états de facture client.",
+  },
+  {
+    slug: "states/orders",
+    path: "setting.state.order",
+    title: "États bons de commande",
+    description: "Libellés des états de bon de commande.",
+  },
+  {
+    slug: "states/positionings",
+    path: "setting.state.positioning",
+    title: "États positionnements",
+    description: "Libellés des états de positionnement.",
+  },
   // typeOf/* — used to translate the integer `typeOf` attribute on entities
-  { slug: "typeOf/resources",     title: "Types ressources",     description: "Types de ressource (interne, sous-traitant, freelance...)." },
-  { slug: "typeOf/candidates",    title: "Types candidats",      description: "Types de candidat." },
-  { slug: "typeOf/contacts",      title: "Types contacts",       description: "Types de contact." },
-  { slug: "typeOf/projects",      title: "Types projets",        description: "Types de projet (régie, forfait, produit...)." },
-  { slug: "typeOf/actions",       title: "Types actions",        description: "Types d'action (appel, email, RDV, note...)." },
-  { slug: "typeOf/absences",      title: "Types absences",       description: "Types d'absence (CP, RTT, maladie, sans solde...)." },
+  {
+    slug: "typeOf/resources",
+    path: "setting.typeOf.resource",
+    title: "Types ressources",
+    description: "Types de ressource (interne, sous-traitant, freelance...).",
+  },
+  {
+    slug: "typeOf/contacts",
+    path: "setting.typeOf.contact",
+    title: "Types contacts",
+    description: "Types de contact.",
+  },
+  {
+    slug: "typeOf/projects",
+    path: "setting.typeOf.project",
+    title: "Types projets",
+    description: "Types de projet (régie, forfait, produit...).",
+  },
+  // Skills / referential
+  {
+    slug: "tools",
+    path: "setting.tool",
+    title: "Outils / Technos",
+    description: "Catalogue des outils et technologies utilisables sur les ressources et candidats (Java, AWS, ...).",
+  },
+  {
+    slug: "expertiseAreas",
+    path: "setting.expertiseArea",
+    title: "Domaines d'expertise",
+    description: "Domaines d'expertise métier (DevOps, Data, Frontend, ...).",
+  },
+  {
+    slug: "experiences",
+    path: "setting.experience",
+    title: "Niveaux d'expérience",
+    description: "Niveaux d'expérience (junior, confirmé, senior, ...).",
+  },
+  {
+    slug: "activityAreas",
+    path: "setting.activityArea",
+    title: "Secteurs d'activité",
+    description: "Secteurs d'activité des sociétés clientes.",
+  },
+  {
+    slug: "mobilityAreas",
+    path: "setting.mobilityArea",
+    title: "Mobilités",
+    description: "Zones de mobilité géographique.",
+  },
   // Global lookups
-  { slug: "countries",            title: "Pays",                 description: "Liste des pays (codes ISO + libellés)." },
-  { slug: "currencies",           title: "Devises",              description: "Liste des devises supportées." },
-  { slug: "languages",            title: "Langues",              description: "Liste des langues parlées." },
+  { slug: "countries", path: "country", title: "Pays", description: "Liste des pays (codes ISO + libellés)." },
+  { slug: "currencies", path: "setting.currency", title: "Devises", description: "Liste des devises supportées." },
+  {
+    slug: "languages",
+    path: "languages",
+    title: "Langues",
+    description: "Langues d'interface BoondManager (fr, en, es).",
+  },
 ];
 
 /** URI prefix under which all dictionaries are exposed. */
@@ -90,15 +188,20 @@ export function registerAllResources(server: McpServer): void {
         mimeType: "application/json",
       },
       async () => {
-        // Mirror the path used by the boond_application_dictionary tool so
-        // both read paths stay in sync if the upstream API moves.
-        const response = await apiRequest(`/application/dictionaries/${dict.slug}`);
+        const { payload } = await getDictionary();
+        const node = resolveDictionaryPath(payload, dict.path);
+        const body =
+          node === undefined
+            ? {
+                error: `Path "${dict.path}" not found in BoondManager dictionary. The upstream API may have changed — please open an issue.`,
+              }
+            : node;
         return {
           contents: [
             {
               uri,
               mimeType: "application/json",
-              text: JSON.stringify(response, null, 2),
+              text: JSON.stringify(body, null, 2),
             },
           ],
         };
@@ -115,8 +218,8 @@ export function registerAllResources(server: McpServer): void {
     {
       title: "Utilisateur courant",
       description:
-        "Profil de l'utilisateur authentifié auprès de l'API BoondManager (id, agence, permissions). "
-        + "Utile pour résoudre 'mon ID' avant un appel filtré par perimeterManagers.",
+        "Profil de l'utilisateur authentifié auprès de l'API BoondManager (id, agence, permissions). " +
+        "Utile pour résoudre 'mon ID' avant un appel filtré par perimeterManagers.",
       mimeType: "application/json",
     },
     async () => {

--- a/src/services/dictionary.test.ts
+++ b/src/services/dictionary.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as boondClient from "./boond-client.js";
+import { getDictionary, resolveDictionaryPath, resetDictionaryCacheForTests } from "./dictionary.js";
+
+describe("dictionary service", () => {
+  beforeEach(() => {
+    resetDictionaryCacheForTests();
+    vi.restoreAllMocks();
+    delete process.env["BOOND_DICTIONARY_TTL_MS"];
+  });
+
+  afterEach(() => {
+    delete process.env["BOOND_DICTIONARY_TTL_MS"];
+  });
+
+  describe("getDictionary", () => {
+    it("fetches /application/dictionary on first call with default language=fr", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: {} },
+      } as never);
+      const result = await getDictionary();
+      expect(apiSpy).toHaveBeenCalledTimes(1);
+      expect(apiSpy).toHaveBeenCalledWith("/application/dictionary", "GET", undefined, {
+        language: "fr",
+      });
+      expect(result.language).toBe("fr");
+      expect(result.payload).toEqual({ data: { setting: {} } });
+    });
+
+    it("returns the cached entry on subsequent calls within the TTL", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: { tool: [{ id: 1 }] } },
+      } as never);
+      const r1 = await getDictionary();
+      const r2 = await getDictionary();
+      const r3 = await getDictionary();
+      expect(apiSpy).toHaveBeenCalledTimes(1);
+      expect(r1).toBe(r2);
+      expect(r2).toBe(r3);
+    });
+
+    it("re-fetches when force=true is passed", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: {} },
+      } as never);
+      await getDictionary();
+      await getDictionary({ force: true });
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-fetches when the requested language differs from the cached one", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: {} },
+      } as never);
+      await getDictionary({ language: "fr" });
+      await getDictionary({ language: "en" });
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      expect(apiSpy).toHaveBeenNthCalledWith(2, "/application/dictionary", "GET", undefined, {
+        language: "en",
+      });
+    });
+
+    it("deduplicates concurrent fetches into a single API call", async () => {
+      let resolve!: (v: unknown) => void;
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockImplementation(
+        () =>
+          new Promise((res) => {
+            resolve = res;
+          })
+      );
+      const p1 = getDictionary();
+      const p2 = getDictionary();
+      const p3 = getDictionary();
+      // Resolve the underlying request once.
+      resolve({ data: { setting: {} } });
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+      expect(apiSpy).toHaveBeenCalledTimes(1);
+      expect(r1).toBe(r2);
+      expect(r2).toBe(r3);
+    });
+
+    it("does not poison the cache when the API request fails", async () => {
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockRejectedValueOnce(new Error("network down"))
+        .mockResolvedValueOnce({ data: { setting: {} } } as never);
+      await expect(getDictionary()).rejects.toThrow("network down");
+      // Subsequent call should retry, not return a cached error.
+      const ok = await getDictionary();
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      expect(ok.payload).toEqual({ data: { setting: {} } });
+    });
+
+    it("re-fetches once the TTL expires", async () => {
+      process.env["BOOND_DICTIONARY_TTL_MS"] = "1";
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: {} },
+      } as never);
+      await getDictionary();
+      // Wait > TTL so the cache entry is considered stale.
+      await new Promise((r) => setTimeout(r, 5));
+      await getDictionary();
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("resolveDictionaryPath", () => {
+    const payload = {
+      data: {
+        setting: {
+          state: { resource: [{ id: 1, value: "Actif" }] },
+          tool: [{ id: 42, value: "Java" }],
+        },
+        country: [{ id: "FR", value: "France" }],
+        languages: [{ id: "fr", value: "Français" }],
+      },
+    } as unknown as Parameters<typeof resolveDictionaryPath>[0];
+
+    it("resolves nested setting paths", () => {
+      expect(resolveDictionaryPath(payload, "setting.state.resource")).toEqual([{ id: 1, value: "Actif" }]);
+      expect(resolveDictionaryPath(payload, "setting.tool")).toEqual([{ id: 42, value: "Java" }]);
+    });
+
+    it("resolves top-level data.* paths", () => {
+      expect(resolveDictionaryPath(payload, "country")).toEqual([{ id: "FR", value: "France" }]);
+      expect(resolveDictionaryPath(payload, "languages")).toEqual([{ id: "fr", value: "Français" }]);
+    });
+
+    it("returns undefined for unknown paths", () => {
+      expect(resolveDictionaryPath(payload, "setting.state.nope")).toBeUndefined();
+      expect(resolveDictionaryPath(payload, "totally.invalid.path")).toBeUndefined();
+      expect(resolveDictionaryPath(payload, "")).toBeUndefined();
+    });
+
+    it("trims surrounding whitespace from the path", () => {
+      expect(resolveDictionaryPath(payload, "  setting.tool  ")).toEqual([{ id: 42, value: "Java" }]);
+    });
+  });
+});

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -1,0 +1,110 @@
+import { apiRequest } from "./boond-client.js";
+import type { JsonApiResponse } from "../types.js";
+
+/**
+ * Cache du dictionnaire BoondManager.
+ *
+ * L'API BoondManager expose **un seul endpoint** `GET /application/dictionary`
+ * qui retourne l'intégralité des dictionnaires (états, types, pays, devises,
+ * langues, outils, expertises, …) en une seule réponse JSON. La structure
+ * pertinente pour les outils du serveur est `data.setting.*` et
+ * `data.{country,languages}` (cf. RAML `schemas/application/dictionary.json`).
+ *
+ * Sans cache, chaque lecture de ressource ou appel à `boond_application_dictionary`
+ * forcerait un appel HTTP de plusieurs centaines de Ko, alors que le contenu
+ * change rarement (libellés d'états, types métier, …). On cache donc en mémoire
+ * pour la durée du process, avec un TTL configurable.
+ *
+ * Concurrent fetches sont dédupliqués via une promesse partagée pour éviter
+ * de marteler l'API quand plusieurs ressources sont lues en parallèle au
+ * démarrage d'une session MCP.
+ */
+
+export type DictionaryLanguage = "fr" | "en" | "es";
+
+interface CacheEntry {
+  payload: JsonApiResponse;
+  fetchedAt: number;
+  language: DictionaryLanguage;
+}
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function resolveTtlMs(): number {
+  const raw = process.env["BOOND_DICTIONARY_TTL_MS"];
+  if (!raw) return DEFAULT_TTL_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TTL_MS;
+}
+
+let cache: CacheEntry | null = null;
+let inFlight: Promise<CacheEntry> | null = null;
+
+export interface GetDictionaryOptions {
+  language?: DictionaryLanguage;
+  /** Bypass the cache and re-fetch. */
+  force?: boolean;
+}
+
+/**
+ * Returns the full BoondManager dictionary payload, fetching once per TTL.
+ * Concurrent calls share the same in-flight request.
+ */
+export async function getDictionary(opts: GetDictionaryOptions = {}): Promise<CacheEntry> {
+  const language: DictionaryLanguage = opts.language ?? "fr";
+  const now = Date.now();
+
+  if (!opts.force && cache !== null && cache.language === language && now - cache.fetchedAt < resolveTtlMs()) {
+    return cache;
+  }
+
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const payload = await apiRequest("/application/dictionary", "GET", undefined, {
+        language,
+      });
+      cache = { payload, fetchedAt: Date.now(), language };
+      return cache;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/**
+ * Resolves a dotted path inside the dictionary `data` object.
+ *
+ * Examples:
+ *   "setting.state.resource"       → array of resource states
+ *   "setting.tool"                 → array of tools / technos
+ *   "country"                      → array of countries
+ *   "languages"                    → array of UI languages
+ *   "setting.state.resource[0]"    → not supported (no bracket notation; pass plain dotted path)
+ *
+ * Returns `undefined` if any segment is missing.
+ */
+export function resolveDictionaryPath(payload: JsonApiResponse, path: string): unknown {
+  const trimmed = path.trim();
+  if (!trimmed) return undefined;
+  const parts = trimmed.split(".");
+  // The dictionary payload is `{ meta, data: { setting, country, languages, ... } }`.
+  // We always look under `data` so callers don't have to repeat it.
+  const root = (payload as unknown as { data?: unknown }).data;
+  let node: unknown = root ?? payload;
+  for (const part of parts) {
+    if (node === null || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[part];
+    if (node === undefined) return undefined;
+  }
+  return node;
+}
+
+/** Reset the cache. Exposed for tests. */
+export function resetDictionaryCacheForTests(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/src/tools/application.test.ts
+++ b/src/tools/application.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerApplicationTools } from "./application.js";
+import * as boondClient from "../services/boond-client.js";
+import * as dictionaryService from "../services/dictionary.js";
 
 function createMockServer() {
   return {
@@ -13,6 +15,8 @@ describe("registerApplicationTools", () => {
 
   beforeEach(() => {
     server = createMockServer();
+    vi.restoreAllMocks();
+    dictionaryService.resetDictionaryCacheForTests();
   });
 
   it("should register 2 application tools", () => {
@@ -39,5 +43,52 @@ describe("registerApplicationTools", () => {
       expect(metadata.annotations?.readOnlyHint).toBe(true);
       expect(metadata.annotations?.destructiveHint).toBe(false);
     }
+  });
+
+  describe("boond_application_dictionary", () => {
+    function getDictionaryHandler() {
+      registerApplicationTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_application_dictionary");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return call![2] as any;
+    }
+
+    it("extracts the requested sub-path from the cached dictionary", async () => {
+      vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: {
+          setting: {
+            state: { resource: [{ id: 1, value: "Actif" }] },
+            tool: [{ id: 42, value: "Java" }],
+          },
+        },
+      } as never);
+      const handler = getDictionaryHandler();
+      const result = await handler({ dictionaryType: "setting.state.resource" });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Actif");
+      expect(result.content[0].text).toContain("1");
+    });
+
+    it("hits the API once across multiple invocations (caching)", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: { state: { resource: [], candidate: [] } } },
+      } as never);
+      const handler = getDictionaryHandler();
+      await handler({ dictionaryType: "setting.state.resource" });
+      await handler({ dictionaryType: "setting.state.candidate" });
+      await handler({ dictionaryType: "setting.state.resource" });
+      expect(apiSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns isError=true with a hint when the path is unknown", async () => {
+      vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: { setting: {} },
+      } as never);
+      const handler = getDictionaryHandler();
+      const result = await handler({ dictionaryType: "states/resources" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/states\/resources/);
+      expect(result.content[0].text).toMatch(/setting\.state\.resource/);
+    });
   });
 });

--- a/src/tools/application.ts
+++ b/src/tools/application.ts
@@ -1,7 +1,17 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { DictionaryGetSchema } from "../schemas/index.js";
 import type { DictionaryGetInput } from "../schemas/index.js";
+import { CHARACTER_LIMIT } from "../constants.js";
 import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { getDictionary, resolveDictionaryPath } from "../services/dictionary.js";
+
+function formatDictionaryNode(node: unknown): string {
+  const text = JSON.stringify(node, null, 2);
+  if (text.length > CHARACTER_LIMIT) {
+    return text.substring(0, CHARACTER_LIMIT) + "\n\n[Résultat tronqué...]";
+  }
+  return text;
+}
 
 export function registerApplicationTools(server: McpServer): void {
   // Get dictionary
@@ -9,24 +19,29 @@ export function registerApplicationTools(server: McpServer): void {
     "boond_application_dictionary",
     {
       title: "Récupérer un dictionnaire BoondManager",
-      description: `Récupère un dictionnaire de référence de l'application BoondManager (types d'actions, types d'absences, états des entités, pays, devises, langues...).
+      description: `Récupère un dictionnaire de référence BoondManager (états, types, pays, devises, langues, outils, expertises, ...).
+
+L'API expose un seul endpoint \`/application/dictionary\` qui renvoie tout — le serveur le cache (TTL 1h, configurable via \`BOOND_DICTIONARY_TTL_MS\`) et extrait un sous-arbre par chemin dotté.
 
 Args:
-  - dictionaryType (string): Type de dictionnaire. Exemples :
-    - "typeOf/actions" : types d'actions
-    - "typeOf/absences" : types d'absences
-    - "typeOf/expenses" : types de frais
-    - "states/candidates" : états des candidats
-    - "states/resources" : états des ressources
-    - "states/opportunities" : états des opportunités
-    - "states/projects" : états des projets
-    - "states/invoices" : états des factures
-    - "states/orders" : états des bons de commande
-    - "countries" : liste des pays
-    - "currencies" : liste des devises
-    - "languages" : liste des langues
+  - dictionaryType (string): Chemin dans la réponse (relatif à \`data\`). Exemples :
+    - "setting.state.{resource,candidate,contact,company,opportunity,project,invoice,order,positioning}" → états par entité
+    - "setting.typeOf.{resource,contact,project}" → types par entité
+    - "setting.action.{candidate,resource,opportunity,project,...}" → actions disponibles
+    - "setting.tool" → outils / technos (Java, AWS...)
+    - "setting.expertiseArea" → domaines d'expertise
+    - "setting.experience" → niveaux d'expérience
+    - "setting.languageSpoken" → langues parlées
+    - "setting.activityArea" → secteurs d'activité
+    - "setting.mobilityArea" → mobilités géographiques
+    - "setting.currency" → devises
+    - "setting.civility" → civilités
+    - "country" → pays
+    - "languages" → langues d'interface (fr, en, es)
 
-Returns: Données du dictionnaire (clé/valeur).`,
+Note : l'ancienne forme "states/resources" (slash) n'est pas valide — utilisez "setting.state.resource".
+
+Retourne le sous-arbre (souvent un tableau \`{id, value, ...}\`) ou \`isError: true\` si le chemin est introuvable.`,
       inputSchema: DictionaryGetSchema,
       annotations: {
         readOnlyHint: true,
@@ -36,10 +51,21 @@ Returns: Données du dictionnaire (clé/valeur).`,
       },
     },
     async (params: DictionaryGetInput) => {
-      const response = await apiRequest(`/application/dictionaries/${params.dictionaryType}`);
-      const text = formatDetailResponse(response);
+      const { payload } = await getDictionary();
+      const node = resolveDictionaryPath(payload, params.dictionaryType);
+      if (node === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Chemin "${params.dictionaryType}" introuvable dans le dictionnaire BoondManager. Les chemins sont relatifs à \`data\` (ex: "setting.state.resource", "country"). Note: "states/resources" (slash) n'est pas un chemin valide ; utilisez "setting.state.resource".`,
+            },
+          ],
+          isError: true,
+        };
+      }
       return {
-        content: [{ type: "text" as const, text }],
+        content: [{ type: "text" as const, text: formatDictionaryNode(node) }],
       };
     }
   );


### PR DESCRIPTION
## Summary

- Fixe le 404 systématique sur `boond_application_dictionary` et toutes les ressources `boond://dictionary/*` — la cause de "Failed to attach resource" dans Claude Desktop.
- Le code appelait `/application/dictionaries/{slug}` (pluriel, inexistant) ; l'API expose en réalité un endpoint unique `/application/dictionary` (singulier) qui renvoie tout l'arbre `data.setting.*` / `data.country` / `data.languages`.
- Cache mémoire (TTL 1h, configurable via `BOOND_DICTIONARY_TTL_MS`) avec déduplication des fetches concurrents — un seul appel HTTP au lieu d'un par lecture.
- Ressources recalibrées : retiré 4 slugs qui ne mappaient sur rien (`states/absences`, `typeOf/candidates`, `typeOf/actions`, `typeOf/absences`), ajouté 5 utiles (`tools`, `expertiseAreas`, `experiences`, `activityAreas`, `mobilityAreas`). Total 21 (vs 20).
- Versions bumped à 1.7.3 partout.

## Test plan

- [x] `npm test` — 401 tests pass (10 nouveaux pour le service dictionary + tool extraction)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run docs:tools:check` — TOOLS.md à jour (21 ressources)
- [ ] À vérifier après release : tester l'attachement d'une ressource `boond://dictionary/states/resources` dans Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)