### PR TITLE
fix(resources): route reference CRUD through technical-data PUT

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -586,49 +586,74 @@ export const ResourceTechnicalDataUpdateSchema = z
   .strict();
 
 // ---- Reference (DT experience) schemas ----
-// Source: spec issue #79. POST /resources/{id}/references — PUT/DELETE /references/{id}.
-const referenceMonth = z
-  .string()
-  .regex(/^(0[1-9]|1[0-2])$/)
-  .describe("Mois sur 2 chiffres ('01'..'12').");
-const referenceYear = z
-  .string()
-  .regex(/^\d{4}$/)
-  .describe("Année sur 4 chiffres (ex: '2024').");
+// Validated live against the BoondManager API on 2026-05-20: references are NOT a
+// standalone REST entity. They're sub-objects embedded in the resource's DT (the
+// `attributes.references` array returned by `/resources/{id}/technical-data`).
+// All CRUD on references therefore goes through `PUT /resources/{id}/technical-data`
+// with the full `references` array.
+//
+// API quirks learned from probing:
+// - `description` is REQUIRED for any new reference (1017 otherwise)
+// - `startMonth` / `endMonth` accept int 1..12 OR string without leading zero ("5")
+//   — "05" is rejected with 1002. We normalize to int via `z.coerce.number()`.
+// - `startYear` / `endYear` accept int or string YYYY — coerced to int.
+const referenceMonth = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(12)
+  .describe("Mois (1-12). Accepte int ou string ('5'). ⚠️ '05' avec leading zero est rejeté par l'API Boond.");
+const referenceYear = z.coerce
+  .number()
+  .int()
+  .min(1900)
+  .max(2100)
+  .describe("Année (ex: 2024). Accepte int ou string '2024'.");
 
 export const ReferenceCreateSchema = z
   .object({
     resourceId: z.string().min(1).describe("ID de la ressource à laquelle rattacher la référence."),
     title: z.string().min(1).describe("Intitulé du poste."),
     company: z.string().min(1).describe("Société / employeur."),
+    description: z
+      .string()
+      .min(1)
+      .describe("Description / missions / réalisations. ⚠️ Requis côté API Boond (1017 sans)."),
     location: z.string().optional().describe("Lieu (ville)."),
     startMonth: referenceMonth.optional(),
     startYear: referenceYear.optional(),
     endMonth: referenceMonth.optional(),
     endYear: referenceYear.optional(),
     skills: z.string().optional().describe("Compétences mobilisées (texte libre, séparées par virgule)."),
-    description: z.string().optional().describe("Description / missions / réalisations."),
   })
   .strict();
 
 export const ReferenceUpdateSchema = z
   .object({
+    resourceId: z
+      .string()
+      .min(1)
+      .describe("ID de la ressource portant la référence (les references sont embarquées dans le DT)."),
     referenceId: z.string().min(1).describe("ID de la référence à modifier."),
     title: z.string().optional().describe("Intitulé du poste."),
     company: z.string().optional().describe("Société / employeur."),
+    description: z.string().optional().describe("Description / missions / réalisations."),
     location: z.string().optional().describe("Lieu (ville)."),
     startMonth: referenceMonth.optional(),
     startYear: referenceYear.optional(),
     endMonth: referenceMonth.optional(),
     endYear: referenceYear.optional(),
     skills: z.string().optional().describe("Compétences mobilisées."),
-    description: z.string().optional().describe("Description."),
   })
   .strict();
 
 export const ReferenceIdSchema = z
   .object({
-    referenceId: z.string().min(1).describe("ID de la référence."),
+    resourceId: z
+      .string()
+      .min(1)
+      .describe("ID de la ressource portant la référence (les references sont embarquées dans le DT)."),
+    referenceId: z.string().min(1).describe("ID de la référence à supprimer."),
   })
   .strict();
 

--- a/src/tools/resources.test.ts
+++ b/src/tools/resources.test.ts
@@ -225,11 +225,50 @@ describe("registerResourceTools", () => {
     });
   });
 
