### PR TITLE
fix(auth): send JWT in X-Jwt-Client-Boondmanager header (1.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.8.2] - 2026-05-08
+
+Correction d'authentification : le client n'arrivait plus à se connecter à BoondManager via la méthode JWT (auto-construit ou pré-construit). L'API renvoyait `422 - Signature verification failed (parameter: jwt)` à chaque requête. Cause : le JWT était envoyé dans `Authorization: Bearer …`, alors que la spec officielle BoondManager exige le header dédié `X-Jwt-Client-Boondmanager`. Le mode BasicAuth (`BOOND_USER` + `BOOND_PASSWORD`) restait fonctionnel via `Authorization: Basic …`.
+
+### Corrigé
+
+- **Header d'auth JWT** (`src/services/boond-client.ts`, `src/types.ts`) — `initClient()` route désormais le JWT (auto-construit depuis `BOOND_USER_TOKEN` + `BOOND_CLIENT_TOKEN` + `BOOND_CLIENT_KEY`, ou pré-construit via `BOOND_API_TOKEN`) dans le header `X-Jwt-Client-Boondmanager` (constante exportée `JWT_HEADER_NAME`). BasicAuth continue d'utiliser `Authorization: Basic …`. `BoondConfig` passe de `{ baseUrl, authHeader }` à `{ baseUrl, authHeaderName, authHeaderValue }` pour porter le nom du header. Validé contre l'API réelle : `GET /application/current-user` répond désormais `200 OK`.
+
+### Tests
+
+- **+3 tests dans `src/services/boond-client.test.ts`** (`apiRequest auth header routing`) qui pinnent le contrat : JWT auto-construit → `X-Jwt-Client-Boondmanager` (pas d'`Authorization`), `BOOND_API_TOKEN` → idem, BasicAuth → `Authorization: Basic …`. **425 tests passants** (vs 422 en 1.8.1).
+
 ## [1.8.1] - 2026-05-04
 
 Durcissement sécurité du transport HTTP et relèvement du plancher SDK pour fermer trois CVE remontées par les scanners marketplace.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.8.1/boondmanager-mcp-server-v1.8.1.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.8.2/boondmanager-mcp-server-v1.8.2.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -487,6 +487,86 @@ describe("apiRequest", () => {
   });
 });
 
