### PR TITLE
feat(resources): write tools for technical data and references

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**167 tools** across **37 domains** · **11 prompts** · **21 resources**.
+**171 tools** across **37 domains** · **11 prompts** · **21 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -282,7 +282,7 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_reporting_resources` | Reporting ressources | read · idempotent · open-world |
 | `boond_reporting_synthesis` | Reporting synthèse | read · idempotent · open-world |
 
-### resources (16)
+### resources (20)
 
 | Tool | Title | Hints |
 |---|---|---|
@@ -297,8 +297,12 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_resources_information` | Informations générales d'une ressource | read · idempotent |
 | `boond_resources_positionings` | Positionnements d'une ressource | read · idempotent |
 | `boond_resources_projects` | Projets d'une ressource | read · idempotent |
+| `boond_resources_reference_create` | Créer une référence (expérience pro) sur une ressource | write |
+| `boond_resources_reference_delete` | Supprimer une référence (expérience pro) | delete |
+| `boond_resources_reference_update` | Modifier une référence (expérience pro) | write · idempotent |
 | `boond_resources_search` | Rechercher des ressources | read · idempotent · open-world |
 | `boond_resources_technical_data` | Compétences techniques d'une ressource | read · idempotent |
+| `boond_resources_technical_data_update` | Mettre à jour le dossier technique d'une ressource | write · idempotent |
 | `boond_resources_times_reports` | Feuilles de temps d'une ressource | read · idempotent |
 | `boond_resources_timesheets` | Feuilles de temps d'une ressource | read · idempotent |
 | `boond_resources_update` | Modifier un(e) ressource | write · idempotent |

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -541,6 +541,97 @@ export const ResourceUpdateSchema = z
   })
   .strict();
 