+  // References live as embedded sub-objects inside /resources/{id}/technical-data.
+  // The three reference tools therefore all do a GET-then-PUT on technical-data
+  // (full references[] array republished).
+  function mockDtRefs(refs: Array<Record<string, unknown>>) {
+    return vi.spyOn(boondClient, "apiRequest").mockImplementation(async (_path, method, body) => {
+      if (method === undefined || method === "GET") {
+        return {
+          data: { id: "42", type: "resource", attributes: { references: refs } },
+        } as never;
+      }
+      const next =
+        (body as { data?: { attributes?: { references?: Array<Record<string, unknown>> } } } | undefined)?.data
+          ?.attributes?.references ?? refs;
+      return {
+        data: { id: "42", type: "resource", attributes: { references: next } },
+      } as never;
+    });
+  }
+
   describe("boond_resources_reference_create handler", () => {
-    it("POSTs to /resources/{id}/references with type=reference and no resourceId in attributes", async () => {
-      const apiSpy = vi
-        .spyOn(boondClient, "apiRequest")
-        .mockResolvedValue({ data: { id: "999", type: "reference", attributes: {} } } as never);
+    it("GETs the current refs then PUTs technical-data with the new ref appended", async () => {
+      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockImplementation(async (_p, method) => {
+        if (method === undefined || method === "GET") {
+          return {
+            data: {
+              id: "42",
+              type: "resource",
+              attributes: { references: [{ id: "10", title: "Existing", company: "Old Co", description: "x" }] },
+            },
+          } as never;
+        }
+        return {
+          data: {
+            id: "42",
+            type: "resource",
+            attributes: {
+              references: [
+                { id: "10", title: "Existing", company: "Old Co", description: "x" },
+                { id: "11", title: "Lead Dev", company: "Acme", description: "New role" },
+              ],
+            },
+          },
+        } as never;
+      });
 
       registerResourceTools(server);
       const handler = vi
@@ -237,34 +276,54 @@ describe("registerResourceTools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mock.calls.find((c) => c[0] === "boond_resources_reference_create")![2] as any;
 
-      await handler({
+      const result = await handler({
         resourceId: "42",
         title: "Lead Dev",
         company: "Acme",
-        startMonth: "01",
-        startYear: "2024",
+        description: "New role",
+        startMonth: 5,
+        startYear: 2024,
       });
 
-      const [path, method, body] = apiSpy.mock.calls[0];
-      expect(path).toBe("/resources/42/references");
-      expect(method).toBe("POST");
-      const data = (body as { data: { type: string; attributes: Record<string, unknown>; id?: string } }).data;
-      expect(data.type).toBe("reference");
-      expect(data.id).toBeUndefined();
-      expect(data.attributes).toEqual({
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      expect(apiSpy.mock.calls[0][0]).toBe("/resources/42/technical-data");
+      expect(apiSpy.mock.calls[0][1]).toBeUndefined();
+
+      const [putPath, putMethod, putBody] = apiSpy.mock.calls[1];
+      expect(putPath).toBe("/resources/42/technical-data");
+      expect(putMethod).toBe("PUT");
+      const data = (putBody as { data: { id: string; type: string; attributes: { references: unknown[] } } }).data;
+      expect(data.id).toBe("42");
+      expect(data.type).toBe("resource");
+      const refs = data.attributes.references;
+      expect(refs).toHaveLength(2);
+      expect(refs[0]).toEqual({ id: "10", title: "Existing", company: "Old Co", description: "x" });
+      expect(refs[1]).toEqual({
         title: "Lead Dev",
         company: "Acme",
-        startMonth: "01",
-        startYear: "2024",
+        description: "New role",
+        startMonth: 5,
+        startYear: 2024,
       });
+      expect(result.content[0].text).toMatch(/✅/);
     });
   });
 
   describe("boond_resources_reference_update handler", () => {
-    it("PUTs to /references/{id} with only the provided attributes", async () => {
-      const apiSpy = vi
-        .spyOn(boondClient, "apiRequest")
-        .mockResolvedValue({ data: { id: "999", type: "reference", attributes: {} } } as never);
+    it("patches only the provided fields of the matching reference, others intact", async () => {
+      const apiSpy = mockDtRefs([
+        {
+          id: "10",
+          title: "Silamir",
+          company: "Silamir Group",
+          description: "BU Manager",
+          startMonth: "",
+          startYear: "",
+          endMonth: "",
+          endYear: "",
+        },
+        { id: "20", title: "AFD.TECH", company: "AFD", description: "Lead Dev", startMonth: "1", startYear: "2022" },
+      ]);
 
       registerResourceTools(server);
       const handler = vi
@@ -273,23 +332,63 @@ describe("registerResourceTools", () => {
         .mock.calls.find((c) => c[0] === "boond_resources_reference_update")![2] as any;
 
       await handler({
-        referenceId: "999",
-        endMonth: "12",
-        endYear: "2025",
+        resourceId: "42",
+        referenceId: "10",
+        startMonth: 5,
+        startYear: 2024,
+        endMonth: 1,
+        endYear: 2026,
       });
 
-      const [path, method, body] = apiSpy.mock.calls[0];
-      expect(path).toBe("/references/999");
-      expect(method).toBe("PUT");
-      const data = (body as { data: { id: string; type: string; attributes: Record<string, unknown> } }).data;
-      expect(data.id).toBe("999");
-      expect(data.attributes).toEqual({ endMonth: "12", endYear: "2025" });
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      const [, , putBody] = apiSpy.mock.calls[1];
+      const refs = (putBody as { data: { attributes: { references: Array<Record<string, unknown>> } } }).data.attributes
+        .references;
+      expect(refs).toHaveLength(2);
+      // Reference #10: dates filled, title/company/description preserved
+      expect(refs[0]).toEqual({
+        id: "10",
+        title: "Silamir",
+        company: "Silamir Group",
+        description: "BU Manager",
+        startMonth: 5,
+        startYear: 2024,
+        endMonth: 1,
+        endYear: 2026,
+      });
+      // Reference #20: untouched
+      expect(refs[1]).toEqual({
+        id: "20",
+        title: "AFD.TECH",
+        company: "AFD",
+        description: "Lead Dev",
+        startMonth: "1",
+        startYear: "2022",
+      });
+    });
+
+    it("returns isError=true with hint when the ref id isn't on the resource", async () => {
+      mockDtRefs([{ id: "10", title: "Other" }]);
+
+      registerResourceTools(server);
+      const handler = vi
+        .mocked(server.registerTool)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mock.calls.find((c) => c[0] === "boond_resources_reference_update")![2] as any;
+
+      const result = await handler({ resourceId: "42", referenceId: "999", endMonth: 5 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/introuvable/i);
+      expect(result.content[0].text).toMatch(/10/); // lists existing ids
     });
   });
 
   describe("boond_resources_reference_delete handler", () => {
-    it("DELETEs /references/{id}", async () => {
-      const apiSpy = vi.spyOn(boondClient, "apiRequest").mockResolvedValue({ data: [] } as never);
+    it("PUTs technical-data with the targeted reference removed", async () => {
+      const apiSpy = mockDtRefs([
+        { id: "10", title: "Keep me" },
+        { id: "20", title: "Delete me" },
+      ]);
 
       registerResourceTools(server);
       const handler = vi
@@ -297,9 +396,29 @@ describe("registerResourceTools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mock.calls.find((c) => c[0] === "boond_resources_reference_delete")![2] as any;
 
-      const result = await handler({ referenceId: "999" });
-      expect(apiSpy).toHaveBeenCalledWith("/references/999", "DELETE");
-      expect(result.content[0].text).toMatch(/999/);
+      const result = await handler({ resourceId: "42", referenceId: "20" });
+      expect(apiSpy).toHaveBeenCalledTimes(2);
+      const [, method, putBody] = apiSpy.mock.calls[1];
+      expect(method).toBe("PUT");
+      const refs = (putBody as { data: { attributes: { references: Array<Record<string, unknown>> } } }).data.attributes
+        .references;
+      expect(refs).toEqual([{ id: "10", title: "Keep me" }]);
+      expect(result.content[0].text).toMatch(/🗑️/);
+    });
+
+    it("returns isError when the ref id isn't on the resource", async () => {
+      const apiSpy = mockDtRefs([{ id: "10", title: "Only one" }]);
+
+      registerResourceTools(server);
+      const handler = vi
+        .mocked(server.registerTool)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mock.calls.find((c) => c[0] === "boond_resources_reference_delete")![2] as any;
+
+      const result = await handler({ resourceId: "42", referenceId: "999" });
+      expect(result.isError).toBe(true);
+      // Only the GET happened; no PUT
+      expect(apiSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -277,16 +277,52 @@ Les expériences professionnelles (références) ne sont PAS gérées ici : util
 
 const REFERENCE_CREATE_DESCRIPTION = `Crée une expérience professionnelle (référence) rattachée au DT d'une ressource.
 
-Champs requis : resourceId, title, company.
-Dates : startMonth/endMonth au format '01'..'12' et startYear/endYear au format 'YYYY' (chaînes, pas entiers).
+⚠️ Les références sont des sous-objets embarqués dans le DT, pas une entité REST autonome. L'outil fait read-modify-write : lit la liste actuelle via /resources/{id}/technical-data, ajoute la nouvelle référence et republie la liste complète.
 
-Pour ajouter des dates manquantes à une référence existante, préférer boond_resources_reference_update pour ne pas dupliquer.`;
+Champs requis : resourceId, title, company, description.
+Dates : startMonth/endMonth en int 1..12 (ou string '1'..'12' sans leading zero) ; startYear/endYear en int 4 chiffres. ⚠️ "05" avec leading zero est rejeté par l'API.
 
-const REFERENCE_UPDATE_DESCRIPTION = `Met à jour une référence existante. Seuls les champs explicitement fournis sont envoyés à l'API — un champ omis ne sera jamais écrasé par "".
+Pour compléter une référence existante, utiliser boond_resources_reference_update pour ne pas dupliquer.`;
+
+const REFERENCE_UPDATE_DESCRIPTION = `Met à jour une référence existante. Read-modify-write sur /resources/{id}/technical-data — seuls les champs explicitement fournis remplacent ceux de la référence ciblée, les autres champs et toutes les autres références restent intacts.
 
 Cas d'usage type : compléter startMonth/startYear/endMonth/endYear sur une référence sans toucher au titre, à la société ou à la description.`;
 
-const REFERENCE_DELETE_DESCRIPTION = `Supprime définitivement une référence (expérience professionnelle) du DT d'une ressource. ⚠️ Action irréversible — vérifier l'ID au préalable.`;
+const REFERENCE_DELETE_DESCRIPTION = `Supprime une référence (expérience professionnelle) du DT d'une ressource. Read-modify-write : lit la liste actuelle, en retire la référence ciblée, republie le reste. ⚠️ Action irréversible — vérifier l'ID au préalable.`;
+
+type EmbeddedReference = Record<string, unknown> & { id?: string | number };
+
+async function fetchTechnicalDataReferences(resourceId: string): Promise<EmbeddedReference[]> {
+  const response = await apiRequest(`/resources/${resourceId}/technical-data`);
+  const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+  const refs = (entity?.attributes as { references?: unknown })?.references;
+  return Array.isArray(refs) ? (refs as EmbeddedReference[]) : [];
+}
+
+// Boond's GET on /technical-data returns empty strings for unset date fields
+// (`startMonth: ""`, `startYear: ""`, …) but its PUT validator rejects those
+// same empty strings with "1002 Wrong or missing attribute". So when we
+// echo back references unchanged we have to scrub null/empty fields first,
+// otherwise an innocuous round-trip blows up on any reference that has
+// missing dates. Exported for tests.
+export function normalizeReferenceForApi(ref: EmbeddedReference): EmbeddedReference {
+  const out: EmbeddedReference = {};
+  for (const [k, v] of Object.entries(ref)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string" && v === "") continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+async function putTechnicalDataReferences(
+  resourceId: string,
+  references: EmbeddedReference[]
+): Promise<ReturnType<typeof apiRequest>> {
+  const sanitized = references.map(normalizeReferenceForApi);
+  const body = buildJsonApiBody("resource", { references: sanitized }, resourceId);
+  return apiRequest(`/resources/${resourceId}/technical-data`, "PUT", body);
+}
 
 export function registerResourceTools(server: McpServer): void {
   registerSearchTool(server, OPTS, {
@@ -395,14 +431,21 @@ export function registerResourceTools(server: McpServer): void {
     },
     async (params: ReferenceCreateInput) => {
       const { resourceId, ...attrs } = params;
-      const body = buildJsonApiBody("reference", attrs);
-      const response = await apiRequest(`/resources/${resourceId}/references`, "POST", body);
+      const provided: Record<string, unknown> = Object.fromEntries(
+        Object.entries(attrs).filter(([, v]) => v !== undefined)
+      );
+      const current = await fetchTechnicalDataReferences(resourceId);
+      const next = [...current, provided as EmbeddedReference];
+      const response = await putTechnicalDataReferences(resourceId, next);
       const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      const refs = ((entity?.attributes as { references?: EmbeddedReference[] })?.references ??
+        []) as EmbeddedReference[];
+      const created = refs[refs.length - 1];
       return {
         content: [
           {
             type: "text" as const,
-            text: `✅ Référence créée pour la ressource #${resourceId}.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+            text: `✅ Référence créée sur la ressource #${resourceId} (${refs.length} référence(s) au total).\nID: ${created?.id ?? "(non retourné)"}\n\n${formatDetailResponse(response)}`,
           },
         ],
       };
@@ -423,14 +466,31 @@ export function registerResourceTools(server: McpServer): void {
       },
     },
     async (params: ReferenceUpdateInput) => {
-      const { referenceId, ...attrs } = params;
-      const body = buildJsonApiBody("reference", attrs, referenceId);
-      const response = await apiRequest(`/references/${referenceId}`, "PUT", body);
+      const { resourceId, referenceId, ...attrs } = params;
+      const provided: Record<string, unknown> = Object.fromEntries(
+        Object.entries(attrs).filter(([, v]) => v !== undefined)
+      );
+      const current = await fetchTechnicalDataReferences(resourceId);
+      const idx = current.findIndex((r) => String(r.id) === String(referenceId));
+      if (idx === -1) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Référence #${referenceId} introuvable sur la ressource #${resourceId}. IDs présents: ${current.map((r) => r.id).join(", ") || "(aucun)"}.`,
+            },
+          ],
+        };
+      }
+      const next = [...current];
+      next[idx] = { ...current[idx], ...provided };
+      const response = await putTechnicalDataReferences(resourceId, next);
       return {
         content: [
           {
             type: "text" as const,
-            text: `✅ Référence #${referenceId} mise à jour.\n\n${formatDetailResponse(response)}`,
+            text: `✅ Référence #${referenceId} mise à jour sur la ressource #${resourceId}.\n\n${formatDetailResponse(response)}`,
           },
         ],
       };
@@ -451,12 +511,26 @@ export function registerResourceTools(server: McpServer): void {
       },
     },
     async (params: ReferenceIdInput) => {
-      await apiRequest(`/references/${params.referenceId}`, "DELETE");
+      const { resourceId, referenceId } = params;
+      const current = await fetchTechnicalDataReferences(resourceId);
+      const next = current.filter((r) => String(r.id) !== String(referenceId));
+      if (next.length === current.length) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Référence #${referenceId} introuvable sur la ressource #${resourceId}. IDs présents: ${current.map((r) => r.id).join(", ") || "(aucun)"}.`,
+            },
+          ],
+        };
+      }
+      await putTechnicalDataReferences(resourceId, next);
       return {
         content: [
           {
             type: "text" as const,
-            text: `🗑️ Référence #${params.referenceId} supprimée.`,
+            text: `🗑️ Référence #${referenceId} supprimée de la ressource #${resourceId} (${next.length} référence(s) restante(s)).`,
           },
         ],
       };


### PR DESCRIPTION
## Summary

The reference tools added in 1.9.0 (#80) hit endpoints that don't exist on the BoondManager API and returned 404 for every reference operation in production. Live probing showed that **references are not a standalone REST entity** — they're sub-objects embedded in the resource's DT (the `attributes.references[]` array of `/resources/{id}/technical-data`). All CRUD must therefore go through `PUT /resources/{id}/technical-data` with the full updated `references` array.

### Tool behavior changes

- **`boond_resources_reference_create`** — GET current DT, append new ref, PUT full array. `description` is now **required** (Boond returns 1017 without it).
- **`boond_resources_reference_update`** — now requires `resourceId` in addition to `referenceId`. GET → locate ref by id → patch only the provided fields → PUT. Returns `isError: true` with the list of existing ids when the ref isn't found, instead of an opaque 404.
- **`boond_resources_reference_delete`** — same read-modify-write pattern with the targeted ref filtered out. Also requires `resourceId`.

### API quirks handled by the patch

- **Empty-string echo bug**: Boond's GET returns `""` for unset date fields (`startMonth`, `startYear`, …) but its PUT validator rejects `""` with `1002 - Wrong or missing attribute`. A new `normalizeReferenceForApi()` strips empty / null fields from every reference before PUT, so echoing the existing list back doesn't blow up on the dates of every ref that has some unset. Exported for tests.
- **Date format**: `startMonth` / `endMonth` schemas now coerce to `int 1..12` (input accepts int or string without leading zero — `"05"` is rejected by the API with 1002). Same coercion on `startYear` / `endYear` to int.

### Validated live

On Damien FRANCES (#36639, 7 refs): the patched `reference_update` filled `startMonth: 5 / startYear: 2024 / endMonth: 1 / endYear: 2026` on the Silamir Group ref, the 6 other refs were preserved unchanged, and `title` / `company` / `description` of the patched ref were untouched.

Closes the follow-up bug surfaced on the 1.9.0 production run (the Damien dossier could not have its 7 reference periods updated).

## Test plan

- [x] `npm test` — **442 tests** pass (+2 vs 1.9.0, both covering the new "ref id not found → isError" path on update and delete)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run docs:tools` — TOOLS.md not stale
- [x] Live test on Damien FRANCES #36639 — Silamir ref dates filled, 6 others intact