+describe("apiRequest auth header routing", () => {
+  // BoondManager rejects JWT auth carried in `Authorization: Bearer …` with
+  // `422 Signature verification failed`. The token must travel in
+  // `X-Jwt-Client-Boondmanager`. BasicAuth, by contrast, is plain HTTP and
+  // belongs in `Authorization`. These tests pin that contract so we don't
+  // regress.
+  const successResponse = () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-length": "10" }),
+    json: () => Promise.resolve({ data: [] }),
+  });
+
+  beforeEach(() => {
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_USER;
+    delete process.env.BOOND_PASSWORD;
+    delete process.env.BOOND_USER_TOKEN;
+    delete process.env.BOOND_CLIENT_TOKEN;
+    delete process.env.BOOND_CLIENT_KEY;
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_USER;
+    delete process.env.BOOND_PASSWORD;
+    delete process.env.BOOND_USER_TOKEN;
+    delete process.env.BOOND_CLIENT_TOKEN;
+    delete process.env.BOOND_CLIENT_KEY;
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
+  });
+
+  it("sends auto-built JWT in X-Jwt-Client-Boondmanager (not Authorization)", async () => {
+    process.env.BOOND_USER_TOKEN = "user-tok";
+    process.env.BOOND_CLIENT_TOKEN = "client-tok";
+    process.env.BOOND_CLIENT_KEY = "secret";
+    initClient();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    expect(headers["X-Jwt-Client-Boondmanager"]).toBeDefined();
+    expect(headers["X-Jwt-Client-Boondmanager"].split(".")).toHaveLength(3);
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("sends pre-built BOOND_API_TOKEN in X-Jwt-Client-Boondmanager (not Authorization)", async () => {
+    process.env.BOOND_API_TOKEN = "pre-built.jwt.value";
+    initClient();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    expect(headers["X-Jwt-Client-Boondmanager"]).toBe("pre-built.jwt.value");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("sends BasicAuth credentials in Authorization header", async () => {
+    process.env.BOOND_USER = "alice";
+    process.env.BOOND_PASSWORD = "s3cret";
+    initClient();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    const expected = `Basic ${Buffer.from("alice:s3cret").toString("base64")}`;
+    expect(headers.Authorization).toBe(expected);
+    expect(headers["X-Jwt-Client-Boondmanager"]).toBeUndefined();
+  });
+});
+
 describe("resolveTimeoutMs", () => {
   afterEach(() => {
     delete process.env.BOOND_HTTP_TIMEOUT_MS;

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -33,6 +33,8 @@ function envOrUndefined(key: string): string | undefined {
   return v;
 }
 
+export const JWT_HEADER_NAME = "X-Jwt-Client-Boondmanager";
+
 export function initClient(): void {
   const baseUrl = envOrUndefined("BOOND_BASE_URL") || DEFAULT_BASE_URL;
 
@@ -40,6 +42,11 @@ export function initClient(): void {
   // 1. Build JWT from components (userToken + clientToken + clientKey)
   // 2. Pre-built JWT token
   // 3. BasicAuth (user:password)
+  //
+  // Per BoondManager's JWT spec the token must travel in the
+  // `X-Jwt-Client-Boondmanager` header — sending it as `Authorization: Bearer`
+  // makes the API reject the request with 422 "Signature verification failed".
+  // BasicAuth, on the other hand, uses the standard `Authorization` header.
   const userToken = envOrUndefined("BOOND_USER_TOKEN");
   const clientToken = envOrUndefined("BOOND_CLIENT_TOKEN");
   const clientKey = envOrUndefined("BOOND_CLIENT_KEY");
@@ -47,23 +54,25 @@ export function initClient(): void {
   const user = envOrUndefined("BOOND_USER");
   const password = envOrUndefined("BOOND_PASSWORD");
 
-  let authHeader: string;
+  let authHeaderName: string;
+  let authHeaderValue: string;
 
   if (userToken && clientToken && clientKey) {
-    const jwt = buildJwt(userToken, clientToken, clientKey);
-    authHeader = `Bearer ${jwt}`;
+    authHeaderName = JWT_HEADER_NAME;
+    authHeaderValue = buildJwt(userToken, clientToken, clientKey);
   } else if (token) {
-    authHeader = `Bearer ${token}`;
+    authHeaderName = JWT_HEADER_NAME;
+    authHeaderValue = token;
   } else if (user && password) {
-    const encoded = Buffer.from(`${user}:${password}`).toString("base64");
-    authHeader = `Basic ${encoded}`;
+    authHeaderName = "Authorization";
+    authHeaderValue = `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
   } else {
     throw new Error(
       "Authentication required. Set BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY, or BOOND_API_TOKEN, or both BOOND_USER and BOOND_PASSWORD."
     );
   }
 
-  config = { baseUrl, authHeader };
+  config = { baseUrl, authHeaderName, authHeaderValue };
 }
 
 function getConfig(): BoondConfig {
@@ -377,7 +386,7 @@ export async function apiRequest(
   body?: unknown,
   queryParams?: Record<string, QueryValue>
 ): Promise<JsonApiResponse> {
-  const { baseUrl, authHeader } = getConfig();
+  const { baseUrl, authHeaderName, authHeaderValue } = getConfig();
 
   const url = new URL(`${baseUrl}${path}`);
 
@@ -399,7 +408,7 @@ export async function apiRequest(
   }
 
   const headers: Record<string, string> = {
-    Authorization: authHeader,
+    [authHeaderName]: authHeaderValue,
     Accept: "application/json",
     "Content-Type": "application/json",
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,12 @@ export interface JsonApiResource {
   id: string;
   type: string;
   attributes: Record<string, unknown>;
-  relationships?: Record<string, {
-    data: { id: string; type: string } | { id: string; type: string }[] | null;
-  }>;
+  relationships?: Record<
+    string,
+    {
+      data: { id: string; type: string } | { id: string; type: string }[] | null;
+    }
+  >;
   links?: Record<string, string>;
 }
 
@@ -22,7 +25,8 @@ export interface JsonApiResponse {
 
 export interface BoondConfig {
   baseUrl: string;
-  authHeader: string;
+  authHeaderName: string;
+  authHeaderValue: string;
 }
 
 export interface SearchParams {


### PR DESCRIPTION
## Summary

- **Bug** : tout appel à BoondManager via la méthode JWT (auto-construit depuis `BOOND_USER_TOKEN` + `BOOND_CLIENT_TOKEN` + `BOOND_CLIENT_KEY`, ou pré-construit via `BOOND_API_TOKEN`) renvoie `422 - Signature verification failed (parameter: jwt)`. Cause : le JWT était envoyé dans `Authorization: Bearer …`. La spec BoondManager exige le header dédié `X-Jwt-Client-Boondmanager`.
- **Fix** : `initClient()` route le JWT vers `X-Jwt-Client-Boondmanager` et garde `Authorization: Basic …` pour BasicAuth. `BoondConfig` passe à `{ authHeaderName, authHeaderValue }`.
- **Vérifié contre l'API réelle** : `GET /application/current-user` → `200 OK` avec l'utilisateur courant.

## Test plan

- [x] `npm run lint` ✅
- [x] `npm run typecheck` ✅
- [x] `npm test` ✅ (425 tests, +3 nouveaux dans `apiRequest auth header routing`)
- [x] `npm run build` ✅
- [x] `npm run docs:tools:check` ✅ (pas de drift TOOLS.md)
- [x] Smoke test live contre `https://ui.boondmanager.com/api` → `200 OK`
- [x] Versions cohérentes `package.json` / `manifest.json` / `server.json` → 1.8.2 (vérifié par CI)
- [x] CI verte sur Node 20 + 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)