+// ---- Resource technical-data (DT) write schema ----
+// Source: spec issue #79. PUT /resources/{id}/technical-data with type=resource.
+const technicalDataToolItemSchema = z
+  .object({
+    tool: z
+      .string()
+      .min(1)
+      .describe("Slug de l'outil (ex: 'aws', 'snowflake', 'microsoftazure'). Voir dictionnaire setting.tool."),
+    level: z.number().int().min(1).max(4).describe("Niveau de maîtrise (1 = débutant, 4 = expert)."),
+  })
+  .strict();
+
+const technicalDataLanguageItemSchema = z
+  .object({
+    language: z.string().min(1).describe("Langue (ex: 'Anglais', 'Espagnol')."),
+    level: z.enum(["scolaire", "intermediaire", "courant", "bilingue", "maternel"]).describe("Niveau parlé."),
+  })
+  .strict();
+
+export const ResourceTechnicalDataUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID de la ressource dont le dossier technique est mis à jour."),
+    mode: z
+      .enum(["merge", "replace"])
+      .default("merge")
+      .describe(
+        "'merge' (défaut) enrichit le DT sans rien écraser. 'replace' remplace intégralement chaque champ fourni."
+      ),
+    title: z.string().optional().describe("Titre / poste actuel."),
+    summary: z.string().optional().describe("Résumé / synthèse du parcours."),
+    skills: z.string().optional().describe("Compétences libres, séparées par virgule (ex: 'Python, AWS, GCP')."),
+    experience: z.number().int().min(0).optional().describe("Années d'expérience."),
+    training: z.string().optional().describe("Formations / parcours académique."),
+    expertiseAreas: z.array(z.string()).optional().describe("Domaines d'expertise (texte libre, ex: 'Banque')."),
+    activityAreas: z.array(z.string()).optional().describe("Secteurs d'activité."),
+    tools: z.array(technicalDataToolItemSchema).optional().describe("Outils maîtrisés avec niveau (1-4)."),
+    languages: z.array(technicalDataLanguageItemSchema).optional().describe("Langues parlées avec niveau."),
+    diplomas: z
+      .array(z.string())
+      .optional()
+      .describe("Diplômes (texte libre, ex: 'DUT Informatique - IUT Bordeaux (2016)')."),
+  })
+  .strict();
+
+// ---- Reference (DT experience) schemas ----
+// Source: spec issue #79. POST /resources/{id}/references — PUT/DELETE /references/{id}.
+const referenceMonth = z
+  .string()
+  .regex(/^(0[1-9]|1[0-2])$/)
+  .describe("Mois sur 2 chiffres ('01'..'12').");
+const referenceYear = z
+  .string()
+  .regex(/^\d{4}$/)
+  .describe("Année sur 4 chiffres (ex: '2024').");
+
+export const ReferenceCreateSchema = z
+  .object({
+    resourceId: z.string().min(1).describe("ID de la ressource à laquelle rattacher la référence."),
+    title: z.string().min(1).describe("Intitulé du poste."),
+    company: z.string().min(1).describe("Société / employeur."),
+    location: z.string().optional().describe("Lieu (ville)."),
+    startMonth: referenceMonth.optional(),
+    startYear: referenceYear.optional(),
+    endMonth: referenceMonth.optional(),
+    endYear: referenceYear.optional(),
+    skills: z.string().optional().describe("Compétences mobilisées (texte libre, séparées par virgule)."),
+    description: z.string().optional().describe("Description / missions / réalisations."),
+  })
+  .strict();
+
+export const ReferenceUpdateSchema = z
+  .object({
+    referenceId: z.string().min(1).describe("ID de la référence à modifier."),
+    title: z.string().optional().describe("Intitulé du poste."),
+    company: z.string().optional().describe("Société / employeur."),
+    location: z.string().optional().describe("Lieu (ville)."),
+    startMonth: referenceMonth.optional(),
+    startYear: referenceYear.optional(),
+    endMonth: referenceMonth.optional(),
+    endYear: referenceYear.optional(),
+    skills: z.string().optional().describe("Compétences mobilisées."),
+    description: z.string().optional().describe("Description."),
+  })
+  .strict();
+
+export const ReferenceIdSchema = z
+  .object({
+    referenceId: z.string().min(1).describe("ID de la référence."),
+  })
+  .strict();
+
 // ---- Contact schemas ----
 
 export const ContactCreateSchema = z
@@ -1106,3 +1197,7 @@ export type ResourceTimesheetInput = z.infer<typeof ResourceTimesheetSchema>;
 export type TimesheetSearchInput = z.infer<typeof TimesheetSearchSchema>;
 export type TimesheetGetInput = z.infer<typeof TimesheetGetSchema>;
 export type DictionaryGetInput = z.infer<typeof DictionaryGetSchema>;
+export type ResourceTechnicalDataUpdateInput = z.infer<typeof ResourceTechnicalDataUpdateSchema>;
+export type ReferenceCreateInput = z.infer<typeof ReferenceCreateSchema>;
+export type ReferenceUpdateInput = z.infer<typeof ReferenceUpdateSchema>;
+export type ReferenceIdInput = z.infer<typeof ReferenceIdSchema>;

