### PR TITLE
chore: release v1.7.4 — manifest prompts_generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.7.4] - 2026-05-03
+
+Hotfix metadata du bundle `.mcpb` : ajoute la déclaration `prompts_generated: true` au `manifest.json` pour que Claude Desktop accepte les 11 prompts dynamiques.
+
+### Corrigé
+
+- **`manifest.json` — `prompts_generated: true`** — sans cette déclaration, Claude Desktop loggait `[warn] Extension BoondManager MCP Server attempted undeclared prompt: synthese_equipe` à chaque tentative d'attachement de prompt et bloquait l'appel `prompts/get` **côté client** (1 ms après émission, jamais reçu par le serveur). Symptôme côté UI : "Failed to attach prompt. You can try again." Le manifest avait déjà `tools_generated: true` pour les 156 outils générés dynamiquement ; le pendant pour les prompts manquait simplement. Cf. [spec MCPB MANIFEST.md](https://github.com/anthropics/mcpb/blob/main/MANIFEST.md) — un client conforme "should only look for tools/prompts present in the manifest.json" sauf si les flags `*_generated: true` sont posés.
+
+### Aucune rupture
+
+- Aucun changement de code (TypeScript inchangé). Seuls `manifest.json`, `package.json`, `server.json` et `package-lock.json` sont touchés. **Tous les utilisateurs ayant installé un `.mcpb` v1.7.3 ou antérieur doivent réinstaller** pour pouvoir attacher les prompts (`synthese_equipe`, `pipeline_commercial`, `staffing_disponible`, etc.) dans Claude Desktop.
+
 ## [1.7.3] - 2026-05-03
 
 Hotfix critique de l'outil `boond_application_dictionary` et des ressources `boond://dictionary/*` : depuis l'origine, ces deux surfaces appelaient un endpoint qui n'existe pas (`/application/dictionaries/{slug}`, pluriel) et retournaient systématiquement un **404 BoondManager**, ce qui bloquait notamment l'attachement de ressources dans Claude Desktop ("Failed to attach resource"). L'API officielle expose en réalité un endpoint unique `/application/dictionary` (singulier) qui renvoie l'intégralité des dictionnaires en une seule réponse, structurée en `data.setting.*`, `data.country`, `data.languages`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",
@@ -84,6 +84,7 @@
     }
   },
   "tools_generated": true,
+  "prompts_generated": true,
   "keywords": ["boondmanager", "esn", "crm", "erp", "candidates", "resources", "mcp"],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 156 tools, 11 prompts, 21 resources (ERP/CRM)",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.7.3/boondmanager-mcp-server-v1.7.3.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.7.4/boondmanager-mcp-server-v1.7.4.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Fix : "Failed to attach prompt" dans Claude Desktop. Le manifest n'avait pas `prompts_generated: true` (le pendant de `tools_generated: true` déjà présent), donc Claude Desktop bloquait \`prompts/get\` côté client avec un warning "attempted undeclared prompt".

Cf. [MCPB MANIFEST.md spec](https://github.com/anthropics/mcpb/blob/main/MANIFEST.md) — sans le flag, un client conforme ignore les prompts non listés statiquement.

## Test plan

- [x] `npm test` (401/401)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Après release : réinstaller le `.mcpb` v1.7.4, attacher un prompt (`synthese_equipe`) → doit ne plus afficher "Failed to attach prompt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)