### PR TITLE
Add stricter search schemas and error handling

### DIFF
--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -297,18 +297,30 @@ describe("ResourceTimesheetSchema", () => {
 });
 
 describe("TimesheetSearchSchema", () => {
-  it("should accept empty search with defaults", () => {
-    const result = TimesheetSearchSchema.parse({});
-    expect(result.page).toBe(1);
-    expect(result.pageSize).toBe(30);
+  it("should require startMonth and endMonth", () => {
+    // The /times-reports endpoint returns 422 when these are missing, so the
+    // schema enforces them at the boundary.
+    const result = TimesheetSearchSchema.safeParse({});
+    expect(result.success).toBe(false);
   });
 
-  it("should accept date range", () => {
-    const result = TimesheetSearchSchema.safeParse({
-      startDate: "2025-01-01",
-      endDate: "2025-12-31",
+  it("should accept a YYYY-MM range and apply pagination defaults", () => {
+    const result = TimesheetSearchSchema.parse({
+      startMonth: "2025-01",
+      endMonth: "2025-12",
     });
-    expect(result.success).toBe(true);
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(30);
+    expect(result.startMonth).toBe("2025-01");
+    expect(result.endMonth).toBe("2025-12");
+  });
+
+  it("should reject YYYY-MM-DD form", () => {
+    const result = TimesheetSearchSchema.safeParse({
+      startMonth: "2025-01-01",
+      endMonth: "2025-12-31",
+    });
+    expect(result.success).toBe(false);
   });
 });
 
@@ -484,7 +496,7 @@ describe("ExpenseCreateSchema", () => {
     const result = ExpenseCreateSchema.safeParse({
       resourceId: "123",
       expenseDate: "2025-06-15",
-      amount: 45.50,
+      amount: 45.5,
     });
     expect(result.success).toBe(true);
   });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -2,19 +2,43 @@ import { z } from "zod";
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
 
 // Common search schema
-export const SearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche (nom, email, compétences...)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
-    .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
-}).strict();
+export const SearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche (nom, email, compétences...)"),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_SEARCH_PAGE)
+      .default(1)
+      .describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
 
 // ---- Reusable filter field helpers ----
 // IMPORTANT: input field names below MUST match the BoondManager API query parameter names
 // exactly (e.g., perimeterManagers, resourceStates, opportunityStates). buildSearchQuery
 // passes them through as `key[]=value` for arrays. See https://doc.boondmanager.com/api-externe/
-const pageField = z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`);
-const pageSizeField = z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
+const pageField = z
+  .number()
+  .int()
+  .min(1)
+  .max(MAX_SEARCH_PAGE)
+  .default(1)
+  .describe(`Numéro de page (défaut: 1, max: ${MAX_SEARCH_PAGE})`);
+const pageSizeField = z
+  .number()
+  .int()
+  .min(1)
+  .max(MAX_PAGE_SIZE)
+  .default(DEFAULT_PAGE_SIZE)
   .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`);
 const sortField = z.string().optional().describe("Champ de tri (ex: lastName, firstName, updateDate)");
 const orderField = z.enum(["asc", "desc"]).optional().describe("Ordre de tri (asc/desc)");
@@ -24,721 +48,1050 @@ const strArray = (doc: string) => z.array(z.string()).optional().describe(doc);
 // Shared "perimeter" filters available on every entity search (from RAML trait `searchable`).
 // These are the CORRECT filters for "my team / my agency / my N-1" — NOT the old `mainManagers`.
 const perimeterManagersField = intArray(
-  "IDs des managers (ressources). Conserve les entités dont le responsable est l'un de ces managers. "
-  + "Pour 'mon équipe / N-1 d'une personne X', passer [X_id]. Obtenir son propre ID via boond_application_current_user."
+  "IDs des managers (ressources). Conserve les entités dont le responsable est l'un de ces managers. " +
+    "Pour 'mon équipe / N-1 d'une personne X', passer [X_id]. Obtenir son propre ID via boond_application_current_user."
 );
-const perimeterAgenciesField = intArray("IDs d'agences. Conserve les entités dont le responsable appartient à ces agences.");
+const perimeterAgenciesField = intArray(
+  "IDs d'agences. Conserve les entités dont le responsable appartient à ces agences."
+);
 const perimeterPolesField = intArray("IDs de pôles. Conserve les entités dont le responsable appartient à ces pôles.");
-const perimeterBusinessUnitsField = intArray("IDs de business units. Conserve les entités dont le responsable appartient à ces BU.");
-const perimeterDynamicField = z.array(
-  z.enum(["data", "agencies", "poles", "businessUnits", "managers"])
-).optional().describe(
-  "Périmètre dynamique relatif à l'utilisateur courant (raccourci sans avoir à connaître son propre ID). "
-  + "Valeurs : 'data' (mes propres données), 'managers' (mon équipe / mes N-1), 'agencies' (mes agences), "
-  + "'poles' (mes pôles), 'businessUnits' (mes BU). Combinable."
+const perimeterBusinessUnitsField = intArray(
+  "IDs de business units. Conserve les entités dont le responsable appartient à ces BU."
 );
-const narrowPerimeterField = z.boolean().optional().describe(
-  "Si true, jointure ET entre les filtres `perimeter*` (au lieu de OU par défaut)."
-);
-const startDateField = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional()
+const perimeterDynamicField = z
+  .array(z.enum(["data", "agencies", "poles", "businessUnits", "managers"]))
+  .optional()
+  .describe(
+    "Périmètre dynamique relatif à l'utilisateur courant (raccourci sans avoir à connaître son propre ID). " +
+      "Valeurs : 'data' (mes propres données), 'managers' (mon équipe / mes N-1), 'agencies' (mes agences), " +
+      "'poles' (mes pôles), 'businessUnits' (mes BU). Combinable."
+  );
+const narrowPerimeterField = z
+  .boolean()
+  .optional()
+  .describe("Si true, jointure ET entre les filtres `perimeter*` (au lieu de OU par défaut).");
+const startDateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .optional()
   .describe("Date de début (YYYY-MM-DD), à utiliser avec `period`.");
-const endDateField = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional()
+const endDateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .optional()
   .describe("Date de fin (YYYY-MM-DD), à utiliser avec `period`.");
 
 // ---- Resource search schema (collaborateurs internes) ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/resources/search.raml
-export const ResourceSearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés (par défaut, recherche dans CV + dossier technique). Pour cibler un champ précis, "
-    + "fournir aussi `keywordsType` (ex: lastName, firstName, fullName, emails, title, titleSkills, phones, reference)."
-  ),
-  keywordsType: z.enum([
-    "resumeTd", "lastName", "firstName", "fullName", "strictFullName",
-    "emails", "title", "titleSkills", "phones", "reference", "resume", "td",
-  ]).optional().describe(
-    "Champ ciblé par `keywords`. Défaut: 'resumeTd' (CV + dossier technique). "
-    + "Pour 'fullName' utiliser `keywords = 'NOM#PRENOM'`."
-  ),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  narrowPerimeter: narrowPerimeterField,
-  resourceStates: intArray(
-    "IDs d'états de ressource (dictionnaire setting.state.resource via boond_application_dictionary)."
-  ),
-  excludeResourceStates: intArray("IDs d'états de ressource à EXCLURE."),
-  resourceTypes: intArray(
-    "IDs de types de ressource (dictionnaire setting.typeOf.resource)."
-  ),
-  excludeResourceTypes: intArray("IDs de types de ressource à EXCLURE."),
-  activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
-  expertiseAreas: strArray("IDs de domaines d'expertise (dictionnaire setting.expertiseArea)."),
-  tools: strArray(
-    "IDs d'outils/technos (dictionnaire setting.tool). Logique OU par défaut. "
-    + "Pour ET, ajouter '#AND#' en 1er élément: tools=['#AND#','12','34']."
-  ),
-  experiences: intArray("IDs de niveaux d'expérience (dictionnaire setting.experience)."),
-  trainings: strArray("IDs de formations (dictionnaire setting.training)."),
-  mobilityAreas: strArray("IDs de zones de mobilité (dictionnaire setting.mobilityArea)."),
-  languages: strArray(
-    "Langues parlées au format `langueId|niveauId` (dictionnaires setting.languageSpoken et setting.languageLevel). Ex: ['anglais|courant']."
-  ),
-  flags: intArray("IDs de tags (drapeaux) attachés à la ressource."),
-  period: z.string().optional().describe(
-    "Champ temporel pour filtrer par période. Valeurs courantes: 'available' (disponibilité), "
-    + "'working' (en mission hors interne), 'workingAll', 'absent', 'idle', 'hired', 'left', "
-    + "'employed', 'unemployed', 'updated', 'arrival', 'birthday', 'seniority', 'present', "
-    + "'noAction'/'withActions'/'withoutActions'/'withAbsences'/'withoutAbsences'. "
-    + "À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  providerCompanies: intArray("IDs de sociétés sous-traitantes (filtre pour ressources externes)."),
-  coordinates: z.string().optional().describe(
-    "Coordonnées GPS 'latitude,longitude' pour recherche géographique. À combiner avec `geoDistance`."
-  ),
-  location: z.string().optional().describe(
-    "Adresse texte (ville, etc.) pour recherche géographique. À combiner avec `geoDistance`."
-  ),
-  geoDistance: z.number().int().min(5).max(200).optional().describe(
-    "Rayon en km pour la recherche géographique (5-200). Requis si `coordinates` ou `location` est fourni."
-  ),
-  excludeManager: z.boolean().optional().describe("Si true, ne retourne que les ressources sans compte manager."),
-  shields: z.array(z.enum(["uncomplete", "minimum", "complete"])).optional()
-    .describe("Niveau de complétude des champs conditionnels."),
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const ResourceSearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe(
+        "Mots-clés (par défaut, recherche dans CV + dossier technique). Pour cibler un champ précis, " +
+          "fournir aussi `keywordsType` (ex: lastName, firstName, fullName, emails, title, titleSkills, phones, reference)."
+      ),
+    keywordsType: z
+      .enum([
+        "resumeTd",
+        "lastName",
+        "firstName",
+        "fullName",
+        "strictFullName",
+        "emails",
+        "title",
+        "titleSkills",
+        "phones",
+        "reference",
+        "resume",
+        "td",
+      ])
+      .optional()
+      .describe(
+        "Champ ciblé par `keywords`. Défaut: 'resumeTd' (CV + dossier technique). " +
+          "Pour 'fullName' utiliser `keywords = 'NOM#PRENOM'`."
+      ),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    narrowPerimeter: narrowPerimeterField,
+    resourceStates: intArray(
+      "IDs d'états de ressource (dictionnaire setting.state.resource via boond_application_dictionary)."
+    ),
+    excludeResourceStates: intArray("IDs d'états de ressource à EXCLURE."),
+    resourceTypes: intArray("IDs de types de ressource (dictionnaire setting.typeOf.resource)."),
+    excludeResourceTypes: intArray("IDs de types de ressource à EXCLURE."),
+    activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
+    expertiseAreas: strArray("IDs de domaines d'expertise (dictionnaire setting.expertiseArea)."),
+    tools: strArray(
+      "IDs d'outils/technos (dictionnaire setting.tool). Logique OU par défaut. " +
+        "Pour ET, ajouter '#AND#' en 1er élément: tools=['#AND#','12','34']."
+    ),
+    experiences: intArray("IDs de niveaux d'expérience (dictionnaire setting.experience)."),
+    trainings: strArray("IDs de formations (dictionnaire setting.training)."),
+    mobilityAreas: strArray("IDs de zones de mobilité (dictionnaire setting.mobilityArea)."),
+    languages: strArray(
+      "Langues parlées au format `langueId|niveauId` (dictionnaires setting.languageSpoken et setting.languageLevel). Ex: ['anglais|courant']."
+    ),
+    flags: intArray("IDs de tags (drapeaux) attachés à la ressource."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Champ temporel pour filtrer par période. Valeurs courantes: 'available' (disponibilité), " +
+          "'working' (en mission hors interne), 'workingAll', 'absent', 'idle', 'hired', 'left', " +
+          "'employed', 'unemployed', 'updated', 'arrival', 'birthday', 'seniority', 'present', " +
+          "'noAction'/'withActions'/'withoutActions'/'withAbsences'/'withoutAbsences'. " +
+          "À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    providerCompanies: intArray("IDs de sociétés sous-traitantes (filtre pour ressources externes)."),
+    coordinates: z
+      .string()
+      .optional()
+      .describe("Coordonnées GPS 'latitude,longitude' pour recherche géographique. À combiner avec `geoDistance`."),
+    location: z
+      .string()
+      .optional()
+      .describe("Adresse texte (ville, etc.) pour recherche géographique. À combiner avec `geoDistance`."),
+    geoDistance: z
+      .number()
+      .int()
+      .min(5)
+      .max(200)
+      .optional()
+      .describe(
+        "Rayon en km pour la recherche géographique (5-200). Requis si `coordinates` ou `location` est fourni."
+      ),
+    excludeManager: z.boolean().optional().describe("Si true, ne retourne que les ressources sans compte manager."),
+    shields: z
+      .array(z.enum(["uncomplete", "minimum", "complete"]))
+      .optional()
+      .describe("Niveau de complétude des champs conditionnels."),
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ---- Candidate search schema ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/candidates/search.raml
-export const CandidateSearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés (par défaut, recherche dans CV + dossier technique). Combinable avec `keywordsType`."
-  ),
-  keywordsType: z.enum([
-    "resumeTd", "lastName", "firstName", "fullName", "strictFullName",
-    "emails", "title", "titleSkills", "phones", "reference", "resume", "td",
-  ]).optional().describe("Champ ciblé par `keywords` (défaut: 'resumeTd')."),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  perimeterManagersType: z.enum(["main", "hr"]).optional().describe(
-    "Type de responsable visé par `perimeterManagers`: 'main' (Main Manager) ou 'hr' (HR Manager)."
-  ),
-  narrowPerimeter: narrowPerimeterField,
-  candidateStates: intArray(
-    "IDs d'états de candidat (dictionnaire setting.state.candidate via boond_application_dictionary)."
-  ),
-  candidateTypes: intArray("IDs de types de candidat (dictionnaire setting.typeOf.resource)."),
-  contractTypes: intArray("IDs de types de contrat recherchés (dictionnaire setting.typeOf.contract)."),
-  availabilityTypes: intArray("IDs de types de disponibilité (dictionnaire setting.availability)."),
-  activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
-  expertiseAreas: strArray("IDs de domaines d'expertise."),
-  tools: strArray(
-    "IDs d'outils/technos. Logique OU par défaut. Pour ET, ajouter '#AND#' en 1er élément."
-  ),
-  experiences: intArray("IDs de niveaux d'expérience."),
-  trainings: strArray("IDs de formations."),
-  mobilityAreas: strArray("IDs de zones de mobilité."),
-  languages: strArray("Langues au format `langueId|niveauId` (ex: ['anglais|courant'])."),
-  evaluations: strArray("IDs d'évaluations."),
-  sources: strArray("IDs de sources de recrutement (dictionnaire setting.source)."),
-  flags: intArray("IDs de tags."),
-  period: z.string().optional().describe(
-    "Filtre temporel : 'created', 'updated', 'available', "
-    + "'noAction'/'withActions'/'withoutActions'. À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  providerCompanies: intArray("IDs de sociétés sous-traitantes."),
-  coordinates: z.string().optional().describe("Coordonnées GPS 'lat,lon'. Requiert `geoDistance`."),
-  location: z.string().optional().describe("Adresse texte. Requiert `geoDistance`."),
-  geoDistance: z.number().int().min(5).max(200).optional().describe("Rayon km (5-200)."),
-  shields: z.array(z.enum(["uncomplete", "minimum", "complete"])).optional()
-    .describe("Niveau de complétude."),
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const CandidateSearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe("Mots-clés (par défaut, recherche dans CV + dossier technique). Combinable avec `keywordsType`."),
+    keywordsType: z
+      .enum([
+        "resumeTd",
+        "lastName",
+        "firstName",
+        "fullName",
+        "strictFullName",
+        "emails",
+        "title",
+        "titleSkills",
+        "phones",
+        "reference",
+        "resume",
+        "td",
+      ])
+      .optional()
+      .describe("Champ ciblé par `keywords` (défaut: 'resumeTd')."),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    perimeterManagersType: z
+      .enum(["main", "hr"])
+      .optional()
+      .describe("Type de responsable visé par `perimeterManagers`: 'main' (Main Manager) ou 'hr' (HR Manager)."),
+    narrowPerimeter: narrowPerimeterField,
+    candidateStates: intArray(
+      "IDs d'états de candidat (dictionnaire setting.state.candidate via boond_application_dictionary)."
+    ),
+    candidateTypes: intArray("IDs de types de candidat (dictionnaire setting.typeOf.resource)."),
+    contractTypes: intArray("IDs de types de contrat recherchés (dictionnaire setting.typeOf.contract)."),
+    availabilityTypes: intArray("IDs de types de disponibilité (dictionnaire setting.availability)."),
+    activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
+    expertiseAreas: strArray("IDs de domaines d'expertise."),
+    tools: strArray("IDs d'outils/technos. Logique OU par défaut. Pour ET, ajouter '#AND#' en 1er élément."),
+    experiences: intArray("IDs de niveaux d'expérience."),
+    trainings: strArray("IDs de formations."),
+    mobilityAreas: strArray("IDs de zones de mobilité."),
+    languages: strArray("Langues au format `langueId|niveauId` (ex: ['anglais|courant'])."),
+    evaluations: strArray("IDs d'évaluations."),
+    sources: strArray("IDs de sources de recrutement (dictionnaire setting.source)."),
+    flags: intArray("IDs de tags."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Filtre temporel : 'created', 'updated', 'available', " +
+          "'noAction'/'withActions'/'withoutActions'. À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    providerCompanies: intArray("IDs de sociétés sous-traitantes."),
+    coordinates: z.string().optional().describe("Coordonnées GPS 'lat,lon'. Requiert `geoDistance`."),
+    location: z.string().optional().describe("Adresse texte. Requiert `geoDistance`."),
+    geoDistance: z.number().int().min(5).max(200).optional().describe("Rayon km (5-200)."),
+    shields: z
+      .array(z.enum(["uncomplete", "minimum", "complete"]))
+      .optional()
+      .describe("Niveau de complétude."),
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ---- Contact search schema ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/contacts/search.raml
-export const ContactSearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés (défaut: nom + prénom + société + fonction + périmètre technique). "
-    + "Combinable avec `keywordsType`."
-  ),
-  keywordsType: z.enum([
-    "default", "lastName", "firstName", "fullName", "strictFullName",
-    "companyFullName", "emails", "phones", "socialNetworks",
-  ]).optional().describe(
-    "Champ ciblé. Défaut: 'default'. Pour 'fullName' utiliser `keywords = 'NOM#PRENOM'`. "
-    + "Pour 'companyFullName' utiliser `keywords = 'CSOCid#NOM#PRENOM'`."
-  ),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  narrowPerimeter: narrowPerimeterField,
-  states: intArray("IDs d'états de contact (dictionnaire setting.state.contact)."),
-  companyStates: intArray("IDs d'états des sociétés rattachées (dictionnaire setting.state.company)."),
-  typesOf: intArray(
-    "IDs de types de contact (dictionnaire setting.typeOf.contact). "
-    + "⚠️ Le paramètre s'appelle `typesOf` (avec un 's'), PAS `typeOf`."
-  ),
-  origins: strArray("IDs d'origines (dictionnaire setting.origin)."),
-  activityAreas: strArray("IDs de secteurs d'activité de la société."),
-  expertiseAreas: strArray("IDs de domaines d'expertise de la société."),
-  tools: strArray("IDs d'outils. Logique OU par défaut, '#AND#' en 1er pour ET."),
-  influencers: intArray("IDs de contacts influenceurs."),
-  flags: intArray("IDs de tags."),
-  period: z.string().optional().describe(
-    "Filtre temporel : 'created', 'updated', 'noAction'/'withActions'/'withoutActions'. "
-    + "À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  completeness: strArray(
-    "Filtre par complétude des champs au format `fieldId:mode` (fieldId: email/phone/socialNetworks ; "
-    + "mode: empty/filled). Logique OU par défaut, '#AND#' en 1er pour ET. Ex: ['email:empty','phone:empty']."
-  ),
-  shields: z.array(z.enum(["uncomplete", "minimum", "complete"])).optional()
-    .describe("Niveau de complétude."),
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const ContactSearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe(
+        "Mots-clés (défaut: nom + prénom + société + fonction + périmètre technique). " +
+          "Combinable avec `keywordsType`."
+      ),
+    keywordsType: z
+      .enum([
+        "default",
+        "lastName",
+        "firstName",
+        "fullName",
+        "strictFullName",
+        "companyFullName",
+        "emails",
+        "phones",
+        "socialNetworks",
+      ])
+      .optional()
+      .describe(
+        "Champ ciblé. Défaut: 'default'. Pour 'fullName' utiliser `keywords = 'NOM#PRENOM'`. " +
+          "Pour 'companyFullName' utiliser `keywords = 'CSOCid#NOM#PRENOM'`."
+      ),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    narrowPerimeter: narrowPerimeterField,
+    states: intArray("IDs d'états de contact (dictionnaire setting.state.contact)."),
+    companyStates: intArray("IDs d'états des sociétés rattachées (dictionnaire setting.state.company)."),
+    typesOf: intArray(
+      "IDs de types de contact (dictionnaire setting.typeOf.contact). " +
+        "⚠️ Le paramètre s'appelle `typesOf` (avec un 's'), PAS `typeOf`."
+    ),
+    origins: strArray("IDs d'origines (dictionnaire setting.origin)."),
+    activityAreas: strArray("IDs de secteurs d'activité de la société."),
+    expertiseAreas: strArray("IDs de domaines d'expertise de la société."),
+    tools: strArray("IDs d'outils. Logique OU par défaut, '#AND#' en 1er pour ET."),
+    influencers: intArray("IDs de contacts influenceurs."),
+    flags: intArray("IDs de tags."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Filtre temporel : 'created', 'updated', 'noAction'/'withActions'/'withoutActions'. " +
+          "À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    completeness: strArray(
+      "Filtre par complétude des champs au format `fieldId:mode` (fieldId: email/phone/socialNetworks ; " +
+        "mode: empty/filled). Logique OU par défaut, '#AND#' en 1er pour ET. Ex: ['email:empty','phone:empty']."
+    ),
+    shields: z
+      .array(z.enum(["uncomplete", "minimum", "complete"]))
+      .optional()
+      .describe("Niveau de complétude."),
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ---- Company search schema ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/companies/search.raml
-export const CompanySearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés (défaut: nom + ville + pays + expertise + informations). Combinable avec `keywordsType`."
-  ),
-  keywordsType: z.enum(["default", "name", "phones", "emails", "socialNetworks"]).optional()
-    .describe("Champ ciblé par `keywords`. Défaut: 'default'."),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  narrowPerimeter: narrowPerimeterField,
-  states: intArray("IDs d'états de société (dictionnaire setting.state.company)."),
-  expertiseAreas: strArray("IDs de domaines d'expertise (dictionnaire setting.expertiseArea)."),
-  origins: strArray("IDs d'origines (dictionnaire setting.origin)."),
-  influencers: intArray("IDs d'influenceurs."),
-  flags: intArray("IDs de tags."),
-  period: z.string().optional().describe(
-    "Filtre temporel : 'created', 'updated', 'noAction'/'withActions'/'withoutActions'. "
-    + "À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  shields: z.array(z.enum(["uncomplete", "minimum", "complete"])).optional()
-    .describe("Niveau de complétude."),
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const CompanySearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe("Mots-clés (défaut: nom + ville + pays + expertise + informations). Combinable avec `keywordsType`."),
+    keywordsType: z
+      .enum(["default", "name", "phones", "emails", "socialNetworks"])
+      .optional()
+      .describe("Champ ciblé par `keywords`. Défaut: 'default'."),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    narrowPerimeter: narrowPerimeterField,
+    states: intArray("IDs d'états de société (dictionnaire setting.state.company)."),
+    expertiseAreas: strArray("IDs de domaines d'expertise (dictionnaire setting.expertiseArea)."),
+    origins: strArray("IDs d'origines (dictionnaire setting.origin)."),
+    influencers: intArray("IDs d'influenceurs."),
+    flags: intArray("IDs de tags."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Filtre temporel : 'created', 'updated', 'noAction'/'withActions'/'withoutActions'. " +
+          "À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    shields: z
+      .array(z.enum(["uncomplete", "minimum", "complete"]))
+      .optional()
+      .describe("Niveau de complétude."),
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ---- Opportunity search schema ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/opportunities/search.raml
-export const OpportunitySearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés. Pour cibler par ID préfixé : 'AOnnn' (opportunité), 'CSOCnnn' (société), "
-    + "'CCONnnn' (contact), 'CANDnnn' (candidat), 'COMPnnn' (ressource), 'PRODnnn' (produit). "
-    + "Sinon recherche plein texte sur titre/société."
-  ),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  perimeterManagersType: z.enum(["main", "hr"]).optional()
-    .describe("Type de responsable visé par `perimeterManagers` (main/hr)."),
-  narrowPerimeter: narrowPerimeterField,
-  opportunityStates: intArray(
-    "IDs d'états d'opportunité (dictionnaire setting.state.opportunity)."
-  ),
-  opportunityTypes: strArray("IDs de types d'opportunité (dictionnaire setting.typeOf.project)."),
-  positioningStates: strArray(
-    "IDs d'états de positionnement, ou 'none' pour les opportunités sans positionnement."
-  ),
-  expertiseAreas: strArray("IDs de domaines d'expertise."),
-  activityAreas: strArray("IDs de secteurs d'activité."),
-  tools: strArray("IDs d'outils."),
-  places: strArray("IDs de zones (dictionnaire setting.mobilityArea)."),
-  durations: intArray("IDs de durées (dictionnaire setting.duration)."),
-  origins: strArray("IDs d'origines."),
-  flags: intArray("IDs de tags."),
-  period: z.string().optional().describe(
-    "Filtre temporel : 'created' (création), 'started', 'closingDate' (date de closing), "
-    + "'updated', 'updatedPositioning', 'noAction'/'withActions'/'withoutActions'. "
-    + "À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  shields: z.array(z.enum(["uncomplete", "minimum", "complete"])).optional()
-    .describe("Niveau de complétude."),
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const OpportunitySearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe(
+        "Mots-clés. Pour cibler par ID préfixé : 'AOnnn' (opportunité), 'CSOCnnn' (société), " +
+          "'CCONnnn' (contact), 'CANDnnn' (candidat), 'COMPnnn' (ressource), 'PRODnnn' (produit). " +
+          "Sinon recherche plein texte sur titre/société."
+      ),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    perimeterManagersType: z
+      .enum(["main", "hr"])
+      .optional()
+      .describe("Type de responsable visé par `perimeterManagers` (main/hr)."),
+    narrowPerimeter: narrowPerimeterField,
+    opportunityStates: intArray("IDs d'états d'opportunité (dictionnaire setting.state.opportunity)."),
+    opportunityTypes: strArray("IDs de types d'opportunité (dictionnaire setting.typeOf.project)."),
+    positioningStates: strArray("IDs d'états de positionnement, ou 'none' pour les opportunités sans positionnement."),
+    expertiseAreas: strArray("IDs de domaines d'expertise."),
+    activityAreas: strArray("IDs de secteurs d'activité."),
+    tools: strArray("IDs d'outils."),
+    places: strArray("IDs de zones (dictionnaire setting.mobilityArea)."),
+    durations: intArray("IDs de durées (dictionnaire setting.duration)."),
+    origins: strArray("IDs d'origines."),
+    flags: intArray("IDs de tags."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Filtre temporel : 'created' (création), 'started', 'closingDate' (date de closing), " +
+          "'updated', 'updatedPositioning', 'noAction'/'withActions'/'withoutActions'. " +
+          "À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    shields: z
+      .array(z.enum(["uncomplete", "minimum", "complete"]))
+      .optional()
+      .describe("Niveau de complétude."),
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ---- Project search schema ----
 // Source: https://doc.boondmanager.com/api-externe/raml-build/resources/projects/search.raml
-export const ProjectSearchSchema = z.object({
-  keywords: z.string().optional().describe(
-    "Mots-clés. Pour cibler par ID préfixé : 'PRJnnn' (projet), 'CSOCnnn' (société), "
-    + "'CCONnnn' (contact), 'AOnnn' (opportunité), 'COMPnnn' (ressource), 'CTRnnn' (contrat)."
-  ),
-  perimeterManagers: perimeterManagersField,
-  perimeterAgencies: perimeterAgenciesField,
-  perimeterPoles: perimeterPolesField,
-  perimeterBusinessUnits: perimeterBusinessUnitsField,
-  perimeterDynamic: perimeterDynamicField,
-  narrowPerimeter: narrowPerimeterField,
-  projectStates: intArray("IDs d'états de projet (dictionnaire setting.state.project)."),
-  projectTypes: intArray("IDs de types de projet (dictionnaire setting.typeOf.project)."),
-  companies: intArray("IDs de sociétés clientes : projets rattachés à ces sociétés."),
-  expertiseAreas: strArray("IDs de domaines d'expertise."),
-  activityAreas: strArray("IDs de secteurs d'activité."),
-  flags: intArray("IDs de tags."),
-  period: z.string().optional().describe(
-    "Filtre temporel : 'running' (en cours), 'created', 'started', 'stopped', 'closed', 'updated', "
-    + "'hasAdditionalDataOrPurchase'. À combiner avec `startDate` + `endDate`."
-  ),
-  startDate: startDateField,
-  endDate: endDateField,
-  sort: sortField,
-  order: orderField,
-  page: pageField,
-  pageSize: pageSizeField,
-}).strict();
+export const ProjectSearchSchema = z
+  .object({
+    keywords: z
+      .string()
+      .optional()
+      .describe(
+        "Mots-clés. Pour cibler par ID préfixé : 'PRJnnn' (projet), 'CSOCnnn' (société), " +
+          "'CCONnnn' (contact), 'AOnnn' (opportunité), 'COMPnnn' (ressource), 'CTRnnn' (contrat)."
+      ),
+    perimeterManagers: perimeterManagersField,
+    perimeterAgencies: perimeterAgenciesField,
+    perimeterPoles: perimeterPolesField,
+    perimeterBusinessUnits: perimeterBusinessUnitsField,
+    perimeterDynamic: perimeterDynamicField,
+    narrowPerimeter: narrowPerimeterField,
+    projectStates: intArray("IDs d'états de projet (dictionnaire setting.state.project)."),
+    projectTypes: intArray("IDs de types de projet (dictionnaire setting.typeOf.project)."),
+    companies: intArray("IDs de sociétés clientes : projets rattachés à ces sociétés."),
+    expertiseAreas: strArray("IDs de domaines d'expertise."),
+    activityAreas: strArray("IDs de secteurs d'activité."),
+    flags: intArray("IDs de tags."),
+    period: z
+      .string()
+      .optional()
+      .describe(
+        "Filtre temporel : 'running' (en cours), 'created', 'started', 'stopped', 'closed', 'updated', " +
+          "'hasAdditionalDataOrPurchase'. À combiner avec `startDate` + `endDate`."
+      ),
+    startDate: startDateField,
+    endDate: endDateField,
+    sort: sortField,
+    order: orderField,
+    page: pageField,
+    pageSize: pageSizeField,
+  })
+  .strict();
 
 // ID param schema
-export const IdSchema = z.object({
-  id: z.string().min(1).describe("Identifiant unique de l'entité BoondManager"),
-}).strict();
+export const IdSchema = z
+  .object({
+    id: z.string().min(1).describe("Identifiant unique de l'entité BoondManager"),
+  })
+  .strict();
 
 // ID + tab param schema
-export const IdTabSchema = z.object({
-  id: z.string().min(1).describe("Identifiant unique de l'entité"),
-  tab: z.string().optional().describe("Onglet spécifique à récupérer (information, technical, financial, actions, contracts, documents)"),
-}).strict();
+export const IdTabSchema = z
+  .object({
+    id: z.string().min(1).describe("Identifiant unique de l'entité"),
+    tab: z
+      .string()
+      .optional()
+      .describe("Onglet spécifique à récupérer (information, technical, financial, actions, contracts, documents)"),
+  })
+  .strict();
 
 // ---- Candidate schemas ----
 
-export const CandidateCreateSchema = z.object({
-  firstName: z.string().min(1).describe("Prénom du candidat"),
-  lastName: z.string().min(1).describe("Nom de famille du candidat"),
-  email1: z.string().email().optional().describe("Email principal"),
-  phone1: z.string().optional().describe("Téléphone principal"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  title: z.string().optional().describe("Titre du poste / fonction"),
-  state: z.number().int().optional().describe("État du candidat (0=en cours, 1=placé, 2=archivé...)"),
-  mainSkills: z.string().optional().describe("Compétences principales (texte libre)"),
-  note: z.string().optional().describe("Notes / commentaires"),
-}).strict();
+export const CandidateCreateSchema = z
+  .object({
+    firstName: z.string().min(1).describe("Prénom du candidat"),
+    lastName: z.string().min(1).describe("Nom de famille du candidat"),
+    email1: z.string().email().optional().describe("Email principal"),
+    phone1: z.string().optional().describe("Téléphone principal"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    title: z.string().optional().describe("Titre du poste / fonction"),
+    state: z.number().int().optional().describe("État du candidat (0=en cours, 1=placé, 2=archivé...)"),
+    mainSkills: z.string().optional().describe("Compétences principales (texte libre)"),
+    note: z.string().optional().describe("Notes / commentaires"),
+  })
+  .strict();
 
-export const CandidateUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID du candidat à modifier"),
-  firstName: z.string().optional().describe("Prénom"),
-  lastName: z.string().optional().describe("Nom"),
-  email1: z.string().email().optional().describe("Email principal"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  title: z.string().optional().describe("Titre / fonction"),
-  state: z.number().int().optional().describe("État du candidat"),
-  mainSkills: z.string().optional().describe("Compétences principales"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const CandidateUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du candidat à modifier"),
+    firstName: z.string().optional().describe("Prénom"),
+    lastName: z.string().optional().describe("Nom"),
+    email1: z.string().email().optional().describe("Email principal"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    title: z.string().optional().describe("Titre / fonction"),
+    state: z.number().int().optional().describe("État du candidat"),
+    mainSkills: z.string().optional().describe("Compétences principales"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Resource schemas ----
 
-export const ResourceCreateSchema = z.object({
-  firstName: z.string().min(1).describe("Prénom de la ressource/collaborateur"),
-  lastName: z.string().min(1).describe("Nom de famille"),
-  email1: z.string().email().optional().describe("Email principal"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  title: z.string().optional().describe("Titre / poste"),
-  state: z.number().int().optional().describe("État de la ressource"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const ResourceCreateSchema = z
+  .object({
+    firstName: z.string().min(1).describe("Prénom de la ressource/collaborateur"),
+    lastName: z.string().min(1).describe("Nom de famille"),
+    email1: z.string().email().optional().describe("Email principal"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    title: z.string().optional().describe("Titre / poste"),
+    state: z.number().int().optional().describe("État de la ressource"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
-export const ResourceUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de la ressource à modifier"),
-  firstName: z.string().optional().describe("Prénom"),
-  lastName: z.string().optional().describe("Nom"),
-  email1: z.string().email().optional().describe("Email principal"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  title: z.string().optional().describe("Titre / poste"),
-  state: z.number().int().optional().describe("État"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const ResourceUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de la ressource à modifier"),
+    firstName: z.string().optional().describe("Prénom"),
+    lastName: z.string().optional().describe("Nom"),
+    email1: z.string().email().optional().describe("Email principal"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    title: z.string().optional().describe("Titre / poste"),
+    state: z.number().int().optional().describe("État"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Contact schemas ----
 
-export const ContactCreateSchema = z.object({
-  firstName: z.string().min(1).describe("Prénom du contact"),
-  lastName: z.string().min(1).describe("Nom de famille"),
-  email1: z.string().email().optional().describe("Email principal"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  title: z.string().optional().describe("Titre / fonction"),
-  companyId: z.string().optional().describe("ID de la société associée"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const ContactCreateSchema = z
+  .object({
+    firstName: z.string().min(1).describe("Prénom du contact"),
+    lastName: z.string().min(1).describe("Nom de famille"),
+    email1: z.string().email().optional().describe("Email principal"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    title: z.string().optional().describe("Titre / fonction"),
+    companyId: z.string().optional().describe("ID de la société associée"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
-export const ContactUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID du contact à modifier"),
-  firstName: z.string().optional().describe("Prénom"),
-  lastName: z.string().optional().describe("Nom"),
-  email1: z.string().email().optional().describe("Email"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  title: z.string().optional().describe("Titre / fonction"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const ContactUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du contact à modifier"),
+    firstName: z.string().optional().describe("Prénom"),
+    lastName: z.string().optional().describe("Nom"),
+    email1: z.string().email().optional().describe("Email"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    title: z.string().optional().describe("Titre / fonction"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Company schemas ----
 
-export const CompanyCreateSchema = z.object({
-  name: z.string().min(1).describe("Nom de la société"),
-  email1: z.string().email().optional().describe("Email de la société"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  website: z.string().optional().describe("Site web"),
-  siret: z.string().optional().describe("Numéro SIRET"),
-  state: z.number().int().optional().describe("État de la société"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const CompanyCreateSchema = z
+  .object({
+    name: z.string().min(1).describe("Nom de la société"),
+    email1: z.string().email().optional().describe("Email de la société"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    website: z.string().optional().describe("Site web"),
+    siret: z.string().optional().describe("Numéro SIRET"),
+    state: z.number().int().optional().describe("État de la société"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
-export const CompanyUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de la société à modifier"),
-  name: z.string().optional().describe("Nom"),
-  email1: z.string().email().optional().describe("Email"),
-  phone1: z.string().optional().describe("Téléphone"),
-  city: z.string().optional().describe("Ville"),
-  country: z.string().optional().describe("Pays"),
-  website: z.string().optional().describe("Site web"),
-  siret: z.string().optional().describe("Numéro SIRET"),
-  state: z.number().int().optional().describe("État"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const CompanyUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de la société à modifier"),
+    name: z.string().optional().describe("Nom"),
+    email1: z.string().email().optional().describe("Email"),
+    phone1: z.string().optional().describe("Téléphone"),
+    city: z.string().optional().describe("Ville"),
+    country: z.string().optional().describe("Pays"),
+    website: z.string().optional().describe("Site web"),
+    siret: z.string().optional().describe("Numéro SIRET"),
+    state: z.number().int().optional().describe("État"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Opportunity schemas ----
 
-export const OpportunityCreateSchema = z.object({
-  name: z.string().min(1).describe("Nom / titre de l'opportunité"),
-  companyId: z.string().optional().describe("ID de la société cliente"),
-  contactId: z.string().optional().describe("ID du contact associé"),
-  state: z.number().int().optional().describe("État de l'opportunité"),
-  startDate: z.string().optional().describe("Date de début prévue (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin prévue (YYYY-MM-DD)"),
-  note: z.string().optional().describe("Notes / description"),
-}).strict();
+export const OpportunityCreateSchema = z
+  .object({
+    name: z.string().min(1).describe("Nom / titre de l'opportunité"),
+    companyId: z.string().optional().describe("ID de la société cliente"),
+    contactId: z.string().optional().describe("ID du contact associé"),
+    state: z.number().int().optional().describe("État de l'opportunité"),
+    startDate: z.string().optional().describe("Date de début prévue (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin prévue (YYYY-MM-DD)"),
+    note: z.string().optional().describe("Notes / description"),
+  })
+  .strict();
 
-export const OpportunityUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de l'opportunité à modifier"),
-  name: z.string().optional().describe("Nom / titre"),
-  state: z.number().int().optional().describe("État"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const OpportunityUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de l'opportunité à modifier"),
+    name: z.string().optional().describe("Nom / titre"),
+    state: z.number().int().optional().describe("État"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Action schemas ----
 
-export const ActionSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  candidateId: z.string().optional().describe("Filtrer par ID candidat"),
-  resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  contactId: z.string().optional().describe("Filtrer par ID contact"),
-  companyId: z.string().optional().describe("Filtrer par ID société"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const ActionSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    candidateId: z.string().optional().describe("Filtrer par ID candidat"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
+    contactId: z.string().optional().describe("Filtrer par ID contact"),
+    companyId: z.string().optional().describe("Filtrer par ID société"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
-export const ActionCreateSchema = z.object({
-  typeOf: z.string().min(1).describe("Type d'action (ex: call, email, meeting, note)"),
-  subject: z.string().optional().describe("Sujet de l'action"),
-  content: z.string().optional().describe("Contenu / description"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD ou ISO)"),
-  endDate: z.string().optional().describe("Date de fin"),
-  candidateId: z.string().optional().describe("ID du candidat associé"),
-  resourceId: z.string().optional().describe("ID de la ressource associée"),
-  contactId: z.string().optional().describe("ID du contact associé"),
-  companyId: z.string().optional().describe("ID de la société associée"),
-}).strict();
+export const ActionCreateSchema = z
+  .object({
+    typeOf: z.string().min(1).describe("Type d'action (ex: call, email, meeting, note)"),
+    subject: z.string().optional().describe("Sujet de l'action"),
+    content: z.string().optional().describe("Contenu / description"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD ou ISO)"),
+    endDate: z.string().optional().describe("Date de fin"),
+    candidateId: z.string().optional().describe("ID du candidat associé"),
+    resourceId: z.string().optional().describe("ID de la ressource associée"),
+    contactId: z.string().optional().describe("ID du contact associé"),
+    companyId: z.string().optional().describe("ID de la société associée"),
+  })
+  .strict();
 
 // ---- Timesheet schemas ----
 
-export const ResourceTimesheetSchema = z.object({
-  resourceId: z.string().min(1).describe("ID de la ressource"),
-  month: z.number().int().min(1).max(12).optional().describe("Mois (1-12). Si omis, mois courant."),
-  year: z.number().int().min(2000).optional().describe("Année (ex: 2025). Si omis, année courante."),
-}).strict();
+export const ResourceTimesheetSchema = z
+  .object({
+    resourceId: z.string().min(1).describe("ID de la ressource"),
+    month: z.number().int().min(1).max(12).optional().describe("Mois (1-12). Si omis, mois courant."),
+    year: z.number().int().min(2000).optional().describe("Année (ex: 2025). Si omis, année courante."),
+  })
+  .strict();
 
-export const TimesheetSearchSchema = z.object({
-  startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE)
-    .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
-}).strict();
+// `/times-reports` requires `startMonth` and `endMonth` in YYYY-MM form. Passing
+// YYYY-MM-DD or omitting them surfaces a 422 "Missing required attribute" from
+// the API, so the schema enforces both at the boundary.
+export const TimesheetSearchSchema = z
+  .object({
+    startMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Mois de début au format YYYY-MM (ex: '2025-01'). Requis."),
+    endMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Mois de fin au format YYYY-MM (ex: '2025-03'). Requis."),
+    keywords: z.string().optional().describe("Mots-clés (préfixes 'TPS', 'COMP'...)."),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
 
-export const TimesheetGetSchema = z.object({
-  id: z.string().min(1).describe("Identifiant unique de la feuille de temps"),
-}).strict();
+export const TimesheetGetSchema = z
+  .object({
+    id: z.string().min(1).describe("Identifiant unique de la feuille de temps"),
+  })
+  .strict();
 
 // ---- Project schemas ----
 
-export const ProjectCreateSchema = z.object({
-  name: z.string().min(1).describe("Nom du projet / mission"),
-  companyId: z.string().optional().describe("ID de la société cliente"),
-  contactId: z.string().optional().describe("ID du contact associé"),
-  opportunityId: z.string().optional().describe("ID de l'opportunité liée"),
-  state: z.number().int().optional().describe("État du projet (0=en cours, 1=terminé, 2=archivé...)"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  note: z.string().optional().describe("Notes / description du projet"),
-}).strict();
+export const ProjectCreateSchema = z
+  .object({
+    name: z.string().min(1).describe("Nom du projet / mission"),
+    companyId: z.string().optional().describe("ID de la société cliente"),
+    contactId: z.string().optional().describe("ID du contact associé"),
+    opportunityId: z.string().optional().describe("ID de l'opportunité liée"),
+    state: z.number().int().optional().describe("État du projet (0=en cours, 1=terminé, 2=archivé...)"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    note: z.string().optional().describe("Notes / description du projet"),
+  })
+  .strict();
 
-export const ProjectUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID du projet à modifier"),
-  name: z.string().optional().describe("Nom du projet"),
-  state: z.number().int().optional().describe("État du projet"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const ProjectUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du projet à modifier"),
+    name: z.string().optional().describe("Nom du projet"),
+    state: z.number().int().optional().describe("État du projet"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 // ---- Invoice schemas ----
 
-export const InvoiceCreateSchema = z.object({
-  reference: z.string().optional().describe("Référence de la facture"),
-  companyId: z.string().optional().describe("ID de la société facturée"),
-  projectId: z.string().optional().describe("ID du projet associé"),
-  state: z.number().int().optional().describe("État de la facture"),
-  invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
-  dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
-  amountExcludingTax: z.number().optional().describe("Montant HT"),
-  taxRate: z.number().optional().describe("Taux de TVA (%)"),
-  note: z.string().optional().describe("Notes / commentaires"),
-}).strict();
+export const InvoiceCreateSchema = z
+  .object({
+    reference: z.string().optional().describe("Référence de la facture"),
+    companyId: z.string().optional().describe("ID de la société facturée"),
+    projectId: z.string().optional().describe("ID du projet associé"),
+    state: z.number().int().optional().describe("État de la facture"),
+    invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
+    dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
+    amountExcludingTax: z.number().optional().describe("Montant HT"),
+    taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    note: z.string().optional().describe("Notes / commentaires"),
+  })
+  .strict();
 
-export const InvoiceUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de la facture à modifier"),
-  reference: z.string().optional().describe("Référence de la facture"),
-  state: z.number().int().optional().describe("État de la facture"),
-  invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
-  dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
-  amountExcludingTax: z.number().optional().describe("Montant HT"),
-  taxRate: z.number().optional().describe("Taux de TVA (%)"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const InvoiceUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de la facture à modifier"),
+    reference: z.string().optional().describe("Référence de la facture"),
+    state: z.number().int().optional().describe("État de la facture"),
+    invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
+    dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
+    amountExcludingTax: z.number().optional().describe("Montant HT"),
+    taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
-export const InvoiceSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche (référence, société...)"),
-  companyId: z.string().optional().describe("Filtrer par ID société"),
-  projectId: z.string().optional().describe("Filtrer par ID projet"),
-  startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
-  period: z.string().optional().describe("Type de période (created, updated, expectedPayment, performedPayment, period)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const InvoiceSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche (référence, société...)"),
+    companyId: z.string().optional().describe("Filtrer par ID société"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
+    period: z
+      .string()
+      .optional()
+      .describe("Type de période (created, updated, expectedPayment, performedPayment, period)"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Order schemas (Bons de commande) ----
 
-export const OrderCreateSchema = z.object({
-  reference: z.string().optional().describe("Référence du bon de commande"),
-  companyId: z.string().optional().describe("ID de la société"),
-  projectId: z.string().optional().describe("ID du projet associé"),
-  state: z.number().int().optional().describe("État du bon de commande"),
-  orderDate: z.string().optional().describe("Date du bon de commande (YYYY-MM-DD)"),
-  amountExcludingTax: z.number().optional().describe("Montant HT"),
-  note: z.string().optional().describe("Notes / commentaires"),
-}).strict();
+export const OrderCreateSchema = z
+  .object({
+    reference: z.string().optional().describe("Référence du bon de commande"),
+    companyId: z.string().optional().describe("ID de la société"),
+    projectId: z.string().optional().describe("ID du projet associé"),
+    state: z.number().int().optional().describe("État du bon de commande"),
+    orderDate: z.string().optional().describe("Date du bon de commande (YYYY-MM-DD)"),
+    amountExcludingTax: z.number().optional().describe("Montant HT"),
+    note: z.string().optional().describe("Notes / commentaires"),
+  })
+  .strict();
 
-export const OrderUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID du bon de commande à modifier"),
-  reference: z.string().optional().describe("Référence"),
-  state: z.number().int().optional().describe("État"),
-  orderDate: z.string().optional().describe("Date (YYYY-MM-DD)"),
-  amountExcludingTax: z.number().optional().describe("Montant HT"),
-  note: z.string().optional().describe("Notes"),
-}).strict();
+export const OrderUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du bon de commande à modifier"),
+    reference: z.string().optional().describe("Référence"),
+    state: z.number().int().optional().describe("État"),
+    orderDate: z.string().optional().describe("Date (YYYY-MM-DD)"),
+    amountExcludingTax: z.number().optional().describe("Montant HT"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
-export const OrderSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  companyId: z.string().optional().describe("Filtrer par ID société"),
-  projectId: z.string().optional().describe("Filtrer par ID projet"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const OrderSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    companyId: z.string().optional().describe("Filtrer par ID société"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Delivery schemas (Livraisons / CRA) ----
 
-export const DeliverySearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  projectId: z.string().optional().describe("Filtrer par ID projet"),
-  companyId: z.string().optional().describe("Filtrer par ID société"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const DeliverySearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    companyId: z.string().optional().describe("Filtrer par ID société"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Absence schemas ----
 
-export const AbsenceCreateSchema = z.object({
-  resourceId: z.string().min(1).describe("ID de la ressource en absence"),
-  typeOf: z.string().min(1).describe("Type d'absence (congé payé, RTT, maladie, sans solde...)"),
-  startDate: z.string().min(1).describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().min(1).describe("Date de fin (YYYY-MM-DD)"),
-  state: z.number().int().optional().describe("État de la demande (0=en attente, 1=validé, 2=refusé...)"),
-  note: z.string().optional().describe("Commentaire / motif"),
-}).strict();
+export const AbsenceCreateSchema = z
+  .object({
+    resourceId: z.string().min(1).describe("ID de la ressource en absence"),
+    typeOf: z.string().min(1).describe("Type d'absence (congé payé, RTT, maladie, sans solde...)"),
+    startDate: z.string().min(1).describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().min(1).describe("Date de fin (YYYY-MM-DD)"),
+    state: z.number().int().optional().describe("État de la demande (0=en attente, 1=validé, 2=refusé...)"),
+    note: z.string().optional().describe("Commentaire / motif"),
+  })
+  .strict();
 
-export const AbsenceUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de l'absence à modifier"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  state: z.number().int().optional().describe("État de la demande"),
-  note: z.string().optional().describe("Commentaire / motif"),
-}).strict();
+export const AbsenceUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de l'absence à modifier"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    state: z.number().int().optional().describe("État de la demande"),
+    note: z.string().optional().describe("Commentaire / motif"),
+  })
+  .strict();
 
-export const AbsenceSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const AbsenceSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
+    startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Expense schemas (Notes de frais) ----
 
-export const ExpenseCreateSchema = z.object({
-  resourceId: z.string().min(1).describe("ID de la ressource"),
-  projectId: z.string().optional().describe("ID du projet associé"),
-  typeOf: z.string().optional().describe("Type de frais (transport, repas, hébergement...)"),
-  expenseDate: z.string().min(1).describe("Date du frais (YYYY-MM-DD)"),
-  amount: z.number().describe("Montant du frais"),
-  currency: z.string().optional().describe("Devise (EUR, USD...)"),
-  state: z.number().int().optional().describe("État de la note de frais"),
-  note: z.string().optional().describe("Description / justification"),
-}).strict();
+export const ExpenseCreateSchema = z
+  .object({
+    resourceId: z.string().min(1).describe("ID de la ressource"),
+    projectId: z.string().optional().describe("ID du projet associé"),
+    typeOf: z.string().optional().describe("Type de frais (transport, repas, hébergement...)"),
+    expenseDate: z.string().min(1).describe("Date du frais (YYYY-MM-DD)"),
+    amount: z.number().describe("Montant du frais"),
+    currency: z.string().optional().describe("Devise (EUR, USD...)"),
+    state: z.number().int().optional().describe("État de la note de frais"),
+    note: z.string().optional().describe("Description / justification"),
+  })
+  .strict();
 
-export const ExpenseUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID de la note de frais à modifier"),
-  amount: z.number().optional().describe("Montant"),
-  state: z.number().int().optional().describe("État"),
-  note: z.string().optional().describe("Description"),
-}).strict();
+export const ExpenseUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de la note de frais à modifier"),
+    amount: z.number().optional().describe("Montant"),
+    state: z.number().int().optional().describe("État"),
+    note: z.string().optional().describe("Description"),
+  })
+  .strict();
 
-export const ExpenseSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  projectId: z.string().optional().describe("Filtrer par ID projet"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const ExpenseSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Product schemas ----
 
-export const ProductCreateSchema = z.object({
-  name: z.string().min(1).describe("Nom du produit"),
-  reference: z.string().optional().describe("Référence du produit"),
-  unitPrice: z.number().optional().describe("Prix unitaire HT"),
-  taxRate: z.number().optional().describe("Taux de TVA (%)"),
-  state: z.number().int().optional().describe("État du produit"),
-  note: z.string().optional().describe("Description du produit"),
-}).strict();
+export const ProductCreateSchema = z
+  .object({
+    name: z.string().min(1).describe("Nom du produit"),
+    reference: z.string().optional().describe("Référence du produit"),
+    unitPrice: z.number().optional().describe("Prix unitaire HT"),
+    taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    state: z.number().int().optional().describe("État du produit"),
+    note: z.string().optional().describe("Description du produit"),
+  })
+  .strict();
 
-export const ProductUpdateSchema = z.object({
-  id: z.string().min(1).describe("ID du produit à modifier"),
-  name: z.string().optional().describe("Nom du produit"),
-  reference: z.string().optional().describe("Référence"),
-  unitPrice: z.number().optional().describe("Prix unitaire HT"),
-  taxRate: z.number().optional().describe("Taux de TVA (%)"),
-  state: z.number().int().optional().describe("État"),
-  note: z.string().optional().describe("Description"),
-}).strict();
+export const ProductUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du produit à modifier"),
+    name: z.string().optional().describe("Nom du produit"),
+    reference: z.string().optional().describe("Référence"),
+    unitPrice: z.number().optional().describe("Prix unitaire HT"),
+    taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    state: z.number().int().optional().describe("État"),
+    note: z.string().optional().describe("Description"),
+  })
+  .strict();
 
 // ---- Positioning schemas ----
 
-export const PositioningCreateSchema = z.object({
-  candidateId: z.string().optional().describe("ID du candidat positionné"),
-  resourceId: z.string().optional().describe("ID de la ressource positionnée"),
-  projectId: z.string().optional().describe("ID du projet"),
-  opportunityId: z.string().optional().describe("ID de l'opportunité"),
-  state: z.number().int().optional().describe("État du positionnement"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  note: z.string().optional().describe("Notes / commentaires"),
-}).strict();
+export const PositioningCreateSchema = z
+  .object({
+    candidateId: z.string().optional().describe("ID du candidat positionné"),
+    resourceId: z.string().optional().describe("ID de la ressource positionnée"),
+    projectId: z.string().optional().describe("ID du projet"),
+    opportunityId: z.string().optional().describe("ID de l'opportunité"),
+    state: z.number().int().optional().describe("État du positionnement"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    note: z.string().optional().describe("Notes / commentaires"),
+  })
+  .strict();
 
-export const PositioningSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  candidateId: z.string().optional().describe("Filtrer par ID candidat"),
-  resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  projectId: z.string().optional().describe("Filtrer par ID projet"),
-  opportunityId: z.string().optional().describe("Filtrer par ID opportunité"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const PositioningSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    candidateId: z.string().optional().describe("Filtrer par ID candidat"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    opportunityId: z.string().optional().describe("Filtrer par ID opportunité"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Payment schemas ----
 
-export const PaymentSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  invoiceId: z.string().optional().describe("Filtrer par ID facture"),
-  companyId: z.string().optional().describe("Filtrer par ID société"),
-  startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-  endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const PaymentSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    invoiceId: z.string().optional().describe("Filtrer par ID facture"),
+    companyId: z.string().optional().describe("Filtrer par ID société"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Advantage schemas ----
 
-export const AdvantageSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+export const AdvantageSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-clés de recherche"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
+  })
+  .strict();
 
 // ---- Application schemas ----
 
-export const DictionaryGetSchema = z.object({
-  dictionaryType: z.string().min(1).describe("Type de dictionnaire (ex: typeOf/actions, typeOf/absences, states/candidates, states/resources, states/opportunities, states/projects, states/invoices, countries, currencies, languages...)"),
-}).strict();
+// ---- Validation schemas ----
+// `/validations` requires `startMonth` + `endMonth` (YYYY-MM). Optional filters
+// from the official RAML follow.
+export const ValidationSearchSchema = z
+  .object({
+    startMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Mois de début YYYY-MM. Requis."),
+    endMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Mois de fin YYYY-MM. Requis."),
+    keywords: z
+      .string()
+      .optional()
+      .describe("Mots-clés. Préfixes acceptés : 'TPS' (CRA), 'EXP' (frais), 'ABS' (absence), 'COMP' (ressource)."),
+    documentTypes: z
+      .array(z.enum(["absencesReport", "timesReport", "expensesReport"]))
+      .optional()
+      .describe("Types de documents à valider."),
+    resourceTypes: z
+      .array(z.number().int())
+      .optional()
+      .describe("IDs de types de ressource (dictionnaire setting.typeOf.resource)."),
+    validationStates: z
+      .array(z.enum(["waitingForValidation", "validated", "rejected"]))
+      .optional()
+      .describe("États de validation."),
+    validationAlerts: z.boolean().optional().describe("Filtrer sur les validations avec alertes."),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
+
+// ---- Notification schemas ----
+// `/notifications` requires the singular `category` (activity/thread/corporate)
+// per the official RAML. Optional `state` filters read/unread; `parentType`
+// narrows by entity module.
+export const NotificationSearchSchema = z
+  .object({
+    category: z
+      .enum(["activity", "thread", "corporate"])
+      .describe(
+        "Catégorie (requis): 'activity' (notifications d'activité), 'thread' (messages), 'corporate' (annonces)."
+      ),
+    state: z.enum(["new", "read"]).optional().describe("Filtrer par état de lecture."),
+    parentType: z
+      .array(z.string())
+      .optional()
+      .describe("Types de modules parents (ex: 'contract', 'global', 'project'...)."),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
+
+// ---- Reporting schemas ----
+// `/reporting-companies` and `/reporting-resources` require `startDate` +
+// `endDate` (YYYY-MM-DD); the others tolerate omission but still benefit from
+// a period filter.
+export const ReportingDateRequiredSchema = z
+  .object({
+    startDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .describe("Date de début YYYY-MM-DD. Requis."),
+    endDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .describe("Date de fin YYYY-MM-DD. Requis."),
+    keywords: z.string().optional().describe("Mots-clés."),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
+
+export const ReportingDateOptionalSchema = z
+  .object({
+    startDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .describe("Date de début YYYY-MM-DD."),
+    endDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .describe("Date de fin YYYY-MM-DD."),
+    keywords: z.string().optional().describe("Mots-clés."),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_PAGE_SIZE)
+      .default(DEFAULT_PAGE_SIZE)
+      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+  })
+  .strict();
+
+export const DictionaryGetSchema = z
+  .object({
+    dictionaryType: z
+      .string()
+      .min(1)
+      .describe(
+        "Type de dictionnaire (ex: typeOf/actions, typeOf/absences, states/candidates, states/resources, states/opportunities, states/projects, states/invoices, countries, currencies, languages...)"
+      ),
+  })
+  .strict();
 
 export type SearchInput = z.infer<typeof SearchSchema>;
 export type ResourceSearchInput = z.infer<typeof ResourceSearchSchema>;

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -106,6 +106,14 @@ describe("formatEntitySummary", () => {
     });
     expect(result).toContain("Jean");
   });
+
+  it("does not crash when the entity lacks a JSON:API attributes wrapper", () => {
+    // /calendars returns flat items shaped like { iso, value, subCalendars }
+    // — no `attributes`. Treat the object itself as the attribute bag.
+    const result = formatEntitySummary({ iso: "FR", value: "France" });
+    expect(result).toContain("France");
+    expect(result).toContain("ISO: FR");
+  });
 });
 
 describe("formatListResponse", () => {
@@ -395,9 +403,12 @@ describe("apiRequest", () => {
         ok: false,
         status: 422,
         statusText: "Unprocessable Entity",
-        text: () => Promise.resolve(JSON.stringify({
-          errors: [{ status: "422", code: "422", detail: "422 - password mismatch" }],
-        })),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              errors: [{ status: "422", code: "422", detail: "422 - password mismatch" }],
+            })
+          ),
       })
     );
 
@@ -510,30 +521,43 @@ describe("resolveTimeoutMs", () => {
 
 describe("parseBoondErrorBody", () => {
   it("returns the detail of a single error", () => {
-    expect(parseBoondErrorBody(JSON.stringify({
-      errors: [{ status: "422", detail: "422 - password mismatch" }],
-    }))).toBe("422 - password mismatch");
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ status: "422", detail: "422 - password mismatch" }],
+        })
+      )
+    ).toBe("422 - password mismatch");
   });
 
   it("joins multiple errors with a separator", () => {
-    expect(parseBoondErrorBody(JSON.stringify({
-      errors: [
-        { detail: "first thing wrong" },
-        { detail: "second thing wrong" },
-      ],
-    }))).toBe("first thing wrong | second thing wrong");
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ detail: "first thing wrong" }, { detail: "second thing wrong" }],
+        })
+      )
+    ).toBe("first thing wrong | second thing wrong");
   });
 
   it("includes title when distinct from detail", () => {
-    expect(parseBoondErrorBody(JSON.stringify({
-      errors: [{ title: "Forbidden", detail: "user cannot access this scope" }],
-    }))).toBe("Forbidden: user cannot access this scope");
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ title: "Forbidden", detail: "user cannot access this scope" }],
+        })
+      )
+    ).toBe("Forbidden: user cannot access this scope");
   });
 
   it("falls back to code when detail is missing", () => {
-    expect(parseBoondErrorBody(JSON.stringify({
-      errors: [{ code: "503" }],
-    }))).toBe("code 503");
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ code: "503" }],
+        })
+      )
+    ).toBe("code 503");
   });
 
   it("returns null on non-JSON body", () => {
@@ -546,6 +570,29 @@ describe("parseBoondErrorBody", () => {
 
   it("returns null on empty input", () => {
     expect(parseBoondErrorBody("")).toBeNull();
+  });
+
+  it("includes source.parameter so the LLM can see which field triggered the error", () => {
+    // Without surfacing source.parameter, "1017 - Missing required attribute"
+    // is opaque — it's the parameter name (startMonth, category, etc.) that
+    // tells the caller what to add.
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ detail: "1017 - Missing required attribute", source: { parameter: "startMonth" } }],
+        })
+      )
+    ).toBe("1017 - Missing required attribute (parameter: startMonth)");
+  });
+
+  it("falls back to source.pointer when parameter is absent", () => {
+    expect(
+      parseBoondErrorBody(
+        JSON.stringify({
+          errors: [{ detail: "validation failed", source: { pointer: "/data/attributes/email" } }],
+        })
+      )
+    ).toBe("validation failed (parameter: /data/attributes/email)");
   });
 });
 
@@ -576,6 +623,19 @@ describe("formatApiError", () => {
   it("emits a 5xx-specific hint", () => {
     const msg = formatApiError(503, "Service Unavailable", "GET", "/resources", "");
     expect(msg).toContain("BoondManager-side error");
+  });
+
+  it("recognises a Cloudflare WAF block and replaces the misleading status hint", () => {
+    const cfBody =
+      "<!DOCTYPE html><html><head><title>Attention Required! | Cloudflare</title>" +
+      "<meta http-equiv='cf-ray' content='abc'></head><body>Just a moment...</body></html>";
+    const msg = formatApiError(403, "Forbidden", "GET", "/advantages", cfBody);
+    expect(msg).toContain("blocked by Cloudflare WAF");
+    // Generic 403 hint is replaced because it's misleading (the request
+    // never reached BoondManager — it isn't a permission issue).
+    expect(msg).not.toContain("the user lacks permission");
+    // The HTML body itself isn't echoed.
+    expect(msg).not.toContain("<html>");
   });
 });
 
@@ -786,9 +846,7 @@ describe("apiRequest retries", () => {
     const fetchMock = vi.fn().mockResolvedValue(errResponse(503, "Service Unavailable"));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(apiRequest("/candidates", "POST", { foo: "bar" })).rejects.toThrow(
-      "BoondManager API 503"
-    );
+    await expect(apiRequest("/candidates", "POST", { foo: "bar" })).rejects.toThrow("BoondManager API 503");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -314,6 +314,21 @@ function hintForStatus(status: number): string {
  * the upstream service is unreachable and the JSON:API hint above is
  * misleading — the request never reached BoondManager.
  */
+function containsCloudflareChallengeHost(htmlSnippet: string): boolean {
+  const urlMatches = htmlSnippet.match(/https?:\/\/[^\s"'<>]+/gi) ?? [];
+  for (const rawUrl of urlMatches) {
+    try {
+      const hostname = new URL(rawUrl).hostname.toLowerCase();
+      if (hostname === "challenges.cloudflare.com" || hostname.endsWith(".challenges.cloudflare.com")) {
+        return true;
+      }
+    } catch {
+      // Ignore unparsable URL fragments in HTML.
+    }
+  }
+  return false;
+}
+
 function looksLikeCloudflareBlock(body: string): boolean {
   if (!body) return false;
   const head = body.slice(0, 1000).toLowerCase();
@@ -323,7 +338,7 @@ function looksLikeCloudflareBlock(body: string): boolean {
     head.includes("attention required") ||
     head.includes("just a moment") ||
     head.includes("cf-ray") ||
-    head.includes("challenges.cloudflare.com")
+    containsCloudflareChallengeHost(head)
   );
 }
 

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -22,9 +22,7 @@ function base64url(data: string | Buffer): string {
 export function buildJwt(userToken: string, clientToken: string, clientKey: string): string {
   const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const payload = base64url(JSON.stringify({ userToken, clientToken }));
-  const signature = base64url(
-    createHmac("sha256", clientKey).update(`${header}.${payload}`).digest()
-  );
+  const signature = base64url(createHmac("sha256", clientKey).update(`${header}.${payload}`).digest());
   return `${header}.${payload}.${signature}`;
 }
 
@@ -92,7 +90,14 @@ export type QueryValue = string | number | Array<string | number> | undefined;
 export function parseBoondErrorBody(body: string): string | null {
   if (!body) return null;
   try {
-    const parsed = JSON.parse(body) as { errors?: Array<{ detail?: string; title?: string; code?: string }> };
+    const parsed = JSON.parse(body) as {
+      errors?: Array<{
+        detail?: string;
+        title?: string;
+        code?: string;
+        source?: { parameter?: string; pointer?: string };
+      }>;
+    };
     const errors = Array.isArray(parsed.errors) ? parsed.errors : [];
     const messages = errors
       .map((e) => {
@@ -100,7 +105,14 @@ export function parseBoondErrorBody(body: string): string | null {
         if (e.title && e.title !== e.detail) parts.push(e.title);
         if (e.detail) parts.push(e.detail);
         else if (e.code) parts.push(`code ${e.code}`);
-        return parts.join(": ").trim();
+        // Boond's JSON:API errors put the offending query/body field in
+        // source.parameter (or source.pointer). Surfacing it turns the
+        // otherwise-opaque "1017 - Missing required attribute" into
+        // "1017 - Missing required attribute (parameter: startMonth)".
+        const ref = e.source?.parameter ?? e.source?.pointer;
+        const head = parts.join(": ").trim();
+        if (!head) return ref ? `parameter: ${ref}` : "";
+        return ref ? `${head} (parameter: ${ref})` : head;
       })
       .filter((m) => m.length > 0);
     if (messages.length === 0) return null;
@@ -176,11 +188,7 @@ export function resolveRetryConfig(): RetryConfig {
  *
  * Exported for unit testing.
  */
-export function isRetryable(
-  method: string,
-  status: number | undefined,
-  isNetworkOrTimeout: boolean
-): boolean {
+export function isRetryable(method: string, status: number | undefined, isNetworkOrTimeout: boolean): boolean {
   if (status === 429) return true;
   if (method !== "GET") return false;
   if (isNetworkOrTimeout) return true;
@@ -300,26 +308,51 @@ function hintForStatus(status: number): string {
   }
 }
 
+/**
+ * Detect whether the response body looks like a Cloudflare WAF challenge or
+ * block page rather than a BoondManager JSON:API response. When this is true,
+ * the upstream service is unreachable and the JSON:API hint above is
+ * misleading — the request never reached BoondManager.
+ */
+function looksLikeCloudflareBlock(body: string): boolean {
+  if (!body) return false;
+  const head = body.slice(0, 1000).toLowerCase();
+  if (!head.includes("<!doctype html") && !head.includes("<html")) return false;
+  return (
+    head.includes("cloudflare") ||
+    head.includes("attention required") ||
+    head.includes("just a moment") ||
+    head.includes("cf-ray") ||
+    head.includes("challenges.cloudflare.com")
+  );
+}
+
 /** Build the Error message for a non-2xx HTTP response. Exported for testing. */
-export function formatApiError(
-  status: number,
-  statusText: string,
-  method: string,
-  path: string,
-  body: string
-): string {
+export function formatApiError(status: number, statusText: string, method: string, path: string, body: string): string {
   const detail = parseBoondErrorBody(body);
-  const headline = detail
-    ? `BoondManager API ${status} ${statusText}: ${detail}`
-    : `BoondManager API ${status} ${statusText}`;
+  const cloudflareBlocked = looksLikeCloudflareBlock(body);
+  const headline = cloudflareBlocked
+    ? `BoondManager API ${status} ${statusText} — request blocked by Cloudflare WAF before reaching the API`
+    : detail
+      ? `BoondManager API ${status} ${statusText}: ${detail}`
+      : `BoondManager API ${status} ${statusText}`;
   const lines = [headline, `Endpoint: ${method} ${path}`];
-  // Only attach the raw body when we couldn't extract a structured detail —
-  // otherwise it's noise that buries the useful message.
-  if (!detail && body) {
+  // Only attach the raw body when we couldn't extract a structured detail
+  // and we don't already know it's a Cloudflare HTML page — in either case
+  // the raw HTML/error chunk just buries the useful message.
+  if (!detail && !cloudflareBlocked && body) {
     const trimmed = body.length > 500 ? body.slice(0, 500) + "…" : body;
     lines.push(`Body: ${trimmed}`);
   }
-  lines.push(`Hint: ${hintForStatus(status)}`);
+  if (cloudflareBlocked) {
+    lines.push(
+      "Hint: The BoondManager edge (Cloudflare) blocked this request. " +
+        "This often means the endpoint is restricted on this tenant, or you've made too many calls in a short window. " +
+        "Wait a few seconds and retry; if it persists, the endpoint is not enabled for this account."
+    );
+  } else {
+    lines.push(`Hint: ${hintForStatus(status)}`);
+  }
   return lines.join("\n");
 }
 
@@ -361,9 +394,7 @@ export async function apiRequest(
   const totalAttempts = retry.maxRetries + 1;
 
   const buildBody = (): string | undefined =>
-    body && (method === "POST" || method === "PUT" || method === "PATCH")
-      ? JSON.stringify(body)
-      : undefined;
+    body && (method === "POST" || method === "PUT" || method === "PATCH") ? JSON.stringify(body) : undefined;
   const serializedBody = buildBody();
 
   let lastError: Error | undefined;
@@ -421,9 +452,7 @@ export async function apiRequest(
 
     if (response) {
       const errorText = await response.text().catch(() => "");
-      attemptError = new Error(
-        formatApiError(response.status, response.statusText, method, path, errorText)
-      );
+      attemptError = new Error(formatApiError(response.status, response.statusText, method, path, errorText));
     } else {
       attemptError = networkError!;
       isNetworkOrTimeout = true;
@@ -479,32 +508,48 @@ export function buildSearchQuery(params: SearchParams): Record<string, QueryValu
   return query;
 }
 
-export function formatEntitySummary(entity: {
-  id: string;
-  type: string;
-  attributes: Record<string, unknown>;
-}): string {
-  const attrs = entity.attributes;
-  const parts: string[] = [`[${entity.type} #${entity.id}]`];
+export function formatEntitySummary(entity: unknown): string {
+  // A few BoondManager endpoints (e.g. `/calendars`, `/application/dictionary`)
+  // return reference items as flat objects without a JSON:API `attributes`
+  // wrapper. Treating the whole entity as the attribute bag in that case
+  // keeps `formatListResponse` from crashing on `attrs.firstName` and yields
+  // a still-useful summary.
+  const e = (entity ?? {}) as Record<string, unknown>;
+  const hasAttrs = e.attributes !== undefined && e.attributes !== null && typeof e.attributes === "object";
+  const attrs: Record<string, unknown> = hasAttrs ? (e.attributes as Record<string, unknown>) : e;
+
+  const id = e.id !== undefined ? String(e.id) : undefined;
+  const type = e.type !== undefined ? String(e.type) : undefined;
+  const header =
+    id !== undefined && type !== undefined
+      ? `[${type} #${id}]`
+      : id !== undefined
+        ? `[#${id}]`
+        : type !== undefined
+          ? `[${type}]`
+          : "[item]";
+  const parts: string[] = [header];
 
   // Common name fields
   if (attrs.firstName || attrs.lastName) {
     parts.push(`${attrs.firstName || ""} ${attrs.lastName || ""}`.trim());
   }
   if (attrs.name) parts.push(String(attrs.name));
+  // `value` covers the `/calendars` and dictionary-style payloads.
+  if (!attrs.firstName && !attrs.lastName && !attrs.name && attrs.value !== undefined) {
+    parts.push(String(attrs.value));
+  }
   if (attrs.email1) parts.push(`Email: ${attrs.email1}`);
   if (attrs.phone1) parts.push(`Tel: ${attrs.phone1}`);
   if (attrs.city) parts.push(`Ville: ${attrs.city}`);
   if (attrs.state !== undefined) parts.push(`Statut: ${attrs.state}`);
   if (attrs.title) parts.push(`Titre: ${attrs.title}`);
+  if (attrs.iso !== undefined && String(attrs.iso) !== id) parts.push(`ISO: ${attrs.iso}`);
 
   return parts.join(" | ");
 }
 
-export function formatListResponse(
-  response: JsonApiResponse,
-  entityType: string
-): string {
+export function formatListResponse(response: JsonApiResponse, entityType: string): string {
   const data = Array.isArray(response.data) ? response.data : [response.data];
   const total = response.meta?.totals?.rows;
 

--- a/src/tools/notifications.ts
+++ b/src/tools/notifications.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { IdSchema, SearchSchema } from "../schemas/index.js";
+import { IdSchema, NotificationSearchSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 
 export function registerNotificationTools(server: McpServer): void {
@@ -9,8 +9,15 @@ export function registerNotificationTools(server: McpServer): void {
       title: "Rechercher des notifications",
       description: `Recherche des notifications dans BoondManager.
 
+⚠️ Le paramètre \`category\` est REQUIS par l'API (singulier, pas de tableau).
+
+Args:
+  - category (string, requis): 'activity' | 'thread' | 'corporate'
+  - state (string, optional): 'new' | 'read'
+  - parentType (string[], optional): types de modules parents (ex: 'contract', 'global')
+
 Returns: Liste des notifications correspondantes.`,
-      inputSchema: SearchSchema,
+      inputSchema: NotificationSearchSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1,29 +1,77 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SearchSchema } from "../schemas/index.js";
+import { ReportingDateOptionalSchema, ReportingDateRequiredSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse } from "../services/boond-client.js";
 
+interface ReportingEndpoint {
+  name: string;
+  path: string;
+  title: string;
+  description: string;
+  entity: string;
+  /** When true, the API rejects requests without `startDate` + `endDate` (422). */
+  datesRequired: boolean;
+}
+
 export function registerReportingTools(server: McpServer): void {
-  const reportingEndpoints = [
-    { name: "companies", path: "/reporting-companies", title: "Reporting sociétés", description: "Recherche le reporting des sociétés (CA, marge, activité...).", entity: "reporting société" },
-    { name: "projects", path: "/reporting-projects", title: "Reporting projets", description: "Recherche le reporting des projets (CA, marge, rentabilité...).", entity: "reporting projet" },
-    { name: "resources", path: "/reporting-resources", title: "Reporting ressources", description: "Recherche le reporting des ressources (taux d'occupation, CA, productivité...).", entity: "reporting ressource" },
-    { name: "synthesis", path: "/reporting-synthesis", title: "Reporting synthèse", description: "Recherche le reporting de synthèse globale.", entity: "reporting synthèse" },
-    { name: "production_plans", path: "/reporting-production-plans", title: "Reporting plans de production", description: "Recherche le reporting des plans de production.", entity: "reporting plan de production" },
+  const reportingEndpoints: ReportingEndpoint[] = [
+    {
+      name: "companies",
+      path: "/reporting-companies",
+      title: "Reporting sociétés",
+      description: "Recherche le reporting des sociétés (CA, marge, activité...).",
+      entity: "reporting société",
+      datesRequired: true,
+    },
+    {
+      name: "projects",
+      path: "/reporting-projects",
+      title: "Reporting projets",
+      description: "Recherche le reporting des projets (CA, marge, rentabilité...).",
+      entity: "reporting projet",
+      datesRequired: false,
+    },
+    {
+      name: "resources",
+      path: "/reporting-resources",
+      title: "Reporting ressources",
+      description: "Recherche le reporting des ressources (taux d'occupation, CA, productivité...).",
+      entity: "reporting ressource",
+      datesRequired: true,
+    },
+    {
+      name: "synthesis",
+      path: "/reporting-synthesis",
+      title: "Reporting synthèse",
+      description: "Recherche le reporting de synthèse globale.",
+      entity: "reporting synthèse",
+      datesRequired: true,
+    },
+    {
+      name: "production_plans",
+      path: "/reporting-production-plans",
+      title: "Reporting plans de production",
+      description: "Recherche le reporting des plans de production.",
+      entity: "reporting plan de production",
+      datesRequired: true,
+    },
   ];
 
   for (const ep of reportingEndpoints) {
+    const schema = ep.datesRequired ? ReportingDateRequiredSchema : ReportingDateOptionalSchema;
+    const datesNote = ep.datesRequired ? "\n⚠️ `startDate` + `endDate` (YYYY-MM-DD) sont REQUIS par l'API." : "";
     server.registerTool(
       `boond_reporting_${ep.name}`,
       {
         title: ep.title,
-        description: `${ep.description}
+        description: `${ep.description}${datesNote}
 
 Args:
+  - startDate, endDate (string${ep.datesRequired ? ", requis" : ", optional"}): YYYY-MM-DD
   - keywords (string, optional): Termes de recherche
   - page, pageSize: Pagination
 
 Returns: Données de reporting.`,
-        inputSchema: SearchSchema,
+        inputSchema: schema,
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -31,7 +79,7 @@ Returns: Données de reporting.`,
           openWorldHint: true,
         },
       },
-      async (params) => {
+      async (params: { startDate?: string; endDate?: string; keywords?: string; page?: number; pageSize?: number }) => {
         const query = buildSearchQuery(params);
         const response = await apiRequest(ep.path, "GET", undefined, query);
         return {

--- a/src/tools/timesheets.ts
+++ b/src/tools/timesheets.ts
@@ -1,14 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  ResourceTimesheetSchema,
-  TimesheetSearchSchema,
-  TimesheetGetSchema,
-} from "../schemas/index.js";
-import type {
-  ResourceTimesheetInput,
-  TimesheetSearchInput,
-  TimesheetGetInput,
-} from "../schemas/index.js";
+import { ResourceTimesheetSchema, TimesheetSearchSchema, TimesheetGetSchema } from "../schemas/index.js";
+import type { ResourceTimesheetInput, TimesheetSearchInput, TimesheetGetInput } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatDetailResponse } from "../services/boond-client.js";
 import { CHARACTER_LIMIT } from "../constants.js";
 import type { JsonApiResponse } from "../types.js";
@@ -74,12 +66,7 @@ Returns: Liste des feuilles de temps de la ressource avec jours/heures et statut
       if (params.month !== undefined) queryParams["month"] = params.month;
       if (params.year !== undefined) queryParams["year"] = params.year;
 
-      const response = await apiRequest(
-        `/resources/${params.resourceId}/times-reports`,
-        "GET",
-        undefined,
-        queryParams
-      );
+      const response = await apiRequest(`/resources/${params.resourceId}/times-reports`, "GET", undefined, queryParams);
       const text = formatTimesheetSummary(response);
       return {
         content: [{ type: "text" as const, text }],
@@ -92,13 +79,16 @@ Returns: Liste des feuilles de temps de la ressource avec jours/heures et statut
     "boond_timesheets_search",
     {
       title: "Rechercher des feuilles de temps",
-      description: `Recherche des feuilles de temps dans BoondManager avec filtres par période.
+      description: `Recherche des feuilles de temps (CRA mensuels) dans BoondManager.
+
+⚠️ \`startMonth\` et \`endMonth\` (format YYYY-MM) sont requis par l'API — passer YYYY-MM-DD ou les omettre renvoie un 422.
 
 Args:
-  - startDate (string, optional): Date de début (YYYY-MM-DD)
-  - endDate (string, optional): Date de fin (YYYY-MM-DD)
+  - startMonth (string, requis): Mois de début YYYY-MM (ex: '2025-01')
+  - endMonth (string, requis): Mois de fin YYYY-MM (ex: '2025-03')
+  - keywords (string, optional): Mots-clés
   - page (number): Numéro de page (défaut: 1)
-  - pageSize (number): Résultats par page (défaut: 20)
+  - pageSize (number): Résultats par page (défaut: 30)
 
 Returns: Liste des feuilles de temps correspondantes.`,
       inputSchema: TimesheetSearchSchema,

--- a/src/tools/validations.ts
+++ b/src/tools/validations.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { IdSchema, SearchSchema } from "../schemas/index.js";
+import { IdSchema, ValidationSearchSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 
 export function registerValidationTools(server: McpServer): void {
@@ -9,8 +9,18 @@ export function registerValidationTools(server: McpServer): void {
       title: "Rechercher des validations",
       description: `Recherche des validations en attente dans BoondManager (absences, notes de frais, feuilles de temps...).
 
+⚠️ \`startMonth\` et \`endMonth\` (YYYY-MM) sont requis par l'API.
+
+Args:
+  - startMonth (string, requis): YYYY-MM (ex: '2025-01')
+  - endMonth (string, requis): YYYY-MM
+  - documentTypes (string[], optional): 'absencesReport' | 'timesReport' | 'expensesReport'
+  - validationStates (string[], optional): 'waitingForValidation' | 'validated' | 'rejected'
+  - resourceTypes (number[], optional)
+  - keywords (string, optional): préfixes 'TPS', 'EXP', 'ABS', 'COMP'
+
 Returns: Liste des validations correspondantes.`,
-      inputSchema: SearchSchema,
+      inputSchema: ValidationSearchSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,


### PR DESCRIPTION
Require and validate API-required period params and add related search schemas; update tools to use them and warn callers. Key changes:

- Replace flexible timesheet date fields with startMonth/endMonth (YYYY-MM) and enforce presence; tests updated to expect failures when missing or wrong format and to check pagination defaults.
- Add ValidationSearchSchema, NotificationSearchSchema, ReportingDateRequiredSchema and ReportingDateOptionalSchema to formalize required/optional date formats and filters.
- Update reporting, notifications, validations and timesheets tools to use the new schemas, improve tool descriptions, and surface warnings when the API requires specific fields.
- Improve API error parsing to include source.parameter or source.pointer, and detect Cloudflare WAF HTML blocks so formatApiError avoids leaking HTML and provides a clearer hint when the request was blocked before reaching BoondManager.
- Make formatEntitySummary resilient to non-JSON:API flat entities (e.g. calendars/dictionaries) by treating the object itself as attributes and include fields like value/iso in summaries.
- Add/adjust tests for the new behaviors (parsing errors, Cloudflare detection, and flat-entity summaries).

These changes prevent common 422/opaque errors at the service boundary and produce clearer diagnostics for callers.

## Description

<!-- Breve description des changements -->

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [ ] Mon code suit les conventions du projet
- [ ] J'ai lance `npm run lint` et `npm run typecheck`
- [ ] J'ai ajoute des tests couvrant mes changements
- [ ] Tous les tests passent (`npm test`)
- [ ] J'ai mis a jour la documentation si necessaire