--- a/src/tools/resources.test.ts
+++ b/src/tools/resources.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerResourceTools } from "./resources.js";
+import { registerResourceTools, mergeTechnicalData } from "./resources.js";
+import * as boondClient from "../services/boond-client.js";
 
 function createMockServer() {
   return {
@@ -8,16 +9,24 @@ function createMockServer() {
   } as unknown as McpServer;
 }
 
+const WRITE_DT_TOOLS = [
+  "boond_resources_technical_data_update",
+  "boond_resources_reference_create",
+  "boond_resources_reference_update",
+  "boond_resources_reference_delete",
+] as const;
+
 describe("registerResourceTools", () => {
   let server: McpServer;
 
   beforeEach(() => {
     server = createMockServer();
+    vi.restoreAllMocks();
   });
 
-  it("should register CRUD tools + 10 tab tools = 15 total", () => {
+  it("should register CRUD tools + 10 tab tools + 4 DT-write tools = 19 total", () => {
     registerResourceTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(15);
+    expect(server.registerTool).toHaveBeenCalledTimes(19);
   });
 
   it("should register all CRUD tools", () => {
@@ -45,22 +54,34 @@ describe("registerResourceTools", () => {
     expect(names).toContain("boond_resources_absences_reports");
   });
 
+  it("should register all 4 technical-data write tools", () => {
+    registerResourceTools(server);
+    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
+    for (const name of WRITE_DT_TOOLS) {
+      expect(names).toContain(name);
+    }
+  });
+
   it("should register tab tools as readOnly and non-destructive", () => {
     registerResourceTools(server);
-    const tabCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && [
-        "boond_resources_information",
-        "boond_resources_technical_data",
-        "boond_resources_administrative",
-        "boond_resources_advantages",
-        "boond_resources_actions",
-        "boond_resources_positionings",
-        "boond_resources_projects",
-        "boond_resources_times_reports",
-        "boond_resources_expenses_reports",
-        "boond_resources_absences_reports",
-      ].includes(c[0] as string)
-    );
+    const tabCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          [
+            "boond_resources_information",
+            "boond_resources_technical_data",
+            "boond_resources_administrative",
+            "boond_resources_advantages",
+            "boond_resources_actions",
+            "boond_resources_positionings",
+            "boond_resources_projects",
+            "boond_resources_times_reports",
+            "boond_resources_expenses_reports",
+            "boond_resources_absences_reports",
+          ].includes(c[0] as string)
+      );
 
     expect(tabCalls).toHaveLength(10);
     for (const call of tabCalls) {
@@ -68,5 +89,288 @@ describe("registerResourceTools", () => {
       expect(metadata.annotations?.readOnlyHint).toBe(true);
       expect(metadata.annotations?.destructiveHint).toBe(false);
     }
+  });
+
+  it("flags reference_delete as destructive and the other DT writes as non-destructive", () => {
+    registerResourceTools(server);
+    const byName = new Map(vi.mocked(server.registerTool).mock.calls.map((c) => [c[0] as string, c[1]]));
+    expect(byName.get("boond_resources_technical_data_update")?.annotations?.destructiveHint).toBe(false);
+    expect(byName.get("boond_resources_reference_create")?.annotations?.destructiveHint).toBe(false);
+    expect(byName.get("boond_resources_reference_update")?.annotations?.destructiveHint).toBe(false);
+    expect(byName.get("boond_resources_reference_delete")?.annotations?.destructiveHint).toBe(true);
+  });
+
+  describe("boond_resources_technical_data_update handler", () => {
+    function getHandler() {
+      registerResourceTools(server);
+      const call = vi
+        .mocked(server.registerTool)
+        .mock.calls.find((c) => c[0] === "boond_resources_technical_data_update");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return call![2] as any;
+    }
+
+    it("fetches current DT then PUTs the merged payload in merge mode", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockImplementation(async (path, method) => {
+        if (method === undefined || method === "GET") {
+          return {
+            data: {
+              id: "42",
+              type: "resource",
+              attributes: {
+                skills: "Python, Java",
+                tools: [{ tool: "aws", level: 3 }],
+                languages: [{ language: "Anglais", level: "courant" }],
+                title: "BU Manager",
+                summary: "Old summary",
+                experience: 5,
+                expertiseAreas: ["Banque"],
+                diplomas: ["DUT Informatique"],
+              },
+            },
+          } as never;
+        }
+        return { data: { id: "42", type: "resource", attributes: {} } } as never;
+      });
+
+      const handler = getHandler();
+      await handler({
+        id: "42",
+        mode: "merge",
+        skills: "Java, TensorFlow",
+        tools: [
+          { tool: "aws", level: 1 },
+          { tool: "snowflake", level: 4 },
+        ],
+        languages: [
+          { language: "anglais", level: "scolaire" },
+          { language: "Espagnol", level: "courant" },
+        ],
+        expertiseAreas: ["Banque", "Assurance"],
+        diplomas: ["DUT Informatique", "Master IA (2018)"],
+        title: "ignored because already set",
+        summary: "ignored because already set",
+        experience: 99,
+      });
+
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      const putCall = apiSpy.mock.calls.find((c) => c[1] === "PUT");
+      expect(putCall).toBeDefined();
+      const putPath = putCall![0];
+      const putBody = putCall![2] as { data: { id: string; type: string; attributes: Record<string, unknown> } };
+
+      expect(putPath).toBe("/resources/42/technical-data");
+      expect(putBody.data.type).toBe("resource");
+      expect(putBody.data.id).toBe("42");
+
+      const attrs = putBody.data.attributes;
+      expect(attrs.skills).toBe("Python, Java, TensorFlow");
+      expect(attrs.tools).toEqual([
+        { tool: "aws", level: 3 },
+        { tool: "snowflake", level: 4 },
+      ]);
+      expect(attrs.languages).toEqual([
+        { language: "Anglais", level: "courant" },
+        { language: "Espagnol", level: "courant" },
+      ]);
+      expect(attrs.expertiseAreas).toEqual(["Banque", "Assurance"]);
+      expect(attrs.diplomas).toEqual(["DUT Informatique", "Master IA (2018)"]);
+      expect(attrs.title).toBeUndefined();
+      expect(attrs.summary).toBeUndefined();
+      expect(attrs.experience).toBeUndefined();
+    });
+
+    it("PUTs the raw payload directly in replace mode (no GET)", async () => {
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "42", type: "resource", attributes: {} } } as never);
+
+      const handler = getHandler();
+      await handler({
+        id: "42",
+        mode: "replace",
+        skills: "Python",
+        tools: [{ tool: "aws", level: 2 }],
+      });
+
+      expect(apiSpy).toHaveBeenCalledTimes(1);
+      const [path, method, body] = apiSpy.mock.calls[0];
+      expect(method).toBe("PUT");
+      expect(path).toBe("/resources/42/technical-data");
+      const attrs = (body as { data: { attributes: Record<string, unknown> } }).data.attributes;
+      expect(attrs).toEqual({ skills: "Python", tools: [{ tool: "aws", level: 2 }] });
+    });
+
+    it("short-circuits with a no-op message when merge produces no changes", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({
+        data: {
+          id: "42",
+          type: "resource",
+          attributes: {
+            skills: "Python",
+            title: "Existing title",
+          },
+        },
+      } as never);
+
+      const handler = getHandler();
+      const result = await handler({
+        id: "42",
+        mode: "merge",
+        title: "another title", // ignored: existing is non-empty
+      });
+
+      expect(apiSpy).toHaveBeenCalledTimes(1); // only the GET fetch
+      expect(result.content[0].text).toMatch(/inchangé/i);
+    });
+  });
+
+  describe("boond_resources_reference_create handler", () => {
+    it("POSTs to /resources/{id}/references with type=reference and no resourceId in attributes", async () => {
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "999", type: "reference", attributes: {} } } as never);
+
+      registerResourceTools(server);
+      const handler = vi
+        .mocked(server.registerTool)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mock.calls.find((c) => c[0] === "boond_resources_reference_create")![2] as any;
+
+      await handler({
+        resourceId: "42",
+        title: "Lead Dev",
+        company: "Acme",
+        startMonth: "01",
+        startYear: "2024",
+      });
+
+      const [path, method, body] = apiSpy.mock.calls[0];
+      expect(path).toBe("/resources/42/references");
+      expect(method).toBe("POST");
+      const data = (body as { data: { type: string; attributes: Record<string, unknown>; id?: string } }).data;
+      expect(data.type).toBe("reference");
+      expect(data.id).toBeUndefined();
+      expect(data.attributes).toEqual({
+        title: "Lead Dev",
+        company: "Acme",
+        startMonth: "01",
+        startYear: "2024",
+      });
+    });
+  });
+
+  describe("boond_resources_reference_update handler", () => {
+    it("PUTs to /references/{id} with only the provided attributes", async () => {
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "999", type: "reference", attributes: {} } } as never);
+
+      registerResourceTools(server);
+      const handler = vi
+        .mocked(server.registerTool)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mock.calls.find((c) => c[0] === "boond_resources_reference_update")![2] as any;
+
+      await handler({
+        referenceId: "999",
+        endMonth: "12",
+        endYear: "2025",
+      });
+
+      const [path, method, body] = apiSpy.mock.calls[0];
+      expect(path).toBe("/references/999");
+      expect(method).toBe("PUT");
+      const data = (body as { data: { id: string; type: string; attributes: Record<string, unknown> } }).data;
+      expect(data.id).toBe("999");
+      expect(data.attributes).toEqual({ endMonth: "12", endYear: "2025" });
+    });
+  });
+
+  describe("boond_resources_reference_delete handler", () => {
+    it("DELETEs /references/{id}", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({ data: [] } as never);
+
+      registerResourceTools(server);
+      const handler = vi
+        .mocked(server.registerTool)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mock.calls.find((c) => c[0] === "boond_resources_reference_delete")![2] as any;
+
+      const result = await handler({ referenceId: "999" });
+      expect(apiSpy).toHaveBeenCalledWith("/references/999", "DELETE");
+      expect(result.content[0].text).toMatch(/999/);
+    });
+  });
+});
+
+describe("mergeTechnicalData", () => {
+  it("only emits keys that the caller actually provided", () => {
+    const out = mergeTechnicalData(
+      { skills: "Python", title: "Existing", tools: [{ tool: "aws", level: 3 }] },
+      { skills: "Java" }
+    );
+    expect(Object.keys(out).sort()).toEqual(["skills"]);
+  });
+
+  it("dedups skills case-insensitively while preserving original casing", () => {
+    const out = mergeTechnicalData({ skills: "Python, AWS" }, { skills: "python, GCP" });
+    expect(out.skills).toBe("Python, AWS, GCP");
+  });
+
+  it("keeps existing tool level when slug is already present (no overwrite)", () => {
+    const out = mergeTechnicalData(
+      { tools: [{ tool: "aws", level: 3 }] },
+      {
+        tools: [
+          { tool: "aws", level: 1 },
+          { tool: "gcp", level: 2 },
+        ],
+      }
+    );
+    expect(out.tools).toEqual([
+      { tool: "aws", level: 3 },
+      { tool: "gcp", level: 2 },
+    ]);
+  });
+
+  it("keeps existing language level when language is already present", () => {
+    const out = mergeTechnicalData(
+      { languages: [{ language: "Anglais", level: "courant" }] },
+      {
+        languages: [
+          { language: "anglais", level: "scolaire" },
+          { language: "Espagnol", level: "courant" },
+        ],
+      }
+    );
+    expect(out.languages).toEqual([
+      { language: "Anglais", level: "courant" },
+      { language: "Espagnol", level: "courant" },
+    ]);
+  });
+
+  it("fills title/summary/training only when currently blank", () => {
+    const out = mergeTechnicalData(
+      { title: "", summary: "Existing summary", training: null as unknown as string },
+      { title: "Manager", summary: "New summary", training: "BAC+5" }
+    );
+    expect(out.title).toBe("Manager");
+    expect(out.training).toBe("BAC+5");
+    expect(out.summary).toBeUndefined();
+  });
+
+  it("fills experience only when current is 0/empty", () => {
+    expect(mergeTechnicalData({ experience: 0 }, { experience: 7 }).experience).toBe(7);
+    expect(mergeTechnicalData({ experience: 5 }, { experience: 7 }).experience).toBeUndefined();
+  });
+
+  it("dedups string-array fields like expertiseAreas/diplomas", () => {
+    const out = mergeTechnicalData(
+      { expertiseAreas: ["Banque"], diplomas: ["DUT Info"] },
+      { expertiseAreas: ["banque", "Assurance"], diplomas: ["DUT Info", "Master IA"] }
+    );
+    expect(out.expertiseAreas).toEqual(["Banque", "Assurance"]);
+    expect(out.diplomas).toEqual(["DUT Info", "Master IA"]);
   });
 });

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -1,6 +1,21 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ResourceCreateSchema, ResourceUpdateSchema, ResourceSearchSchema, IdSchema } from "../schemas/index.js";
-import type { IdInput } from "../schemas/index.js";
+import {
+  ResourceCreateSchema,
+  ResourceUpdateSchema,
+  ResourceSearchSchema,
+  ResourceTechnicalDataUpdateSchema,
+  ReferenceCreateSchema,
+  ReferenceUpdateSchema,
+  ReferenceIdSchema,
+  IdSchema,
+} from "../schemas/index.js";
+import type {
+  IdInput,
+  ResourceTechnicalDataUpdateInput,
+  ReferenceCreateInput,
+  ReferenceUpdateInput,
+  ReferenceIdInput,
+} from "../schemas/index.js";
 import {
   registerSearchTool,
   registerGetTool,
@@ -164,6 +179,115 @@ Pagination : \`page\` (1+), \`pageSize\` (1-500). Tri : \`sort: "lastName"\` (ou
 
 Returns : liste paginée. Utiliser \`boond_resources_get\` ou les outils d'onglets pour le détail.`;
 
+type DtToolItem = { tool: string; level: number };
+type DtLanguageItem = { language: string; level: string };
+
+// Merge a partial DT payload into the current DT attributes per the rules
+// agreed in spec issue #79. Only keys actually present in `input` are touched;
+// everything else is left untouched (i.e. not sent back to the API).
+export function mergeTechnicalData(
+  current: Record<string, unknown>,
+  input: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+
+  const isBlank = (v: unknown) => v === undefined || v === null || v === "";
+
+  // Scalars filled only when the existing value is blank.
+  for (const key of ["title", "summary", "training"] as const) {
+    if (input[key] !== undefined && isBlank(current[key])) {
+      out[key] = input[key];
+    }
+  }
+  if (input.experience !== undefined) {
+    const cur = current.experience;
+    if (cur === undefined || cur === null || cur === 0) {
+      out.experience = input.experience;
+    }
+  }
+
+  if (typeof input.skills === "string") {
+    const split = (s: string) =>
+      s
+        .split(",")
+        .map((x) => x.trim())
+        .filter((x) => x !== "");
+    const curList = typeof current.skills === "string" ? split(current.skills) : [];
+    const newItems = split(input.skills);
+    const seen = new Set(curList.map((s) => s.toLowerCase()));
+    const additions = newItems.filter((s) => {
+      const k = s.toLowerCase();
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+    out.skills = [...curList, ...additions].join(", ");
+  }
+
+  for (const key of ["expertiseAreas", "activityAreas", "diplomas"] as const) {
+    const incoming = input[key];
+    if (Array.isArray(incoming)) {
+      const cur = Array.isArray(current[key]) ? (current[key] as unknown[]).map((v) => String(v)) : [];
+      const seen = new Set(cur.map((s) => s.toLowerCase()));
+      const merged = [...cur];
+      for (const raw of incoming) {
+        const v = String(raw);
+        const k = v.toLowerCase();
+        if (!seen.has(k)) {
+          seen.add(k);
+          merged.push(v);
+        }
+      }
+      out[key] = merged;
+    }
+  }
+
+  if (Array.isArray(input.tools)) {
+    const cur = Array.isArray(current.tools) ? (current.tools as Array<Record<string, unknown>>) : [];
+    const existing = new Set(cur.map((t) => String(t.tool).toLowerCase()));
+    const additions = (input.tools as DtToolItem[]).filter((t) => !existing.has(String(t.tool).toLowerCase()));
+    out.tools = [...cur, ...additions];
+  }
+
+  if (Array.isArray(input.languages)) {
+    const cur = Array.isArray(current.languages) ? (current.languages as Array<Record<string, unknown>>) : [];
+    const existing = new Set(cur.map((l) => String(l.language).toLowerCase()));
+    const additions = (input.languages as DtLanguageItem[]).filter(
+      (l) => !existing.has(String(l.language).toLowerCase())
+    );
+    out.languages = [...cur, ...additions];
+  }
+
+  return out;
+}
+
+const TECHNICAL_DATA_UPDATE_DESCRIPTION = `Met à jour le dossier technique (DT) d'une ressource : compétences, outils, langues, expertises, formations, diplômes, expérience.
+
+Mode 'merge' (défaut, recommandé pour automation) — enrichit sans rien écraser :
+• skills (CSV) : concatène les compétences absentes
+• tools / languages : ajoute les entrées dont la clé (slug outil / langue) est nouvelle, conserve le niveau existant pour les autres
+• expertiseAreas, activityAreas, diplomas : ajoute les items absents
+• title, summary, training, experience : remplis UNIQUEMENT si actuellement vides
+
+Mode 'replace' — remplace intégralement chaque champ fourni par la valeur passée. Les champs non passés ne sont pas touchés.
+
+Seuls les champs explicitement fournis dans l'appel sont envoyés à l'API — un champ omis ne sera jamais réinitialisé à vide.
+
+Les expériences professionnelles (références) ne sont PAS gérées ici : utiliser boond_resources_reference_{create|update|delete}.`;
+
+const REFERENCE_CREATE_DESCRIPTION = `Crée une expérience professionnelle (référence) rattachée au DT d'une ressource.
+
+Champs requis : resourceId, title, company.
+Dates : startMonth/endMonth au format '01'..'12' et startYear/endYear au format 'YYYY' (chaînes, pas entiers).
+
+Pour ajouter des dates manquantes à une référence existante, préférer boond_resources_reference_update pour ne pas dupliquer.`;
+
+const REFERENCE_UPDATE_DESCRIPTION = `Met à jour une référence existante. Seuls les champs explicitement fournis sont envoyés à l'API — un champ omis ne sera jamais écrasé par "".
+
+Cas d'usage type : compléter startMonth/startYear/endMonth/endYear sur une référence sans toucher au titre, à la société ou à la description.`;
+
+const REFERENCE_DELETE_DESCRIPTION = `Supprime définitivement une référence (expérience professionnelle) du DT d'une ressource. ⚠️ Action irréversible — vérifier l'ID au préalable.`;
+
 export function registerResourceTools(server: McpServer): void {
   registerSearchTool(server, OPTS, {
     schema: ResourceSearchSchema,
@@ -202,4 +326,140 @@ export function registerResourceTools(server: McpServer): void {
       }
     );
   }
+
+  server.registerTool(
+    "boond_resources_technical_data_update",
+    {
+      title: "Mettre à jour le dossier technique d'une ressource",
+      description: TECHNICAL_DATA_UPDATE_DESCRIPTION,
+      inputSchema: ResourceTechnicalDataUpdateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (params: ResourceTechnicalDataUpdateInput) => {
+      const { id, mode, ...rest } = params;
+      const provided: Record<string, unknown> = Object.fromEntries(
+        Object.entries(rest).filter(([, v]) => v !== undefined)
+      );
+
+      let attributes: Record<string, unknown>;
+      if (mode === "replace") {
+        attributes = provided;
+      } else {
+        const currentResponse = await apiRequest(`/resources/${id}/technical-data`);
+        const currentEntity = Array.isArray(currentResponse.data) ? currentResponse.data[0] : currentResponse.data;
+        const currentAttrs = (currentEntity?.attributes ?? {}) as Record<string, unknown>;
+        attributes = mergeTechnicalData(currentAttrs, provided);
+      }
+
+      if (Object.keys(attributes).length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `ℹ️ Dossier technique #${id} inchangé (aucun champ à mettre à jour en mode ${mode}).`,
+            },
+          ],
+        };
+      }
+
+      const body = buildJsonApiBody("resource", attributes, id);
+      const response = await apiRequest(`/resources/${id}/technical-data`, "PUT", body);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `✅ Dossier technique de la ressource #${id} mis à jour (mode: ${mode}).\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerTool(
+    "boond_resources_reference_create",
+    {
+      title: "Créer une référence (expérience pro) sur une ressource",
+      description: REFERENCE_CREATE_DESCRIPTION,
+      inputSchema: ReferenceCreateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params: ReferenceCreateInput) => {
+      const { resourceId, ...attrs } = params;
+      const body = buildJsonApiBody("reference", attrs);
+      const response = await apiRequest(`/resources/${resourceId}/references`, "POST", body);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `✅ Référence créée pour la ressource #${resourceId}.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerTool(
+    "boond_resources_reference_update",
+    {
+      title: "Modifier une référence (expérience pro)",
+      description: REFERENCE_UPDATE_DESCRIPTION,
+      inputSchema: ReferenceUpdateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (params: ReferenceUpdateInput) => {
+      const { referenceId, ...attrs } = params;
+      const body = buildJsonApiBody("reference", attrs, referenceId);
+      const response = await apiRequest(`/references/${referenceId}`, "PUT", body);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `✅ Référence #${referenceId} mise à jour.\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerTool(
+    "boond_resources_reference_delete",
+    {
+      title: "Supprimer une référence (expérience pro)",
+      description: REFERENCE_DELETE_DESCRIPTION,
+      inputSchema: ReferenceIdSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params: ReferenceIdInput) => {
+      await apiRequest(`/references/${params.referenceId}`, "DELETE");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `🗑️ Référence #${params.referenceId} supprimée.`,
+          },
+        ],
+      };
+    }
+  );
 }


### PR DESCRIPTION
Closes #79.

## Summary

Adds four write tools so the technical dossier (DT) of a resource can be enriched programmatically — previously the DT was read-only via `boond_resources_technical_data`.

- **`boond_resources_technical_data_update`** — `PUT /resources/{id}/technical-data`
  - `mode: "merge"` (default, recommended for automation): fetches the current DT, then:
    - `skills` (CSV) : case-insensitive dedup, preserves existing casing/order
    - `tools` / `languages` : append entries with new slugs/languages; **never overwrite an existing level**
    - `expertiseAreas` / `activityAreas` / `diplomas` : union (dedup case-insensitive)
    - `title` / `summary` / `training` / `experience` : filled **only when currently blank**
    - If nothing would change, short-circuits without a PUT
  - `mode: "replace"` : sends each provided field verbatim
  - Keys absent from the call are never emitted — protects against the "implicit `""` overwrite" garde-fou flagged in the spec.
- **`boond_resources_reference_create`** — `POST /resources/{id}/references`
- **`boond_resources_reference_update`** — `PUT /references/{id}` (only sends explicitly-provided attrs)
- **`boond_resources_reference_delete`** — `DELETE /references/{id}` (flagged `destructiveHint`)

The merge helper `mergeTechnicalData` is exported for unit testing.

`TOOLS.md` regenerated; tool count goes from 167 → 171.

## Test plan

- [x] `npm test` — 49 files / 440 tests pass (19 of those new on `resources.test.ts`)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run docs:tools:check` — TOOLS.md not stale
- [x] Live test on the author's own profile (#18081) against `https://ui.boondmanager.com/api`:
  - Read DT → empty `skills`, 2 diplomas, 3 tools
  - `merge` PUT with a `MCP-Test-…` skill + a test diploma → API accepts; new skill filled the empty field, diploma appended to existing 2, tools/languages/title/summary untouched
  - Rollback PUT → DT identical to original state