### PR TITLE
feat(auth)!: OAuth2 protected-resource on HTTP transport (2.0.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# BoondManager MCP server — environment template for docker-compose.
+# Copy to `.env` and fill in. `.env` is gitignored; never commit secrets.
+#
+# The HTTP transport runs as an OAuth2 *protected resource* — it holds
+# no client_secret, no refresh token, no per-user state. Each MCP client
+# performs the OAuth dance directly against BoondManager and sends its
+# own Bearer token on every request. This file is therefore mostly
+# optional: defaults work for local loopback deployments.
+
+# ---- Public URL of this MCP endpoint (required when fronted by a proxy)
+# Used as the `resource` field of the protected-resource metadata and in
+# the WWW-Authenticate challenge. Defaults to http://<host>:<port><path>,
+# which is only correct for local / loopback deployments.
+# MCP_HTTP_PUBLIC_URL=https://mcp.example.com/mcp
+
+# ---- BoondManager OAuth advertised metadata (optional) -----------------
+# Authorization server URL exposed via /.well-known/oauth-protected-resource
+# so MCP clients can auto-discover where to send the user. Override only
+# if your tenant uses a non-default issuer.
+# BOOND_OAUTH_AUTHORIZATION_SERVER=https://ui.boondmanager.com
+
+# Optional: scopes advertised in the discovery metadata. Space or comma
+# separated. Empty = clients negotiate scopes with Boond directly.
+# BOOND_OAUTH_SCOPES=
+
+# Optional: custom Boond API base URL.
+# BOOND_BASE_URL=https://ui.boondmanager.com/api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,10 @@ jobs:
 
       # ---- Docker image (HTTP gateway mode) ----
       # Multi-arch image so it runs on both x86 servers and Apple-Silicon /
-      # Graviton hosts. Pushed to GHCR alongside the npm/MCP Registry artifacts
-      # so users running LobeChat or a custom MCP gateway can `docker pull`
-      # the same version they would `npm install`.
+      # Graviton hosts. Pushed to GHCR (always) and Docker Hub (when the
+      # DOCKERHUB_TOKEN secret is set) alongside the npm/MCP Registry
+      # artifacts, so users running LobeChat or a custom MCP gateway can
+      # `docker pull` the same version they would `npm install`.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -134,23 +135,50 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub login is conditional: forks without the secret skip it
+      # rather than failing the entire release. The compute-tags step below
+      # uses the same env trick to decide whether to add Docker Hub tags.
+      - name: Log in to Docker Hub
+        if: env.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v4
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Compute image tags
         id: image_tags
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           MAJOR_MINOR="$(echo "$TAG_VERSION" | awk -F. '{print $1"."$2}')"
           MAJOR="$(echo "$TAG_VERSION" | awk -F. '{print $1}')"
-          # On every release we publish four moving tags:
+          # On every release we publish four moving tags per registry:
           #   :<exact>   pinned, the only tag we recommend in production manifests
           #   :<X.Y>     latest patch of a minor (auto-update inside a minor)
           #   :<X>       latest minor of a major (broader, opt-in to new features)
           #   :latest    bleeding edge — convenient for demos, never for prod
+          GHCR_REPO="ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server"
           {
             echo "tags<<EOF"
-            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${TAG_VERSION}"
-            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${MAJOR_MINOR}"
-            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:${MAJOR}"
-            echo "ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server:latest"
+            echo "${GHCR_REPO}:${TAG_VERSION}"
+            echo "${GHCR_REPO}:${MAJOR_MINOR}"
+            echo "${GHCR_REPO}:${MAJOR}"
+            echo "${GHCR_REPO}:latest"
+            if [ -n "$DOCKERHUB_TOKEN" ] && [ -n "$DOCKERHUB_USERNAME" ]; then
+              # Docker Hub repo follows the user's chosen namespace —
+              # defaults to the same name as the GitHub repo for symmetry.
+              DOCKERHUB_REPO="${DOCKERHUB_USERNAME}/boondmanager-mcp-server"
+              echo "${DOCKERHUB_REPO}:${TAG_VERSION}"
+              echo "${DOCKERHUB_REPO}:${MAJOR_MINOR}"
+              echo "${DOCKERHUB_REPO}:${MAJOR}"
+              echo "${DOCKERHUB_REPO}:latest"
+            else
+              echo "::notice ::DOCKERHUB_TOKEN secret not set — skipping Docker Hub publish."
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Verify version matches tag
+      - name: Verify version matches tag + detect prerelease
+        id: version
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
@@ -50,6 +51,25 @@ jobs:
             echo "ERROR: package.json version ($PACKAGE_VERSION) does not match tag (v$TAG_VERSION)"
             exit 1
           fi
+          # SemVer prereleases carry a `-foo` suffix (e.g. 2.0.0-alpha, 1.5.0-rc1).
+          # We branch on that to avoid moving `:latest` / publishing under the
+          # default npm dist-tag etc.
+          if echo "$TAG_VERSION" | grep -q -- '-'; then
+            IS_PRERELEASE=true
+            # npm dist-tag = the identifier before any dot — "alpha", "beta", "rc".
+            NPM_TAG=$(echo "$TAG_VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z0-9]+).*/\1/')
+            if [ -z "$NPM_TAG" ] || [ "$NPM_TAG" = "$TAG_VERSION" ]; then
+              echo "ERROR: failed to derive npm dist-tag from $TAG_VERSION"
+              exit 1
+            fi
+          else
+            IS_PRERELEASE=false
+            NPM_TAG=latest
+          fi
+          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "Detected: version=$TAG_VERSION prerelease=$IS_PRERELEASE npm_tag=$NPM_TAG"
 
       - name: Build MCPB bundle
         run: |
@@ -57,7 +77,10 @@ jobs:
           npx @anthropic-ai/mcpb pack . "boondmanager-mcp-server-v${TAG_VERSION}.mcpb"
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        # `--tag <npm_tag>` ensures prereleases land under e.g. `@alpha`
+        # rather than overwriting the default `latest` dist-tag and reaching
+        # users running `npm install boondmanager-mcp-server` without a tag.
+        run: npm publish --provenance --access public --tag "${{ steps.version.outputs.npm_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -85,6 +108,7 @@ jobs:
           body_path: RELEASE_NOTES.md
           generate_release_notes: true
           files: "*.mcpb"
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
 
       - name: Update server.json for MCP Registry
         run: |
@@ -150,32 +174,40 @@ jobs:
       - name: Compute image tags
         id: image_tags
         env:
+          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          IS_PRERELEASE: ${{ steps.version.outputs.is_prerelease }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          MAJOR_MINOR="$(echo "$TAG_VERSION" | awk -F. '{print $1"."$2}')"
-          MAJOR="$(echo "$TAG_VERSION" | awk -F. '{print $1}')"
-          # On every release we publish four moving tags per registry:
+          # Strip suffix on numeric segments to derive MAJOR / MAJOR_MINOR.
+          # "2.0.0-alpha" -> MAJOR=2, MAJOR_MINOR=2.0 (used for stable only).
+          NUMERIC_VERSION="$(echo "$TAG_VERSION" | sed -E 's/-.*$//')"
+          MAJOR_MINOR="$(echo "$NUMERIC_VERSION" | awk -F. '{print $1"."$2}')"
+          MAJOR="$(echo "$NUMERIC_VERSION" | awk -F. '{print $1}')"
+          GHCR_REPO="ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server"
+          DOCKERHUB_REPO="${DOCKERHUB_USERNAME}/boondmanager-mcp-server"
+          # On a stable release we publish four moving tags per registry:
           #   :<exact>   pinned, the only tag we recommend in production manifests
           #   :<X.Y>     latest patch of a minor (auto-update inside a minor)
           #   :<X>       latest minor of a major (broader, opt-in to new features)
           #   :latest    bleeding edge — convenient for demos, never for prod
-          GHCR_REPO="ghcr.io/${{ github.repository_owner }}/boondmanager-mcp-server"
+          # For prereleases (X.Y.Z-foo) we publish ONLY the pinned tag, to avoid
+          # silently bumping users on `:latest` / `:X` / `:X.Y`.
           {
             echo "tags<<EOF"
             echo "${GHCR_REPO}:${TAG_VERSION}"
-            echo "${GHCR_REPO}:${MAJOR_MINOR}"
-            echo "${GHCR_REPO}:${MAJOR}"
-            echo "${GHCR_REPO}:latest"
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo "${GHCR_REPO}:${MAJOR_MINOR}"
+              echo "${GHCR_REPO}:${MAJOR}"
+              echo "${GHCR_REPO}:latest"
+            fi
             if [ -n "$DOCKERHUB_TOKEN" ] && [ -n "$DOCKERHUB_USERNAME" ]; then
-              # Docker Hub repo follows the user's chosen namespace —
-              # defaults to the same name as the GitHub repo for symmetry.
-              DOCKERHUB_REPO="${DOCKERHUB_USERNAME}/boondmanager-mcp-server"
               echo "${DOCKERHUB_REPO}:${TAG_VERSION}"
-              echo "${DOCKERHUB_REPO}:${MAJOR_MINOR}"
-              echo "${DOCKERHUB_REPO}:${MAJOR}"
-              echo "${DOCKERHUB_REPO}:latest"
+              if [ "$IS_PRERELEASE" != "true" ]; then
+                echo "${DOCKERHUB_REPO}:${MAJOR_MINOR}"
+                echo "${DOCKERHUB_REPO}:${MAJOR}"
+                echo "${DOCKERHUB_REPO}:latest"
+              fi
             else
               echo "::notice ::DOCKERHUB_TOKEN secret not set — skipping Docker Hub publish."
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 .env
 .env.*
+!.env.example
 
 coverage/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.0.0] - 2026-05-23
+
+> **Promotion de [`2.0.0-alpha`](#200-alpha---2026-05-21) en stable** apres smoke test reel : conteneur Docker pull/run depuis Docker Hub, discovery `/.well-known/oauth-protected-resource` + 401 challenge `WWW-Authenticate` verifies, rejet du scheme non-Bearer confirme, handshake MCP `initialize` traverse end-to-end (serverInfo `2.0.0-alpha`, protocol `2025-06-18`).
+
+Aucun changement de code par rapport a 2.0.0-alpha. Seule difference : README mis a jour (badges Docker Hub + GHCR, section *Docker (image officielle)* qui liste les deux registres miroirs avec leurs liens, note sur le scoping des tags de prerelease). Pour le contenu fonctionnel de la 2.x, voir l'entree 2.0.0-alpha ci-dessous.
+
+### Migration depuis 1.x
+
+- **Transport stdio** : aucune action. JWT / BasicAuth via env vars (`BOOND_USER_TOKEN` + `BOOND_CLIENT_TOKEN` + `BOOND_CLIENT_KEY`, ou `BOOND_API_TOKEN`, ou `BOOND_USER` + `BOOND_PASSWORD`) fonctionnent comme avant.
+- **Transport HTTP** : breaking. Si tu utilisais `MCP_HTTP_BEARER_TOKEN` comme shared secret transport-level, supprime-le — il a disparu (il est remplace par l'OAuth Bearer per-user porte par chaque requete). Si tu publiais des credentials Boond cote serveur (env vars JWT/BasicAuth sur le conteneur HTTP), supprime-les egalement — le serveur n'en a plus besoin. A la place : enregistre une App OAuth2 dans BoondManager (*Administration -> Apps -> Security*) et configure ton client MCP pour qu'il fasse la danse OAuth contre Boond, le serveur ne fait que forwarder le Bearer. Procedure complete dans `docs/oauth.md`.
+
 ## [2.0.0-alpha] - 2026-05-21
 
 > **Breaking change majeur** : le transport HTTP passe d'une auth shared-secret + JWT cote serveur a une auth OAuth2 *protected resource* (le Bearer token est porte par chaque requete MCP). Pas de migration possible — c'est une nouvelle architecture, d'ou le bump majeur. Le transport stdio reste inchange. Voir `docs/oauth.md` pour la procedure complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [2.0.0-alpha] - 2026-05-21
+
+> **Breaking change majeur** : le transport HTTP passe d'une auth shared-secret + JWT cote serveur a une auth OAuth2 *protected resource* (le Bearer token est porte par chaque requete MCP). Pas de migration possible — c'est une nouvelle architecture, d'ou le bump majeur. Le transport stdio reste inchange. Voir `docs/oauth.md` pour la procedure complete.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **OAuth2 protected resource sur le transport HTTP.** Le serveur HTTP devient un *protected resource* (spec MCP Authorization 2025-06-18 + RFC 9728) : **aucun secret n'est detenu cote serveur** (pas de `client_secret`, pas de refresh token, pas de stockage utilisateur). Chaque requete MCP doit porter `Authorization: Bearer <boond_access_token>` ; le serveur transmet le token verbatim a BoondManager. Le **client MCP** (Claude Desktop, Claude Code, gateway…) execute la danse OAuth contre BoondManager directement et gere son propre refresh. Multi-tenant par construction : chaque utilisateur agit sous sa propre identite Boond (audit log preserve).
+- **Discovery RFC 9728** : nouvel endpoint public `/.well-known/oauth-protected-resource` (et son variant path-suffixe `…/{MCP_HTTP_PATH}` per §3.2) qui annonce `resource`, `authorization_servers`, `bearer_methods_supported`, et `scopes_supported`. Les 401 emettent un challenge `WWW-Authenticate: Bearer realm="…", resource_metadata="…"` permettant aux clients MCP conformes de decouvrir automatiquement l'authorization server BoondManager.
+- **Provider d'auth dynamique** dans `boond-client` (`initClientWithAuth()` + `oauthContextAuth`) : resolution de l'en-tête par requete via `AsyncLocalStorage`, qui isole les Bearer tokens entre utilisateurs concurrents sur la meme instance HTTP.
+- **Packaging Docker** entierement stateless (HTTP+OAuth2) : `Dockerfile` sans volume, `docker-compose.yml` reduit a un seul service, `.env.example` qui ne contient que des variables optionnelles. Plus de profile `bootstrap`, plus de credentials a persister. L'healthcheck cible le endpoint de discovery (200 sans auth).
+- **Publication Docker dual-registry.** Le workflow `release.yml` pousse maintenant l'image multi-arch a la fois sur GHCR (`ghcr.io/fauguste/boondmanager-mcp-server`) et sur Docker Hub (`docker.io/{DOCKERHUB_USERNAME}/boondmanager-mcp-server`), avec les memes tags `:X.Y.Z` / `:X.Y` / `:X` / `:latest`. La publication Docker Hub est conditionnee a la presence du secret `DOCKERHUB_TOKEN`, pour que les forks sans configuration ne fassent pas echouer le release.
+- **Nouveau workflow manuel `.github/workflows/docker-publish.yml`** (`workflow_dispatch`) pour pousser un tag ad-hoc (RC, branche feature, re-publication) sur les deux registries sans re-couper de release npm. Inputs : `tag`, `ref` (git ref), `platforms`, `push_latest`.
+- Documentation complete : `docs/oauth.md` reecrit avec le bon modele (client-side OAuth, server passthrough, discovery), section *Authentication* de `CLAUDE.md`, section HTTP du README.
+
+### Changed
+
+- **`BoondConfig` passe a un `BoondAuthProvider` async** (resolution per-request) ; `initClient()` (stdio) reste inchange du point de vue API. Stdio garde les 3 methodes JWT / BasicAuth existantes (`BOOND_USER_TOKEN`+`CLIENT_TOKEN`+`CLIENT_KEY`, `BOOND_API_TOKEN`, `BOOND_USER`+`PASSWORD`).
+- **Nouvelle variable `MCP_HTTP_PUBLIC_URL`** pour annoncer la bonne URL externe derriere un reverse proxy.
+
+### Removed
+
+- **`MCP_HTTP_BEARER_TOKEN`** : superflu — l'auth est portee par le Bearer OAuth2 du user, pas par un secret partage cote transport.
+- **CLI `boondmanager-mcp-oauth-login`** + bin + script `oauth:login` : plus de bootstrap serveur, le client fait la danse OAuth directement.
+
+### Tests
+
+- **+34 tests** (`src/services/oauth.test.ts` reecrit : 25 tests sur l'extraction Bearer, l'AsyncLocalStorage, la metadata RFC 9728 ; nouveau bloc `oauthContextAuth` dans `boond-client.test.ts` qui couvre l'isolation multi-tenant concurrente ; +6 tests d'integration HTTP couvrant 401+challenge, discovery sur les deux variants, override de l'authorization server). **471 tests passants** au total.
+
 ## [1.9.1] - 2026-05-20
 
 Patch correctif sur les trois outils `boond_resources_reference_{create,update,delete}` introduits en 1.9.0. La spec d'origine (issue #79) supposait des endpoints REST autonomes (`POST /resources/{id}/references`, `PUT /references/{id}`, `DELETE /references/{id}`) — sondage live de l'API : aucun de ces endpoints n'existe. Les références sont **embarquées** dans le DT (sous-objet `attributes.references[]` de `/resources/{id}/technical-data`), donc tout le CRUD passe par un `PUT /resources/{id}/technical-data` avec la liste complète à jour.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ src/
 ├── transports/
 │   └── http.ts           # startHttpTransport() + resolveHttpOptions() — MCP Streamable HTTP server
 ├── services/
-│   ├── boond-client.ts   # HTTP client: apiRequest(), buildSearchQuery(), formatListResponse(), formatDetailResponse(), parseBoondErrorBody(), formatApiError()
+│   ├── boond-client.ts   # HTTP client: apiRequest(), buildSearchQuery(), formatListResponse(), formatDetailResponse(), parseBoondErrorBody(), formatApiError(); initClient() (stdio) / initClientWithAuth() (OAuth); oauthContextAuth (reads AsyncLocalStorage)
+│   ├── oauth.ts          # OAuth2 protected-resource plumbing for the HTTP transport: oauthContext (AsyncLocalStorage), extractBearerToken(), buildProtectedResourceMetadata() (RFC 9728). No state, no client_secret.
 │   ├── rate-limiter.ts   # Token-bucket rate limiter for BoondManager API
 │   └── logger.ts         # Structured logger (pino) + generateCorrelationId()
 ├── schemas/
@@ -301,8 +302,8 @@ are what the client surfaces.
 
 The server selects its transport from `MCP_TRANSPORT`:
 
-- **`stdio`** (default): wraps `StdioServerTransport`, used by Claude Desktop / Claude Code locally.
-- **`http`** (alias: `streamable-http`): starts a Node HTTP server using `StreamableHTTPServerTransport` from the MCP SDK. Intended for MCP gateways and remote deployments.
+- **`stdio`** (default): wraps `StdioServerTransport`, used by Claude Desktop / Claude Code locally. Auth: JWT (X-Jwt-Client-Boondmanager) or BasicAuth via env vars.
+- **`http`** (alias: `streamable-http`): starts a Node HTTP server using `StreamableHTTPServerTransport` from the MCP SDK. Intended for MCP gateways and remote deployments. **Auth: OAuth2 protected resource** — the server holds no tokens; each MCP request must carry `Authorization: Bearer <boond_access_token>` and is forwarded verbatim to BoondManager. See the *Authentication → http transport* section below.
 
 HTTP env vars (see `src/transports/http.ts::resolveHttpOptions`):
 
@@ -312,8 +313,8 @@ HTTP env vars (see `src/transports/http.ts::resolveHttpOptions`):
 | `MCP_HTTP_PORT` | `3000` | TCP port |
 | `MCP_HTTP_PATH` | `/mcp` | Endpoint path |
 | `MCP_HTTP_STATEFUL` | `false` | `true` to enable session mode (`Mcp-Session-Id`) |
-| `MCP_HTTP_BEARER_TOKEN` | — | Require `Authorization: Bearer <token>` on every request |
 | `MCP_HTTP_JSON_RESPONSE` | `false` | `true` to return JSON instead of SSE streams |
+| `MCP_HTTP_PUBLIC_URL` | (derived) | Public URL advertised in the OAuth2 discovery metadata. Required behind a reverse proxy. |
 | `MCP_HTTP_SESSION_TTL_MS` | `1800000` (30 min) | Stateful only: idle window before a session is closed |
 | `MCP_HTTP_SESSION_SWEEP_INTERVAL_MS` | `300000` (5 min) | Stateful only: how often to scan for idle sessions |
 | `MCP_HTTP_ALLOWED_HOSTS` | (auto) | Comma-separated allow-list of `Host` header hostnames for DNS rebinding protection (CVE-2025-66414). Default = `localhost,127.0.0.1,[::1]` when bound to a loopback interface, otherwise validation is disabled. Set to `*` to opt out explicitly when fronting the server with a reverse proxy that already validates hosts. |
@@ -322,7 +323,12 @@ Stateless mode spins up a fresh `McpServer`+`StreamableHTTPServerTransport` per 
 
 ## Authentication
 
-Configured via environment variables (never hardcoded), in priority order:
+Two distinct models depending on the transport — **stdio** uses the
+existing env-based credentials (single identity, integrator-side);
+**http** is an **OAuth2 protected resource** (multi-tenant, per-user,
+per-request).
+
+### stdio transport (env-based, priority order)
 
 1. **JWT from components** (recommended):
    - `BOOND_USER_TOKEN` — User token (BoondManager → Mon compte → Clé d'API)
@@ -331,6 +337,51 @@ Configured via environment variables (never hardcoded), in priority order:
    - The server generates the JWT (HS256) automatically from these 3 values.
 2. **Pre-built JWT**: `BOOND_API_TOKEN` (JWT Bearer)
 3. **BasicAuth**: `BOOND_USER` + `BOOND_PASSWORD` (base64-encoded)
+
+JWT travels in `X-Jwt-Client-Boondmanager`, BasicAuth in `Authorization`.
+
+### http transport (OAuth2 — protected resource model)
+
+The HTTP server is an **OAuth2 protected resource** (per the MCP
+Authorization 2025-06-18 spec and RFC 9728). It holds **no OAuth state**:
+no `client_secret`, no refresh token, no per-user storage. The flow:
+
+1. The MCP client (Claude Desktop, Claude Code, gateway, …) initiates
+   the OAuth dance against BoondManager directly. The user grants
+   consent to the BoondManager App in their browser; the client receives
+   an `access_token` and a `refresh_token`.
+2. On every MCP request the client sends
+   `Authorization: Bearer <access_token>`.
+3. The HTTP transport (`src/transports/http.ts`) extracts the Bearer
+   token before dispatching to the SDK's `StreamableHTTPServerTransport`,
+   wraps the handler in `oauthContext.run({ accessToken }, …)`.
+4. When a tool fires an API call, `oauthContextAuth` in `boond-client.ts`
+   reads the token out of the AsyncLocalStorage context and forwards it
+   verbatim to BoondManager as `Authorization: Bearer <access_token>`.
+5. The MCP client refreshes its own tokens — the server never sees the
+   refresh flow.
+
+Discovery: the server publishes RFC 9728 protected-resource metadata at
+`/.well-known/oauth-protected-resource` (and at the path-suffixed variant
+`/.well-known/oauth-protected-resource{MCP_HTTP_PATH}` per RFC 9728 §3.2).
+Missing/invalid Bearer tokens get a 401 with
+`WWW-Authenticate: Bearer realm="…", resource_metadata="…"` pointing at
+that endpoint. MCP-spec-compliant clients use this to auto-discover the
+BoondManager authorization server.
+
+Env vars for the HTTP path (all optional — only `MCP_HTTP_PUBLIC_URL`
+really matters in production):
+
+| Var | Purpose |
+|-----|---------|
+| `MCP_HTTP_PUBLIC_URL` | Public URL advertised as the OAuth2 resource identifier (and in the `realm` of the 401 challenge). Required when fronted by a reverse proxy. Defaults to `http://<host>:<port><path>`. |
+| `BOOND_OAUTH_AUTHORIZATION_SERVER` | Issuer URL of the BoondManager authorization server, advertised in `authorization_servers`. Defaults to `https://ui.boondmanager.com`. |
+| `BOOND_OAUTH_SCOPES` | Space/comma-separated scope hints advertised in `scopes_supported`. Empty = clients negotiate directly with Boond. |
+
+Implementation: `src/services/oauth.ts` (AsyncLocalStorage context,
+header parsing, metadata builder), `src/transports/http.ts` (Bearer
+extraction + discovery endpoint + 401 challenge), `src/services/boond-client.ts`
+(`oauthContextAuth` provider). Full setup guide: `docs/oauth.md`.
 - `BOOND_BASE_URL` (optional, defaults to `https://ui.boondmanager.com/api`)
 - `BOOND_HTTP_TIMEOUT_MS` (optional, defaults to `30000`) — per-request timeout for the BoondManager HTTP client. Non-numeric / non-positive values fall back to the default. A timeout surfaces as an `Error` whose message includes the configured value and the failing endpoint.
 - `BOOND_HTTP_MAX_RETRIES` (optional, defaults to `2`) — number of additional attempts after the first failure. Set to `0` to disable retries. Retry policy: GET retries on 5xx / 429 / network / timeout; non-GET retries only on 429 (idempotency safety). `Retry-After` is honoured.
@@ -345,10 +396,22 @@ Configured via environment variables (never hardcoded), in priority order:
   - **GitHub Releases** with `.mcpb` bundle attached; release body extracted from the matching `## [X.Y.Z]` section of `CHANGELOG.md`
   - **MCP Registry** via `mcp-publisher` with GitHub OIDC
   - **GHCR** (`ghcr.io/fauguste/boondmanager-mcp-server`) — multi-arch (`linux/amd64`+`linux/arm64`) with provenance + SBOM, tags `:X.Y.Z` `:X.Y` `:X` `:latest`
+  - **Docker Hub** (`docker.io/{DOCKERHUB_USERNAME}/boondmanager-mcp-server`) — same multi-arch image, same tags. Gated on the `DOCKERHUB_TOKEN` repo secret being present, so forks without the secret skip Docker Hub without failing the release.
+- **Docker publish (manual)** (`.github/workflows/docker-publish.yml`): `workflow_dispatch`-only. Inputs: `tag` (required), `ref` (optional git ref to build), `platforms`, `push_latest` (boolean). Pushes to GHCR + Docker Hub. Use for release candidates, feature-branch images, or ad-hoc re-publishes.
 - **CodeQL** (`.github/workflows/codeql.yml`): static analysis for JS/TS and GitHub Actions.
 - **API Monitor** (`.github/workflows/api-monitor.yml`): Hebdomadaire (lundis 9h UTC), surveille la documentation officielle BoondManager (`https://doc.boondmanager.com/api-externe/raml-build/`), compare avec le snapshot précédent (`.github/api-snapshot.json`), crée une issue GitHub si nouveautés détectées. Documentation complète: `.github/API_MONITORING.md`.
 - **Dependabot**: configured for npm and GitHub Actions.
 - **Distribution**: `docs/distribution.md` is the single source of truth for what ships where and the few manual one-time actions still outstanding (GitHub topics, awesome-mcp-servers PR, Glama/PulseMCP/mcp.so submissions).
+
+### Required GitHub secrets
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `NPM_TOKEN` | `release.yml` | npm publish (automation token, scoped to this package) |
+| `DOCKERHUB_USERNAME` | `release.yml`, `docker-publish.yml` | Docker Hub user/org that owns the published repo |
+| `DOCKERHUB_TOKEN` | `release.yml`, `docker-publish.yml` | Docker Hub access token (Account Settings → Security) |
+
+`GITHUB_TOKEN` is auto-provided by GitHub Actions and covers GHCR, GitHub Releases, and CodeQL — no extra setup. The MCP Registry uses GitHub OIDC (no secret).
 
 ## Code Style
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,20 @@
 # an MCP gateway (LobeChat, custom MCP host, etc.). For stdio usage, prefer
 # `npx boondmanager-mcp-server` directly on the host — Docker's stdio mapping
 # is awkward and you don't gain anything by containerising it.
+#
+# Authentication model (HTTP transport): the MCP server is an OAuth2
+# *protected resource*. It holds **no secrets**: no client_secret, no
+# refresh token, no token store. Each MCP request from the client must
+# carry `Authorization: Bearer <boond_access_token>`; the server forwards
+# the token verbatim to BoondManager. The client (Claude Desktop, Claude
+# Code, MCP gateway, …) performs the OAuth dance against BoondManager
+# directly and refreshes its own tokens.
+#
+# The server publishes RFC 9728 protected-resource metadata at
+# `/.well-known/oauth-protected-resource` so MCP clients auto-discover
+# the BoondManager authorization server.
+#
+# See docs/oauth.md for the full flow.
 
 # ---- builder ----
 FROM node:22-alpine AS builder
@@ -27,7 +41,7 @@ WORKDIR /app
 
 # OCI image annotations — make the image discoverable in registries.
 LABEL org.opencontainers.image.title="boondmanager-mcp-server" \
-      org.opencontainers.image.description="MCP server for the BoondManager API (HTTP gateway mode)" \
+      org.opencontainers.image.description="MCP server for the BoondManager API (HTTP gateway mode, OAuth2 protected resource)" \
       org.opencontainers.image.source="https://github.com/fauguste/boondmanager-mcp-server" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="Silamir"
@@ -50,10 +64,10 @@ ENV NODE_ENV=production \
 
 EXPOSE 3000
 
-# Lightweight liveness check — confirms the HTTP listener is up. We use
-# Node's bundled fetch to avoid pulling curl/wget into the image. A 4xx
-# (e.g. 405 if the path is POST-only) still proves the listener is alive.
+# Lightweight liveness check — confirms the HTTP listener is up. The
+# unauthenticated discovery endpoint is the cheapest probe: always 200,
+# doesn't need credentials, doesn't open a session.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD node -e "fetch('http://127.0.0.1:'+process.env.MCP_HTTP_PORT+process.env.MCP_HTTP_PATH).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"
+    CMD node -e "fetch('http://127.0.0.1:'+process.env.MCP_HTTP_PORT+'/.well-known/oauth-protected-resource').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -434,18 +434,22 @@ Le serveur supporte deux transports MCP, selectionnables via la variable d'envir
 
 Depuis la v1.4.0, le serveur peut etre expose en HTTP (specification MCP Streamable HTTP 2025-03-26) afin d'etre branche derriere une passerelle MCP ou deploye comme service.
 
+> **Authentification BoondManager : OAuth2 protected resource.** Le serveur HTTP **ne detient aucun secret** (ni `client_secret`, ni refresh token, ni stockage utilisateur). Chaque requete MCP doit porter `Authorization: Bearer <boond_access_token>` ; le serveur transmet le token tel quel a BoondManager. C'est le **client MCP** (Claude Desktop, Claude Code, gateway…) qui fait la danse OAuth contre BoondManager et qui gere le refresh. Procedure complete : [docs/oauth.md](docs/oauth.md).
+
 ```bash
 export MCP_TRANSPORT=http
 export MCP_HTTP_HOST=0.0.0.0        # defaut: 127.0.0.1
 export MCP_HTTP_PORT=3000           # defaut: 3000
 export MCP_HTTP_PATH=/mcp           # defaut: /mcp
-export MCP_HTTP_BEARER_TOKEN=xxx    # optionnel: protege l'endpoint
-export BOOND_API_TOKEN=...          # (credentials BoondManager, comme en stdio)
+# Optionnel: requis uniquement derriere un reverse proxy, pour que
+# la discovery annonce la bonne URL publique.
+export MCP_HTTP_PUBLIC_URL=https://mcp.votre-domaine.com/mcp
 
 npx boondmanager-mcp-server
 # 🚀 BoondManager MCP Server running (streamable HTTP transport)
 # 📡 Endpoint: http://0.0.0.0:3000/mcp
 # 🔑 Mode: stateless
+# 🔐 Boond auth: OAuth2 (per-request Bearer from MCP client)
 ```
 
 **Variables d'environnement HTTP**
@@ -457,85 +461,79 @@ npx boondmanager-mcp-server
 | `MCP_HTTP_PORT` | `3000` | Port TCP |
 | `MCP_HTTP_PATH` | `/mcp` | Chemin HTTP de l'endpoint MCP |
 | `MCP_HTTP_STATEFUL` | `false` | `true` pour activer le mode stateful (session `Mcp-Session-Id`) |
-| `MCP_HTTP_BEARER_TOKEN` | _(vide)_ | Si defini, le serveur exige `Authorization: Bearer <token>` |
 | `MCP_HTTP_JSON_RESPONSE` | `false` | `true` pour forcer des reponses JSON (sans SSE) |
+| `MCP_HTTP_PUBLIC_URL` | _(derivee)_ | URL publique annoncee dans la discovery OAuth2 (`resource`) et le challenge `WWW-Authenticate`. Requise derriere un reverse proxy. |
 | `MCP_HTTP_SESSION_TTL_MS` | `1800000` (30 min) | En mode stateful, duree d'inactivite au-dela de laquelle une session est fermee. |
 | `MCP_HTTP_SESSION_SWEEP_INTERVAL_MS` | `300000` (5 min) | Frequence de balayage des sessions inactives. |
+| `MCP_HTTP_ALLOWED_HOSTS` | _(auto)_ | Liste blanche du header `Host` (anti DNS rebinding, CVE-2025-66414). `*` pour desactiver explicitement. |
+
+**Variables OAuth2 — discovery (toutes optionnelles)**
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `BOOND_OAUTH_AUTHORIZATION_SERVER` | `https://ui.boondmanager.com` | Issuer de l'authorization server BoondManager, annonce dans `authorization_servers` |
+| `BOOND_OAUTH_SCOPES` | _(vide)_ | Scopes annonces dans `scopes_supported` (espace ou virgule). Vide = le client negocie directement avec Boond. |
 
 **Stateless (defaut)** : chaque requete HTTP POST est independante, idealement adapte a un gateway qui multiplexe plusieurs serveurs MCP. Aucune session n'est conservee cote serveur.
 
 **Stateful** : le serveur genere un `Mcp-Session-Id` a l'initialisation que le client doit renvoyer dans chaque requete suivante. Utile pour les clients MCP natifs qui beneficient du streaming SSE et des notifications serveur.
 
-#### Exemple : verifier l'endpoint
+#### Exemple : discovery + 401 challenge
 
 ```bash
-curl -s -X POST http://localhost:3000/mcp \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json, text/event-stream' \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-      "protocolVersion": "2025-06-18",
-      "capabilities": {},
-      "clientInfo": { "name": "curl", "version": "1.0" }
-    }
-  }'
+# Public, pas d'auth -> documente OU envoyer le user pour autoriser
+curl -s http://localhost:3000/.well-known/oauth-protected-resource | jq .
+# {
+#   "resource": "http://0.0.0.0:3000/mcp",
+#   "authorization_servers": ["https://ui.boondmanager.com"],
+#   "bearer_methods_supported": ["header"]
+# }
+
+# Appel MCP sans token -> 401 + WWW-Authenticate qui pointe vers la discovery
+curl -s -o /dev/null -w "%{http_code}\n%header{www-authenticate}\n" \
+  -X POST http://localhost:3000/mcp -d '{}'
+# 401
+# Bearer realm="http://0.0.0.0:3000/mcp", resource_metadata="http://0.0.0.0:3000/.well-known/oauth-protected-resource/mcp"
 ```
 
 #### Exemple : Claude Code via HTTP
 
+Avec un client MCP conforme a la spec MCP Authorization 2025-06-18, la decouverte OAuth est automatique :
+
 ```bash
-claude mcp add --transport http \
-  --header "Authorization: Bearer votre_token_local" \
-  boondmanager https://mcp.votre-domaine.com/mcp
-```
-
-#### Exemple : configuration `.mcp.json` HTTP
-
-```json
-{
-  "mcpServers": {
-    "boondmanager": {
-      "type": "http",
-      "url": "https://mcp.votre-domaine.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${MCP_HTTP_BEARER_TOKEN}"
-      }
-    }
-  }
-}
+claude mcp add --transport http boondmanager https://mcp.votre-domaine.com/mcp
+# Le client recoit le 401 + WWW-Authenticate, fetch la metadata, ouvre
+# le navigateur pour autoriser l'App BoondManager, puis re-emet la requete
+# avec le Bearer token recu.
 ```
 
 #### Exemple : Docker (image officielle GHCR)
 
-Une image Docker prete a l'emploi est publiee a chaque release sur GitHub Container Registry, multi-arch (`linux/amd64` + `linux/arm64`). Elle demarre par defaut en transport HTTP, sur le port 3000, sur l'interface `0.0.0.0`.
+Une image Docker prete a l'emploi est publiee a chaque release sur GitHub Container Registry, multi-arch (`linux/amd64` + `linux/arm64`). Elle demarre par defaut en transport HTTP, sur le port 3000, sur l'interface `0.0.0.0`. **Aucun volume, aucun secret a stocker** — le serveur est stateless par construction.
 
 ```bash
-docker run --rm -p 3000:3000 \
-  -e MCP_HTTP_BEARER_TOKEN=$(openssl rand -hex 32) \
-  -e BOOND_API_TOKEN=$BOOND_API_TOKEN \
+docker run -d --restart unless-stopped \
+  -p 127.0.0.1:3000:3000 \
+  -e MCP_HTTP_PUBLIC_URL=https://mcp.votre-domaine.com/mcp \
+  --name boondmanager-mcp \
   ghcr.io/fauguste/boondmanager-mcp-server:latest
 ```
 
 Tags disponibles : `:latest`, `:1`, `:1.5`, `:1.5.1` (la version exacte est recommandee pour la prod). Variables d'environnement supportees : voir [Configuration](#configuration) et [Transports](#transports).
 
-#### Exemple : Docker (image ad-hoc via npx)
+#### Exemple : docker-compose
 
-Si vous preferez ne pas utiliser l'image GHCR, le serveur peut tourner dans une image Node generique :
+Le repo embarque un `docker-compose.yml` pret a l'emploi : un seul service stateless, aucun volume, aucun secret cote serveur.
 
 ```bash
-docker run --rm -p 3000:3000 \
-  -e MCP_TRANSPORT=http \
-  -e MCP_HTTP_HOST=0.0.0.0 \
-  -e MCP_HTTP_BEARER_TOKEN=$(openssl rand -hex 32) \
-  -e BOOND_API_TOKEN=$BOOND_API_TOKEN \
-  node:22-alpine \
-  npx -y boondmanager-mcp-server
+# Optionnel : surcharger MCP_HTTP_PUBLIC_URL si fronted par un reverse proxy
+cp .env.example .env
+
+docker compose up -d
+docker compose logs -f mcp
 ```
 
-> **Securite** : en HTTP, les credentials BoondManager restent cote serveur (variables d'environnement du conteneur). Seul le token MCP (`MCP_HTTP_BEARER_TOKEN`) circule entre le client et le serveur. Derriere un reverse proxy, ajoutez TLS (HTTPS) et limitez l'acces reseau au gateway.
+> **Securite** : le serveur HTTP est stateless et ne stocke aucun secret BoondManager. Chaque utilisateur authentifie le serveur via son propre token OAuth2 (issu de sa propre App BoondManager), et toutes les actions sont attribuees a son identite dans l'audit log Boond. Derriere un reverse proxy : terminez TLS (HTTPS), forwardez l'en-tete `Authorization`, et reglez `MCP_HTTP_PUBLIC_URL` sur l'URL publique pour que la discovery soit coherente.
 
 ## Exemples d'utilisation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Node.js](https://img.shields.io/node/v/boondmanager-mcp-server.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue.svg)](https://www.typescriptlang.org/)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io/)
+[![Docker Hub](https://img.shields.io/docker/v/fauguste/boondmanager-mcp-server?label=Docker%20Hub&logo=docker&color=2496ED)](https://hub.docker.com/r/fauguste/boondmanager-mcp-server)
+[![GHCR](https://img.shields.io/badge/GHCR-fauguste%2Fboondmanager--mcp--server-181717?logo=github)](https://github.com/fauguste/boondmanager-mcp-server/pkgs/container/boondmanager-mcp-server)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claude (Desktop, Cowork, Code) de rechercher, consulter, creer et modifier des enregistrements dans votre instance BoondManager.
@@ -507,19 +509,34 @@ claude mcp add --transport http boondmanager https://mcp.votre-domaine.com/mcp
 # avec le Bearer token recu.
 ```
 
-#### Exemple : Docker (image officielle GHCR)
+#### Exemple : Docker (image officielle)
 
-Une image Docker prete a l'emploi est publiee a chaque release sur GitHub Container Registry, multi-arch (`linux/amd64` + `linux/arm64`). Elle demarre par defaut en transport HTTP, sur le port 3000, sur l'interface `0.0.0.0`. **Aucun volume, aucun secret a stocker** — le serveur est stateless par construction.
+Une image Docker prete a l'emploi est publiee a chaque release sur deux registres miroirs, multi-arch (`linux/amd64` + `linux/arm64`) :
+
+| Registre | Image | Page |
+|---|---|---|
+| GitHub Container Registry | `ghcr.io/fauguste/boondmanager-mcp-server` | [github.com/fauguste/boondmanager-mcp-server/pkgs/container/boondmanager-mcp-server](https://github.com/fauguste/boondmanager-mcp-server/pkgs/container/boondmanager-mcp-server) |
+| Docker Hub | `docker.io/fauguste/boondmanager-mcp-server` | [hub.docker.com/r/fauguste/boondmanager-mcp-server](https://hub.docker.com/r/fauguste/boondmanager-mcp-server) |
+
+Memes digests, memes tags — choisissez celui qui s'aligne avec votre tooling. L'image demarre par defaut en transport HTTP, sur le port 3000, sur l'interface `0.0.0.0`. **Aucun volume, aucun secret a stocker** — le serveur est stateless par construction.
 
 ```bash
+# Via GHCR (authentification GitHub si registre prive)
 docker run -d --restart unless-stopped \
   -p 127.0.0.1:3000:3000 \
   -e MCP_HTTP_PUBLIC_URL=https://mcp.votre-domaine.com/mcp \
   --name boondmanager-mcp \
   ghcr.io/fauguste/boondmanager-mcp-server:latest
+
+# Ou via Docker Hub (anonyme)
+docker run -d --restart unless-stopped \
+  -p 127.0.0.1:3000:3000 \
+  -e MCP_HTTP_PUBLIC_URL=https://mcp.votre-domaine.com/mcp \
+  --name boondmanager-mcp \
+  fauguste/boondmanager-mcp-server:latest
 ```
 
-Tags disponibles : `:latest`, `:1`, `:1.5`, `:1.5.1` (la version exacte est recommandee pour la prod). Variables d'environnement supportees : voir [Configuration](#configuration) et [Transports](#transports).
+Tags disponibles sur les deux registres : `:latest`, `:X`, `:X.Y`, `:X.Y.Z` pour chaque release stable (la version exacte est recommandee pour la prod). Les **prereleases** (par exemple `:2.0.0-alpha`) sont publiees **uniquement sous leur tag pinne** — ni `:latest`, ni `:X`, ni `:X.Y` ne bougent. Variables d'environnement supportees : voir [Configuration](#configuration) et [Transports](#transports).
 
 #### Exemple : docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# BoondManager MCP server — production-leaning compose example.
+#
+# This is a fully stateless service:
+#   - No volume, no secret on disk, no client_secret.
+#   - The MCP server is an OAuth2 protected resource — each request from
+#     the MCP client must carry `Authorization: Bearer <boond_access_token>`.
+#   - The MCP client (Claude Desktop, Claude Code, MCP gateway, …) does
+#     the OAuth dance against BoondManager directly and refreshes its own
+#     token. The server holds nothing.
+#
+# Quick start:
+#   1. (Optional) cp .env.example .env  &&  set MCP_HTTP_PUBLIC_URL if
+#      you front this with a reverse proxy. No secrets to set.
+#   2. docker compose up -d
+#   3. Discover the OAuth metadata:
+#      curl http://localhost:3000/.well-known/oauth-protected-resource
+#   4. Configure your MCP client with the resulting URL — the client
+#      handles the OAuth flow with BoondManager from there.
+#
+# Behind a reverse proxy (Traefik / Caddy / Nginx), add TLS upstream
+# and set MCP_HTTP_PUBLIC_URL to the public HTTPS URL so the discovery
+# metadata advertises the right resource identifier.
+
+services:
+  mcp:
+    image: ghcr.io/fauguste/boondmanager-mcp-server:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    env_file:
+      - .env
+    environment:
+      MCP_TRANSPORT: http
+      MCP_HTTP_HOST: 0.0.0.0
+      MCP_HTTP_PORT: "3000"
+      MCP_HTTP_PATH: /mcp
+      MCP_HTTP_STATEFUL: "false"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+process.env.MCP_HTTP_PORT+'/.well-known/oauth-protected-resource').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,215 @@
+# OAuth2 (HTTP transport)
+
+The HTTP transport of the BoondManager MCP server is an **OAuth2 protected
+resource** (per the [MCP Authorization 2025-06-18 spec][mcp-auth] and
+[RFC 9728][rfc-9728]). The stdio transport keeps the existing
+JWT / BasicAuth env-var methods documented in the [README](../README.md);
+this guide covers HTTP only.
+
+[mcp-auth]: https://spec.modelcontextprotocol.io/specification/2025-06-18/basic/authorization/
+[rfc-9728]: https://datatracker.ietf.org/doc/html/rfc9728
+
+## Architecture in one diagram
+
+```
+┌──────────────┐  1. discovery (unauth)   ┌────────────────────┐
+│  MCP client  │ ─────────────────────►   │   MCP server       │
+│ (Claude…)    │ ◄─── auth_server URL ─── │   (/.well-known/…) │
+│              │                          └────────────────────┘
+│              │
+│              │   2. OAuth dance (browser)
+│              │ ─────────────────────────► ┌───────────────────┐
+│              │ ◄────── access_token ───── │   BoondManager    │
+│              │                            │   (auth server)   │
+│              │                            └─────────▲─────────┘
+│              │   3. MCP request                     │
+│              │      Authorization: Bearer <token>   │
+│              │ ─────────────────────────► ┌─────────┴─────────┐
+│              │                            │   MCP server      │
+│              │                            │  (this repo)      │
+│              │                            └─────────┬─────────┘
+│              │                                      │
+│              │                                      │  4. API call
+│              │                                      │     Authorization: Bearer <same token>
+│              │                                      ▼
+│              │                            ┌───────────────────┐
+│              │                            │   BoondManager    │
+│              │                            │   (resource API)  │
+│              │                            └───────────────────┘
+└──────────────┘
+```
+
+The MCP server **holds no OAuth state**: no `client_secret`, no refresh
+token, no per-user storage. It validates that a Bearer token is present
+on every request, pushes it into an `AsyncLocalStorage` context, and
+forwards it verbatim to BoondManager when tool calls fire. If
+BoondManager rejects the token (401), the failure surfaces back through
+the MCP response. Multi-tenant by construction — each user's actions are
+attributed to *their* Boond identity in Boond's audit log.
+
+---
+
+## 1. Register an App in BoondManager
+
+OAuth2 is configured per *App* in BoondManager:
+
+1. **Administration → Apps → Security tab.**
+2. Toggle **OAuth2** on.
+3. Add **at least one redirect URL** — the URL your MCP client uses to
+   receive the OAuth callback. For local Claude Desktop / Claude Code,
+   that's typically a `localhost` or `127.0.0.1` URL on whichever port
+   the client listens on (consult your client's docs). For browser-based
+   MCP clients, that's the client's own public callback URL.
+4. Note the **Client ID**, **Authorization URL**, and **Access Token URL**
+   shown by the Security tab. They are what the MCP client needs in step 3.
+5. Configure **Authorized APIs** — these become the scopes the App can
+   request.
+
+> The MCP server does **not** need the `client_secret`. That secret lives
+> with the MCP client (or in your IdP / OAuth broker, depending on how
+> you wire authentication into the MCP client).
+
+---
+
+## 2. Run the MCP server
+
+No bootstrap, no login CLI — just start it.
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HTTP_HOST=0.0.0.0
+export MCP_HTTP_PORT=3000
+# Required when behind a reverse proxy so discovery advertises the
+# externally-reachable URL.
+export MCP_HTTP_PUBLIC_URL=https://mcp.example.com/mcp
+npx boondmanager-mcp-server
+```
+
+That's it. The server is now:
+
+- accepting OAuth2 Bearer tokens at `https://mcp.example.com/mcp`
+- publishing discovery metadata at
+  `https://mcp.example.com/.well-known/oauth-protected-resource`
+  (also reachable at the path-suffixed variant
+  `…/.well-known/oauth-protected-resource/mcp` per RFC 9728 §3.2).
+
+Optional env vars for the discovery metadata:
+
+| Var | Purpose |
+|-----|---------|
+| `MCP_HTTP_PUBLIC_URL` | Public URL advertised as the OAuth2 resource identifier. Defaults to `http://<host>:<port><path>` — set this whenever you front the server with a reverse proxy. |
+| `BOOND_OAUTH_AUTHORIZATION_SERVER` | Issuer URL of the BoondManager authorization server, advertised in `authorization_servers`. Defaults to `https://ui.boondmanager.com`. |
+| `BOOND_OAUTH_SCOPES` | Space/comma-separated list of scope hints advertised in `scopes_supported`. Empty = clients negotiate scopes directly with Boond. |
+| `BOOND_BASE_URL` | API base URL used when forwarding tool calls. Defaults to `https://ui.boondmanager.com/api`. |
+
+---
+
+## 3. Configure the MCP client
+
+The MCP client discovers the OAuth flow automatically by fetching the
+protected-resource metadata. With a spec-compliant MCP client, the
+typical sequence is:
+
+1. Client connects to `https://mcp.example.com/mcp`, gets back `401` +
+   `WWW-Authenticate: Bearer resource_metadata="…"`.
+2. Client fetches the metadata URL, learns the authorization server is
+   `https://ui.boondmanager.com`.
+3. Client fetches the authorization server's metadata
+   (`.well-known/oauth-authorization-server`) — or uses pre-configured
+   `authorize` / `token` URLs — and opens the browser for user consent.
+4. User authorizes the App in BoondManager. The browser redirects back
+   to the client with an `authorization_code`.
+5. Client exchanges the code for an `access_token` (and `refresh_token`)
+   at the Boond token endpoint, using the App's `client_id` (and
+   `client_secret` if non-public).
+6. Client retries the MCP request with `Authorization: Bearer <access_token>`.
+7. Server forwards the token to Boond on every API call; refresh happens
+   entirely client-side.
+
+If your MCP client does **not** support the discovery flow, configure
+the BoondManager OAuth endpoints manually using the values from the App
+Security tab.
+
+---
+
+## 4. Deploying to production
+
+Because the server is stateless, deployment is trivial: just a long-running
+HTTP service behind a TLS-terminating reverse proxy.
+
+### Docker
+
+```bash
+docker run -d --restart unless-stopped \
+  -p 127.0.0.1:3000:3000 \
+  -e MCP_HTTP_PUBLIC_URL=https://mcp.example.com/mcp \
+  --name boondmanager-mcp \
+  ghcr.io/fauguste/boondmanager-mcp-server:latest
+```
+
+No volume, no secret, no env var that you wouldn't paste into a Slack
+channel. Restart-safe (no state).
+
+### docker-compose
+
+The repo ships a ready-to-use `docker-compose.yml`:
+
+```bash
+# Optional — only if you need to override MCP_HTTP_PUBLIC_URL etc.
+cp .env.example .env
+docker compose up -d
+docker compose logs -f mcp
+```
+
+### Behind a reverse proxy
+
+Set `MCP_HTTP_PUBLIC_URL` to the public HTTPS URL so the
+`resource` field in the discovery metadata and the `realm` /
+`resource_metadata` parameters in the 401 challenge advertise the
+correct externally-reachable URL.
+
+The reverse proxy must forward at least:
+- `Authorization` header (Bearer token)
+- `Host` header (or set `MCP_HTTP_ALLOWED_HOSTS` to include the public
+  hostname)
+- The request body for POSTs
+
+There is nothing to protect at the network layer beyond what the OAuth
+token already gates — there is no "service-account" secret stored on the
+server that an attacker could steal by reaching the listener.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401 Unauthorized` on every MCP request, no `WWW-Authenticate` advertised by the client | MCP client doesn't yet implement the [MCP Authorization spec][mcp-auth]. Configure the BoondManager OAuth endpoints manually. |
+| `401 Bearer realm=…` but the client's discovery fails | `MCP_HTTP_PUBLIC_URL` is unset behind a reverse proxy → the metadata advertises `http://0.0.0.0:3000/mcp`, which clients can't reach. Set it to the public HTTPS URL. |
+| MCP server logs `BoondManager API 401`, client gets `-32603` | The forwarded access token was rejected by Boond — the user needs to re-authorize. The MCP client should handle this and trigger a new OAuth flow. |
+| MCP server logs `No OAuth access token in request context` | Either a stdio code path is being hit on the HTTP transport (bug — file an issue), or `oauthContext.run(...)` was skipped (custom transport modifications). |
+| `/.well-known/oauth-protected-resource` returns 404 | Wrong URL. The endpoint sits at the **root** of the public hostname (not under `/mcp`). |
+| `scopes_supported` is missing from the metadata | Expected when `BOOND_OAUTH_SCOPES` is empty — clients then negotiate scopes directly with Boond. |
+
+---
+
+## 6. Implementation notes
+
+- **`src/services/oauth.ts`** — minimal: `oauthContext` (AsyncLocalStorage),
+  `extractBearerToken`, `buildProtectedResourceMetadata`,
+  `resolveAuthorizationServer`, `resolveAdvertisedScopes`.
+- **`src/transports/http.ts`** — extracts the Bearer token before
+  dispatching to the SDK's `StreamableHTTPServerTransport`, wraps the
+  handler in `oauthContext.run({ accessToken }, …)`, serves the public
+  discovery endpoint, returns RFC 6750 §3.1 challenges on missing/invalid
+  tokens.
+- **`src/services/boond-client.ts`** — `oauthContextAuth` is the
+  `BoondAuthProvider` registered by the HTTP bootstrap. It reads the
+  context per-call and forwards `Authorization: Bearer <token>` to Boond.
+- **No state** is persisted server-side. The container has nothing to
+  back up, nothing to rotate, nothing to encrypt at rest.
+- Tests: `src/services/oauth.test.ts` (context propagation, header
+  parsing, metadata builder), `src/transports/http.test.ts` (401 +
+  WWW-Authenticate, discovery endpoint, both metadata variants,
+  authorization-server override), `src/services/boond-client.test.ts`
+  (concurrent multi-tenant Bearer isolation via `oauthContextAuth`).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "1.9.1",
+  "version": "2.0.0-alpha",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.0.0-alpha",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.9.1",
+  "version": "2.0.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "1.9.1",
+      "version": "2.0.0-alpha",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "1.9.1",
+  "version": "2.0.0-alpha",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.0.0-alpha",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.0.0-alpha/boondmanager-mcp-server-v2.0.0-alpha.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.0.0/boondmanager-mcp-server-v2.0.0.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
-  "version": "1.9.1",
+  "version": "2.0.0-alpha",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "1.9.1",
+      "version": "2.0.0-alpha",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v1.9.1/boondmanager-mcp-server-v1.9.1.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.0.0-alpha/boondmanager-mcp-server-v2.0.0-alpha.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { initClient } from "./services/boond-client.js";
+import { initClient, initClientWithAuth, oauthContextAuth } from "./services/boond-client.js";
 import { createMcpServer, REGISTERED_DOMAINS } from "./server.js";
 import { resolveHttpOptions, startHttpTransport } from "./transports/http.js";
 
@@ -13,21 +13,21 @@ function resolveTransport(): TransportKind {
 }
 
 async function main(): Promise<void> {
-  try {
-    initClient();
-  } catch (error) {
-    console.error("⚠️  Configuration warning:", (error as Error).message);
-    console.error("The server will start but API calls will fail without proper credentials.");
-  }
-
   const kind = resolveTransport();
 
   if (kind === "http") {
+    // HTTP transport: OAuth2 only. The MCP server is a *protected resource*
+    // — it does not hold any OAuth client secrets and does not store tokens.
+    // Each MCP request carries its own `Authorization: Bearer <token>`,
+    // which the transport pushes into an AsyncLocalStorage context that the
+    // boond-client reads to call BoondManager on behalf of the user.
+    initClientWithAuth(oauthContextAuth);
     const options = resolveHttpOptions();
     const handle = await startHttpTransport(createMcpServer, options);
     console.error("🚀 BoondManager MCP Server running (streamable HTTP transport)");
     console.error(`📡 Endpoint: http://${handle.address.host}:${handle.address.port}${handle.address.path}`);
-    console.error(`🔑 Mode: ${options.stateless ? "stateless" : "stateful"}${options.bearerToken ? " (bearer auth)" : ""}`);
+    console.error(`🔑 Mode: ${options.stateless ? "stateless" : "stateful"}`);
+    console.error("🔐 Boond auth: OAuth2 (per-request Bearer from MCP client)");
     console.error(`📦 Domains: ${REGISTERED_DOMAINS.join(", ")}`);
 
     const shutdown = async (signal: string): Promise<void> => {
@@ -40,6 +40,14 @@ async function main(): Promise<void> {
     return;
   }
 
+  // stdio path: existing JWT / BasicAuth env vars (unchanged).
+  try {
+    initClient();
+  } catch (error) {
+    console.error("⚠️  Configuration warning:", (error as Error).message);
+    console.error("The server will start but API calls will fail without proper credentials.");
+  }
+
   const server = createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -48,6 +56,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
-  console.error("Fatal error:", error);
+  console.error("Fatal error:", error instanceof Error ? error.message : error);
   process.exit(1);
 });

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -16,7 +16,11 @@ import {
   computeBackoffMs,
   resolveRateLimitConfig,
   resetRateLimiterForTests,
+  initClientWithAuth,
+  resetClientForTests,
+  oauthContextAuth,
 } from "./boond-client.js";
+import { oauthContext } from "./oauth.js";
 import {
   CHARACTER_LIMIT,
   DEFAULT_HTTP_TIMEOUT_MS,
@@ -1073,5 +1077,134 @@ describe("apiRequest rate limiting", () => {
     const after = vi.mocked(fetchMock).mock.calls.length;
 
     expect(after - before).toBe(5);
+  });
+});
+
+describe("initClientWithAuth (dynamic auth provider)", () => {
+  // Used by the HTTP transport to plug in OAuth — the access token is
+  // resolved per request so it can refresh transparently between calls.
+  const successResponse = () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-length": "10" }),
+    json: () => Promise.resolve({ data: [] }),
+  });
+
+  beforeEach(() => {
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_USER;
+    delete process.env.BOOND_PASSWORD;
+    delete process.env.BOOND_USER_TOKEN;
+    delete process.env.BOOND_CLIENT_TOKEN;
+    delete process.env.BOOND_CLIENT_KEY;
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
+    resetClientForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
+    resetClientForTests();
+  });
+
+  it("sends the provider-supplied header on each request", async () => {
+    initClientWithAuth(async () => ({ name: "Authorization", value: "Bearer AT-1" }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer AT-1");
+    expect(headers["X-Jwt-Client-Boondmanager"]).toBeUndefined();
+  });
+
+  it("re-invokes the provider on every request so the token can rotate", async () => {
+    let n = 0;
+    initClientWithAuth(async () => ({ name: "Authorization", value: `Bearer AT-${++n}` }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    await apiRequest("/application/current-user");
+    const headersFirst = (vi.mocked(fetch).mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    const headersSecond = (vi.mocked(fetch).mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(headersFirst.Authorization).toBe("Bearer AT-1");
+    expect(headersSecond.Authorization).toBe("Bearer AT-2");
+  });
+
+  it("respects a custom baseUrl override", async () => {
+    initClientWithAuth(async () => ({ name: "Authorization", value: "Bearer X" }), "https://example.test/api");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await apiRequest("/application/current-user");
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toBe("https://example.test/api/application/current-user");
+  });
+});
+
+describe("oauthContextAuth", () => {
+  // Bridge between the HTTP transport (which fills the AsyncLocalStorage
+  // context) and the boond-client (which forwards the Bearer to Boond).
+  const successResponse = () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-length": "10" }),
+    json: () => Promise.resolve({ data: [] }),
+  });
+
+  beforeEach(() => {
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
+    resetClientForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
+    resetClientForTests();
+  });
+
+  it("forwards the per-request access token from AsyncLocalStorage as a Bearer", async () => {
+    initClientWithAuth(oauthContextAuth);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await oauthContext.run({ accessToken: "user-AT" }, async () => {
+      await apiRequest("/application/current-user");
+    });
+    const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer user-AT");
+  });
+
+  it("uses a different Bearer per concurrent request (multi-tenant isolation)", async () => {
+    initClientWithAuth(oauthContextAuth);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+
+    await Promise.all([
+      oauthContext.run({ accessToken: "tenant-A" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        await apiRequest("/application/current-user");
+      }),
+      oauthContext.run({ accessToken: "tenant-B" }, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        await apiRequest("/application/current-user");
+      }),
+    ]);
+    const tokens = vi
+      .mocked(fetch)
+      .mock.calls.map((c) => ((c[1] as RequestInit).headers as Record<string, string>).Authorization);
+    expect(tokens.sort()).toEqual(["Bearer tenant-A", "Bearer tenant-B"]);
+  });
+
+  it("throws a clear error when called outside a request context", async () => {
+    initClientWithAuth(oauthContextAuth);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
+    await expect(apiRequest("/application/current-user")).rejects.toThrow(/Bearer/);
   });
 });

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -9,10 +9,30 @@ import {
   DEFAULT_HTTP_RATE_LIMIT_RPS,
   DEFAULT_HTTP_RATE_LIMIT_BURST,
 } from "../constants.js";
-import type { BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
+import type { BoondAuthProvider, BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
 import { TokenBucket } from "./rate-limiter.js";
+import { oauthContext } from "./oauth.js";
 
 let config: BoondConfig | null = null;
+
+/**
+ * Auth provider for the HTTP transport: reads the Bearer token from the
+ * per-request AsyncLocalStorage populated by the transport layer and
+ * forwards it verbatim to BoondManager as `Authorization: Bearer …`.
+ *
+ * Errors out clearly if called outside a request context — which would
+ * indicate that the transport layer forgot to wrap the request in
+ * `oauthContext.run(...)`.
+ */
+export const oauthContextAuth: BoondAuthProvider = async () => {
+  const ctx = oauthContext.getStore();
+  if (!ctx) {
+    throw new Error(
+      "No OAuth access token in request context. The HTTP transport requires an `Authorization: Bearer <boond_access_token>` header on every request."
+    );
+  }
+  return { name: "Authorization", value: `Bearer ${ctx.accessToken}` };
+};
 
 function base64url(data: string | Buffer): string {
   const b64 = Buffer.from(data).toString("base64");
@@ -35,10 +55,19 @@ function envOrUndefined(key: string): string | undefined {
 
 export const JWT_HEADER_NAME = "X-Jwt-Client-Boondmanager";
 
+/**
+ * Wrap a static header pair in the dynamic AuthProvider contract.
+ * Used by the stdio transport, which sticks to the JWT / BasicAuth paths.
+ */
+function staticAuth(name: string, value: string): BoondAuthProvider {
+  const cached = Promise.resolve({ name, value });
+  return () => cached;
+}
+
 export function initClient(): void {
   const baseUrl = envOrUndefined("BOOND_BASE_URL") || DEFAULT_BASE_URL;
 
-  // Auth priority:
+  // Auth priority (stdio transport):
   // 1. Build JWT from components (userToken + clientToken + clientKey)
   // 2. Pre-built JWT token
   // 3. BasicAuth (user:password)
@@ -47,6 +76,8 @@ export function initClient(): void {
   // `X-Jwt-Client-Boondmanager` header — sending it as `Authorization: Bearer`
   // makes the API reject the request with 422 "Signature verification failed".
   // BasicAuth, on the other hand, uses the standard `Authorization` header.
+  //
+  // HTTP transport uses OAuth2 exclusively — see `initClientWithAuth`.
   const userToken = envOrUndefined("BOOND_USER_TOKEN");
   const clientToken = envOrUndefined("BOOND_CLIENT_TOKEN");
   const clientKey = envOrUndefined("BOOND_CLIENT_KEY");
@@ -54,25 +85,38 @@ export function initClient(): void {
   const user = envOrUndefined("BOOND_USER");
   const password = envOrUndefined("BOOND_PASSWORD");
 
-  let authHeaderName: string;
-  let authHeaderValue: string;
+  let auth: BoondAuthProvider;
 
   if (userToken && clientToken && clientKey) {
-    authHeaderName = JWT_HEADER_NAME;
-    authHeaderValue = buildJwt(userToken, clientToken, clientKey);
+    auth = staticAuth(JWT_HEADER_NAME, buildJwt(userToken, clientToken, clientKey));
   } else if (token) {
-    authHeaderName = JWT_HEADER_NAME;
-    authHeaderValue = token;
+    auth = staticAuth(JWT_HEADER_NAME, token);
   } else if (user && password) {
-    authHeaderName = "Authorization";
-    authHeaderValue = `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+    auth = staticAuth("Authorization", `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`);
   } else {
     throw new Error(
       "Authentication required. Set BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY, or BOOND_API_TOKEN, or both BOOND_USER and BOOND_PASSWORD."
     );
   }
 
-  config = { baseUrl, authHeaderName, authHeaderValue };
+  config = { baseUrl, auth };
+}
+
+/**
+ * Install a custom auth provider — used by the HTTP transport bootstrap to
+ * wire in an OAuth2 token source (where the access token is refreshed
+ * transparently per request rather than baked in at startup).
+ */
+export function initClientWithAuth(auth: BoondAuthProvider, baseUrl?: string): void {
+  config = {
+    baseUrl: baseUrl ?? envOrUndefined("BOOND_BASE_URL") ?? DEFAULT_BASE_URL,
+    auth,
+  };
+}
+
+/** Test helper — reset the cached config so the next call re-initialises. */
+export function resetClientForTests(): void {
+  config = null;
 }
 
 function getConfig(): BoondConfig {
@@ -302,7 +346,7 @@ function hintForStatus(status: number): string {
     case 400:
       return "Check the request body or query parameters — likely a malformed field.";
     case 401:
-      return "Authentication failed. Verify BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY (or BOOND_API_TOKEN, or BOOND_USER + BOOND_PASSWORD).";
+      return "Authentication failed. Verify BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY (or BOOND_API_TOKEN, or BOOND_USER + BOOND_PASSWORD). On HTTP transport, the OAuth access token may have expired — re-run boondmanager-mcp-oauth-login.";
     case 403:
       return "Authenticated, but the user lacks permission for this endpoint or scope.";
     case 404:
@@ -386,7 +430,7 @@ export async function apiRequest(
   body?: unknown,
   queryParams?: Record<string, QueryValue>
 ): Promise<JsonApiResponse> {
-  const { baseUrl, authHeaderName, authHeaderValue } = getConfig();
+  const { baseUrl, auth } = getConfig();
 
   const url = new URL(`${baseUrl}${path}`);
 
@@ -407,12 +451,6 @@ export async function apiRequest(
     }
   }
 
-  const headers: Record<string, string> = {
-    [authHeaderName]: authHeaderValue,
-    Accept: "application/json",
-    "Content-Type": "application/json",
-  };
-
   const timeoutMs = resolveTimeoutMs();
   const retry = resolveRetryConfig();
   const totalAttempts = retry.maxRetries + 1;
@@ -430,6 +468,16 @@ export async function apiRequest(
     // rate budget — this is what actually protects us from feedback loops
     // (transient 5xx → retry → transient 5xx → …) saturating the API.
     if (limiter) await limiter.acquire();
+
+    // Resolve the auth header per-attempt so OAuth2 refreshes are picked
+    // up between retries (the access token may have expired since the
+    // previous attempt).
+    const authHeader = await auth();
+    const headers: Record<string, string> = {
+      [authHeader.name]: authHeader.value,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
 
     const fetchOptions: RequestInit = {
       method,

--- a/src/services/oauth.test.ts
+++ b/src/services/oauth.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_AUTHORIZATION_SERVER,
+  buildProtectedResourceMetadata,
+  extractBearerToken,
+  oauthContext,
+  resolveAdvertisedScopes,
+  resolveAuthorizationServer,
+} from "./oauth.js";
+
+describe("extractBearerToken", () => {
+  it("returns the token when the header is a valid Bearer string", () => {
+    expect(extractBearerToken("Bearer abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("is case-insensitive on the scheme name", () => {
+    expect(extractBearerToken("bearer abc")).toBe("abc");
+    expect(extractBearerToken("BEARER abc")).toBe("abc");
+  });
+
+  it("ignores leading/trailing whitespace", () => {
+    expect(extractBearerToken("  Bearer   tok  ")).toBe("tok");
+  });
+
+  it("returns null for missing or empty headers", () => {
+    expect(extractBearerToken(undefined)).toBeNull();
+    expect(extractBearerToken("")).toBeNull();
+  });
+
+  it("returns null when the scheme is not Bearer", () => {
+    expect(extractBearerToken("Basic dXNlcjpwYXNz")).toBeNull();
+    expect(extractBearerToken("Token abc")).toBeNull();
+  });
+
+  it("returns null when the Bearer value is empty", () => {
+    expect(extractBearerToken("Bearer ")).toBeNull();
+    expect(extractBearerToken("Bearer   ")).toBeNull();
+  });
+
+  it("returns the first element when given an array header (Node's IncomingMessage shape)", () => {
+    expect(extractBearerToken(["Bearer tok1", "Bearer tok2"])).toBe("tok1");
+  });
+});
+
+describe("oauthContext (AsyncLocalStorage)", () => {
+  it("returns undefined outside any run() scope", () => {
+    expect(oauthContext.getStore()).toBeUndefined();
+  });
+
+  it("makes the access token visible synchronously inside run()", () => {
+    oauthContext.run({ accessToken: "AT" }, () => {
+      expect(oauthContext.getStore()?.accessToken).toBe("AT");
+    });
+  });
+
+  it("propagates the context across async boundaries", async () => {
+    await oauthContext.run({ accessToken: "AT" }, async () => {
+      // Cross a microtask boundary — AsyncLocalStorage must still carry the value.
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 1));
+      expect(oauthContext.getStore()?.accessToken).toBe("AT");
+    });
+  });
+
+  it("isolates concurrent runs from each other", async () => {
+    const tokens = await Promise.all([
+      oauthContext.run({ accessToken: "A" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return oauthContext.getStore()?.accessToken;
+      }),
+      oauthContext.run({ accessToken: "B" }, async () => {
+        await new Promise((r) => setTimeout(r, 2));
+        return oauthContext.getStore()?.accessToken;
+      }),
+      oauthContext.run({ accessToken: "C" }, async () => {
+        return oauthContext.getStore()?.accessToken;
+      }),
+    ]);
+    expect(tokens).toEqual(["A", "B", "C"]);
+  });
+});
+
+describe("buildProtectedResourceMetadata", () => {
+  it("emits the required RFC 9728 fields", () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: "https://mcp.example.com/mcp",
+      authorizationServers: ["https://ui.boondmanager.com"],
+    });
+    expect(doc).toEqual({
+      resource: "https://mcp.example.com/mcp",
+      authorization_servers: ["https://ui.boondmanager.com"],
+      bearer_methods_supported: ["header"],
+    });
+  });
+
+  it("includes scopes_supported when provided", () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: "https://mcp.example.com/mcp",
+      authorizationServers: ["https://ui.boondmanager.com"],
+      scopesSupported: ["candidates", "resources"],
+    });
+    expect(doc["scopes_supported"]).toEqual(["candidates", "resources"]);
+  });
+
+  it("omits scopes_supported when the list is empty", () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: "r",
+      authorizationServers: ["a"],
+      scopesSupported: [],
+    });
+    expect(doc).not.toHaveProperty("scopes_supported");
+  });
+});
+
+describe("resolveAuthorizationServer", () => {
+  const original = process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"];
+  afterEach(() => {
+    if (original === undefined) delete process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"];
+    else process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"] = original;
+  });
+
+  it("falls back to the default Boond authorization server", () => {
+    delete process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"];
+    expect(resolveAuthorizationServer()).toBe(DEFAULT_AUTHORIZATION_SERVER);
+  });
+
+  it("uses the override when configured", () => {
+    process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"] = "https://custom.boondmanager.com";
+    expect(resolveAuthorizationServer()).toBe("https://custom.boondmanager.com");
+  });
+
+  it("ignores unresolved ${...} placeholders", () => {
+    process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"] = "${user_config.issuer}";
+    expect(resolveAuthorizationServer()).toBe(DEFAULT_AUTHORIZATION_SERVER);
+  });
+});
+
+describe("resolveAdvertisedScopes", () => {
+  const original = process.env["BOOND_OAUTH_SCOPES"];
+  afterEach(() => {
+    if (original === undefined) delete process.env["BOOND_OAUTH_SCOPES"];
+    else process.env["BOOND_OAUTH_SCOPES"] = original;
+  });
+
+  it("returns an empty list when unset", () => {
+    delete process.env["BOOND_OAUTH_SCOPES"];
+    expect(resolveAdvertisedScopes()).toEqual([]);
+  });
+
+  it("splits on comma or whitespace", () => {
+    process.env["BOOND_OAUTH_SCOPES"] = "candidates, resources companies";
+    expect(resolveAdvertisedScopes()).toEqual(["candidates", "resources", "companies"]);
+  });
+});

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -39,14 +39,28 @@ export const oauthContext = new AsyncLocalStorage<OAuthRequestContext>();
 /**
  * Extract a Bearer token from an HTTP `Authorization` header.
  * Returns `null` for missing, malformed, or non-Bearer auth schemes.
+ *
+ * Implemented with plain string operations rather than a regex to stay
+ * O(n) on hostile inputs (e.g. an `Authorization` header full of spaces).
+ * A naive `/^Bearer\s+(.+)$/i` is flagged by CodeQL `js/polynomial-redos`
+ * because the greedy `\s+` and `.+` can backtrack against each other on
+ * adversarial whitespace-only suffixes. The implementation below has no
+ * backtracking surface.
  */
 export function extractBearerToken(header: string | string[] | undefined): string | null {
   if (!header) return null;
   const value = Array.isArray(header) ? header[0] : header;
   if (typeof value !== "string") return null;
-  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
-  if (!match) return null;
-  const token = match[1].trim();
+  const trimmed = value.trim();
+  // "Bearer x" minimum length — scheme (6) + separator (1) + 1-char token.
+  if (trimmed.length < 8) return null;
+  if (trimmed.slice(0, 6).toLowerCase() !== "bearer") return null;
+  // RFC 6750 §2.1 specifies a single space, but be liberal: accept tab too
+  // since plenty of clients tab-separate. Reject anything else (covers
+  // "Bearer-something" and other accidental matches of the prefix).
+  const sep = trimmed.charCodeAt(6);
+  if (sep !== 0x20 /* SP */ && sep !== 0x09 /* HT */) return null;
+  const token = trimmed.slice(7).trim();
   return token.length > 0 ? token : null;
 }
 

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -1,0 +1,106 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * OAuth2 plumbing for the HTTP transport.
+ *
+ * Architecture (corrected): the MCP server is a **OAuth2 protected resource**,
+ * not an OAuth client. The MCP client (Claude Desktop, Claude Code, an MCP
+ * gateway, …) performs the OAuth dance against BoondManager directly,
+ * receives an access token, and forwards it as `Authorization: Bearer <token>`
+ * on every MCP request. This server:
+ *
+ *   1. Validates the presence of a Bearer token on every request.
+ *   2. Stores it in a per-request AsyncLocalStorage context.
+ *   3. Forwards it verbatim when calling the BoondManager API
+ *      (boond-client.ts reads the context via `oauthContextAuth`).
+ *   4. Publishes RFC 9728 protected-resource metadata at
+ *      `/.well-known/oauth-protected-resource` so MCP clients can discover
+ *      the authorization server (BoondManager) automatically.
+ *
+ * The server holds **no secrets** related to OAuth: no client_secret, no
+ * refresh token, no token store. Each user's session lives entirely on the
+ * MCP client side. Multi-tenant by construction — each MCP user's Boond
+ * actions are attributed to *that* user in Boond's audit log.
+ */
+
+export interface OAuthRequestContext {
+  /** Bearer access token received from the MCP client (forwarded verbatim to Boond). */
+  accessToken: string;
+}
+
+/**
+ * Per-request context, populated by the HTTP transport before dispatching
+ * to the MCP SDK and read by `oauthContextAuth` (boond-client) when an API
+ * call is about to be issued. Stdio transport never uses this — it relies
+ * on env-var credentials.
+ */
+export const oauthContext = new AsyncLocalStorage<OAuthRequestContext>();
+
+/**
+ * Extract a Bearer token from an HTTP `Authorization` header.
+ * Returns `null` for missing, malformed, or non-Bearer auth schemes.
+ */
+export function extractBearerToken(header: string | string[] | undefined): string | null {
+  if (!header) return null;
+  const value = Array.isArray(header) ? header[0] : header;
+  if (typeof value !== "string") return null;
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  if (!match) return null;
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
+/** Default BoondManager OAuth authorization server (issuer). */
+export const DEFAULT_AUTHORIZATION_SERVER = "https://ui.boondmanager.com";
+
+export interface ProtectedResourceMetadataOptions {
+  /** Canonical URL of this protected resource — e.g. `https://mcp.example.com/mcp`. */
+  resource: string;
+  /** Issuer URL(s) of the authorization server — e.g. `https://ui.boondmanager.com`. */
+  authorizationServers: string[];
+  /** Optional scope hints exposed to MCP clients. */
+  scopesSupported?: string[];
+}
+
+/**
+ * Build an RFC 9728 *OAuth 2.0 Protected Resource Metadata* document.
+ * Served at `/.well-known/oauth-protected-resource` (and the path-suffixed
+ * variant matching MCP_HTTP_PATH) so MCP clients can auto-discover where
+ * to send the user for authorization.
+ */
+export function buildProtectedResourceMetadata(opts: ProtectedResourceMetadataOptions): Record<string, unknown> {
+  const doc: Record<string, unknown> = {
+    resource: opts.resource,
+    authorization_servers: opts.authorizationServers,
+    bearer_methods_supported: ["header"],
+  };
+  if (opts.scopesSupported && opts.scopesSupported.length > 0) {
+    doc["scopes_supported"] = opts.scopesSupported;
+  }
+  return doc;
+}
+
+function envOrUndefined(key: string): string | undefined {
+  const v = process.env[key];
+  if (!v || v.startsWith("${")) return undefined;
+  return v;
+}
+
+/**
+ * Resolve the authorization server URL surfaced in the discovery metadata.
+ * Configurable so dedicated BoondManager instances (custom hostnames) can
+ * advertise the right issuer.
+ */
+export function resolveAuthorizationServer(): string {
+  return envOrUndefined("BOOND_OAUTH_AUTHORIZATION_SERVER") ?? DEFAULT_AUTHORIZATION_SERVER;
+}
+
+/**
+ * Optional scope list advertised in the discovery metadata. Lets the MCP
+ * client request appropriate scopes when initiating the OAuth flow.
+ */
+export function resolveAdvertisedScopes(): string[] {
+  const raw = envOrUndefined("BOOND_OAUTH_SCOPES");
+  if (!raw) return [];
+  return raw.split(/[\s,]+/).filter((s) => s.length > 0);
+}

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -49,12 +49,17 @@ const ENV_KEYS = [
   "MCP_HTTP_HOST",
   "MCP_HTTP_PATH",
   "MCP_HTTP_STATEFUL",
-  "MCP_HTTP_BEARER_TOKEN",
   "MCP_HTTP_JSON_RESPONSE",
   "MCP_HTTP_SESSION_TTL_MS",
   "MCP_HTTP_SESSION_SWEEP_INTERVAL_MS",
   "MCP_HTTP_ALLOWED_HOSTS",
+  "MCP_HTTP_PUBLIC_URL",
+  "BOOND_OAUTH_AUTHORIZATION_SERVER",
+  "BOOND_OAUTH_SCOPES",
 ];
+
+/** Shorthand for an authenticated MCP request body (OAuth Bearer required). */
+const AUTH_HEADER = { Authorization: "Bearer test-access-token" };
 
 function clearEnv(): void {
   for (const key of ENV_KEYS) delete process.env[key];
@@ -71,7 +76,7 @@ describe("resolveHttpOptions", () => {
     expect(opts.path).toBe("/mcp");
     expect(opts.stateless).toBe(true);
     expect(opts.enableJsonResponse).toBe(false);
-    expect(opts.bearerToken).toBeUndefined();
+    expect(opts.publicUrl).toBeUndefined();
     expect(opts.sessionTtlMs).toBe(30 * 60_000);
     expect(opts.sessionSweepIntervalMs).toBe(5 * 60_000);
   });
@@ -97,16 +102,16 @@ describe("resolveHttpOptions", () => {
     process.env["MCP_HTTP_HOST"] = "0.0.0.0";
     process.env["MCP_HTTP_PATH"] = "/api/mcp";
     process.env["MCP_HTTP_STATEFUL"] = "true";
-    process.env["MCP_HTTP_BEARER_TOKEN"] = "sekret";
     process.env["MCP_HTTP_JSON_RESPONSE"] = "true";
+    process.env["MCP_HTTP_PUBLIC_URL"] = "https://mcp.example.com/api/mcp";
 
     const opts = resolveHttpOptions();
     expect(opts.port).toBe(4242);
     expect(opts.host).toBe("0.0.0.0");
     expect(opts.path).toBe("/api/mcp");
     expect(opts.stateless).toBe(false);
-    expect(opts.bearerToken).toBe("sekret");
     expect(opts.enableJsonResponse).toBe(true);
+    expect(opts.publicUrl).toBe("https://mcp.example.com/api/mcp");
   });
 
   it("ignores unresolved ${...} placeholders", () => {
@@ -182,17 +187,20 @@ describe("startHttpTransport (integration)", () => {
       stateless: true,
       enableJsonResponse: true,
     });
-    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`);
+    // GET on the MCP endpoint still needs to be authenticated — the 401
+    // challenge fires before stateless-vs-stateful routing.
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      headers: AUTH_HEADER,
+    });
     expect(res.status).toBe(405);
   });
 
-  it("rejects unauthorized requests when a bearer token is configured", async () => {
+  it("returns 401 with a WWW-Authenticate challenge when no Bearer token is present", async () => {
     handle = await startHttpTransport(createMcpServer, {
       host: "127.0.0.1",
       port: 34569,
       path: "/mcp",
       stateless: true,
-      bearerToken: "sekret",
       enableJsonResponse: true,
     });
     const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
@@ -200,7 +208,74 @@ describe("startHttpTransport (integration)", () => {
       body: "{}",
     });
     expect(res.status).toBe(401);
-    expect(res.headers.get("www-authenticate")).toBe("Bearer");
+    const challenge = res.headers.get("www-authenticate") ?? "";
+    expect(challenge).toMatch(/^Bearer /);
+    expect(challenge).toContain("resource_metadata=");
+    expect(challenge).toContain("/.well-known/oauth-protected-resource/mcp");
+  });
+
+  it("rejects requests with a non-Bearer Authorization scheme", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34579,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      headers: { Authorization: "Basic dGVzdDp0ZXN0" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("publishes RFC 9728 protected-resource metadata at /.well-known/oauth-protected-resource", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34580,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+      publicUrl: "https://mcp.example.com/mcp",
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/.well-known/oauth-protected-resource`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const doc = (await res.json()) as Record<string, unknown>;
+    expect(doc["resource"]).toBe("https://mcp.example.com/mcp");
+    expect(doc["authorization_servers"]).toEqual(["https://ui.boondmanager.com"]);
+    expect(doc["bearer_methods_supported"]).toEqual(["header"]);
+  });
+
+  it("serves the path-suffixed metadata variant per RFC 9728 §3.2", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34581,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/.well-known/oauth-protected-resource/mcp`);
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as Record<string, unknown>;
+    expect(typeof doc["resource"]).toBe("string");
+  });
+
+  it("honours BOOND_OAUTH_AUTHORIZATION_SERVER + BOOND_OAUTH_SCOPES in the discovery metadata", async () => {
+    process.env["BOOND_OAUTH_AUTHORIZATION_SERVER"] = "https://custom.boondmanager.com";
+    process.env["BOOND_OAUTH_SCOPES"] = "candidates,resources";
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34582,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/.well-known/oauth-protected-resource`);
+    const doc = (await res.json()) as Record<string, unknown>;
+    expect(doc["authorization_servers"]).toEqual(["https://custom.boondmanager.com"]);
+    expect(doc["scopes_supported"]).toEqual(["candidates", "resources"]);
   });
 
   it("reaps idle stateful sessions on sweep", async () => {
@@ -221,6 +296,7 @@ describe("startHttpTransport (integration)", () => {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
+        ...AUTH_HEADER,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -285,11 +361,11 @@ describe("startHttpTransport (integration)", () => {
           clientInfo: { name: "vitest", version: "1.0.0" },
         },
       }),
-      { Accept: "application/json, text/event-stream" }
+      { Accept: "application/json, text/event-stream", ...AUTH_HEADER }
     );
     expect(okRes.status).toBe(200);
 
-    const koRes = await postWithHost(handle.address.port, "/mcp", "other.example.com", "{}");
+    const koRes = await postWithHost(handle.address.port, "/mcp", "other.example.com", "{}", AUTH_HEADER);
     expect(koRes.status).toBe(403);
   });
 
@@ -316,7 +392,7 @@ describe("startHttpTransport (integration)", () => {
           clientInfo: { name: "vitest", version: "1.0.0" },
         },
       }),
-      { Accept: "application/json, text/event-stream" }
+      { Accept: "application/json, text/event-stream", ...AUTH_HEADER }
     );
     expect(res.status).toBe(200);
   });
@@ -334,6 +410,7 @@ describe("startHttpTransport (integration)", () => {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
+        ...AUTH_HEADER,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -4,13 +4,19 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logger, generateCorrelationId } from "../services/logger.js";
+import {
+  buildProtectedResourceMetadata,
+  extractBearerToken,
+  oauthContext,
+  resolveAdvertisedScopes,
+  resolveAuthorizationServer,
+} from "../services/oauth.js";
 
 export interface HttpTransportOptions {
   host: string;
   port: number;
   path: string;
   stateless: boolean;
-  bearerToken?: string;
   enableJsonResponse: boolean;
   /** Idle timeout for stateful sessions, in ms. Defaults to 30 min. */
   sessionTtlMs?: number;
@@ -23,6 +29,14 @@ export interface HttpTransportOptions {
    * to a loopback interface.
    */
   allowedHosts?: string[];
+  /**
+   * Public URL clients use to reach this MCP endpoint — used as the
+   * `resource` field of the protected-resource metadata and in the
+   * `WWW-Authenticate` challenge. Defaults to `http://{host}:{port}{path}`
+   * which is only correct for local / loopback deployments. Behind a
+   * reverse proxy, set `MCP_HTTP_PUBLIC_URL` explicitly.
+   */
+  publicUrl?: string;
 }
 
 export interface HttpServerHandle {
@@ -112,12 +126,23 @@ export function resolveHttpOptions(): HttpTransportOptions {
     port,
     path: readEnv("MCP_HTTP_PATH") ?? "/mcp",
     stateless,
-    bearerToken: readEnv("MCP_HTTP_BEARER_TOKEN"),
     enableJsonResponse,
     sessionTtlMs: readPositiveInt("MCP_HTTP_SESSION_TTL_MS", DEFAULT_SESSION_TTL_MS),
     sessionSweepIntervalMs: readPositiveInt("MCP_HTTP_SESSION_SWEEP_INTERVAL_MS", DEFAULT_SESSION_SWEEP_INTERVAL_MS),
     allowedHosts: readAllowedHosts(),
+    publicUrl: readEnv("MCP_HTTP_PUBLIC_URL"),
   };
+}
+
+/**
+ * Build the canonical "resource" URL advertised in the OAuth2 protected
+ * resource metadata and in the `WWW-Authenticate` challenge. Behind a
+ * reverse proxy, the operator must set `MCP_HTTP_PUBLIC_URL` so clients
+ * receive the externally-reachable URL, not the loopback default.
+ */
+function resolveResourceUrl(options: HttpTransportOptions): string {
+  if (options.publicUrl) return options.publicUrl.replace(/\/$/, "") || options.publicUrl;
+  return `http://${options.host}:${options.port}${options.path}`;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
@@ -170,6 +195,14 @@ export async function startHttpTransport(
   const sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
   const sessionSweepIntervalMs = options.sessionSweepIntervalMs ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
   const allowedHosts = resolveAllowedHosts(options.allowedHosts, options.host);
+  const resourceUrl = resolveResourceUrl(options);
+  const authorizationServer = resolveAuthorizationServer();
+  const advertisedScopes = resolveAdvertisedScopes();
+  // Per RFC 9728 §3.2 the metadata URL is `/.well-known/oauth-protected-resource`
+  // optionally suffixed with the resource path so multiple resources can
+  // coexist on one host. We serve both for compatibility.
+  const metadataUrl = `${resourceUrl.replace(options.path, "")}/.well-known/oauth-protected-resource${options.path}`;
+  const wwwAuthenticate = `Bearer realm="${resourceUrl}", resource_metadata="${metadataUrl}"`;
 
   const sweepIdleSessions = async (): Promise<number> => {
     const cutoff = Date.now() - sessionTtlMs;
@@ -194,6 +227,33 @@ export async function startHttpTransport(
     sweepTimer.unref?.();
   }
 
+  /** Write the RFC 9728 protected-resource metadata document. */
+  const writeProtectedResourceMetadata = (res: ServerResponse): void => {
+    const doc = buildProtectedResourceMetadata({
+      resource: resourceUrl,
+      authorizationServers: [authorizationServer],
+      scopesSupported: advertisedScopes,
+    });
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.end(JSON.stringify(doc));
+  };
+
+  /** RFC 6750 §3.1 challenge for missing/invalid bearer tokens. */
+  const writeOAuthChallenge = (res: ServerResponse, status: number, message: string): void => {
+    res.statusCode = status;
+    res.setHeader("WWW-Authenticate", wwwAuthenticate);
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32001, message },
+        id: null,
+      })
+    );
+  };
+
   const httpServer = createServer(async (req, res) => {
     const corrId = generateCorrelationId();
     const reqLogger = logger.child({ corrId, method: req.method, path: req.url });
@@ -215,95 +275,115 @@ export async function startHttpTransport(
 
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
+      // Public OAuth2 discovery endpoint (RFC 9728). Must be reachable
+      // without authentication — clients fetch it to learn where to send
+      // the user for authorization. Served at both the canonical root path
+      // and the path-suffixed variant per RFC 9728 §3.2.
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/.well-known/oauth-protected-resource" ||
+          url.pathname === `/.well-known/oauth-protected-resource${options.path}`)
+      ) {
+        writeProtectedResourceMetadata(res);
+        return;
+      }
+
       if (url.pathname !== options.path) {
         res.statusCode = 404;
         res.end("Not found");
         return;
       }
 
-      if (options.bearerToken) {
-        const auth = req.headers["authorization"];
-        if (auth !== `Bearer ${options.bearerToken}`) {
-          res.statusCode = 401;
-          res.setHeader("WWW-Authenticate", "Bearer");
-          res.end("Unauthorized");
-          return;
-        }
+      // OAuth2 Bearer is mandatory on the MCP endpoint. The token is opaque
+      // to us — we forward it to BoondManager, which is authoritative.
+      const accessToken = extractBearerToken(req.headers["authorization"]);
+      if (!accessToken) {
+        writeOAuthChallenge(
+          res,
+          401,
+          "Missing Bearer token. Authenticate against BoondManager and include `Authorization: Bearer <access_token>`."
+        );
+        return;
       }
 
-      if (options.stateless) {
+      // Wrap the rest of the request lifecycle in the AsyncLocalStorage
+      // context so boond-client's `oauthContextAuth` can pull the token
+      // out when issuing API calls.
+      await oauthContext.run({ accessToken }, async () => {
+        if (options.stateless) {
+          if (req.method !== "POST") {
+            writeJsonRpcError(res, 405, "Only POST is supported in stateless mode");
+            return;
+          }
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableJsonResponse: options.enableJsonResponse,
+          });
+          const server = createServerFactory();
+          res.on("close", () => {
+            void transport.close();
+            void server.close();
+          });
+          await server.connect(transport);
+          await transport.handleRequest(req, res);
+          return;
+        }
+
+        // Stateful mode: route by Mcp-Session-Id header
+        const sessionIdHeader = req.headers["mcp-session-id"];
+        const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+        if (sessionId && sessions.has(sessionId)) {
+          const entry = sessions.get(sessionId)!;
+          entry.lastActivityAt = Date.now();
+          await entry.transport.handleRequest(req, res);
+          return;
+        }
+
         if (req.method !== "POST") {
-          writeJsonRpcError(res, 405, "Only POST is supported in stateless mode");
+          writeJsonRpcError(res, 400, "Missing or invalid session ID");
           return;
         }
+
+        // Parse body to detect initialization
+        const body = await readJsonBody(req);
+        if (!isInitializeRequest(body)) {
+          writeJsonRpcError(res, 400, "First request must be an MCP initialize message");
+          return;
+        }
+
         const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined,
+          sessionIdGenerator: () => randomUUID(),
           enableJsonResponse: options.enableJsonResponse,
+          onsessioninitialized: (id) => {
+            sessions.set(id, { transport, server, lastActivityAt: Date.now() });
+            reqLogger.info({ sessionId: id, sessionCount: sessions.size }, "MCP session initialized");
+          },
+          onsessionclosed: (id) => {
+            const entry = sessions.get(id);
+            if (entry) {
+              sessions.delete(id);
+              void destroySession(entry);
+              reqLogger.info({ sessionId: id, sessionCount: sessions.size }, "MCP session closed");
+            }
+          },
         });
-        const server = createServerFactory();
-        res.on("close", () => {
-          void transport.close();
-          void server.close();
-        });
-        await server.connect(transport);
-        await transport.handleRequest(req, res);
-        return;
-      }
-
-      // Stateful mode: route by Mcp-Session-Id header
-      const sessionIdHeader = req.headers["mcp-session-id"];
-      const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
-
-      if (sessionId && sessions.has(sessionId)) {
-        const entry = sessions.get(sessionId)!;
-        entry.lastActivityAt = Date.now();
-        await entry.transport.handleRequest(req, res);
-        return;
-      }
-
-      if (req.method !== "POST") {
-        writeJsonRpcError(res, 400, "Missing or invalid session ID");
-        return;
-      }
-
-      // Parse body to detect initialization
-      const body = await readJsonBody(req);
-      if (!isInitializeRequest(body)) {
-        writeJsonRpcError(res, 400, "First request must be an MCP initialize message");
-        return;
-      }
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: options.enableJsonResponse,
-        onsessioninitialized: (id) => {
-          sessions.set(id, { transport, server, lastActivityAt: Date.now() });
-          reqLogger.info({ sessionId: id, sessionCount: sessions.size }, "MCP session initialized");
-        },
-        onsessionclosed: (id) => {
+        transport.onclose = () => {
+          const id = transport.sessionId;
+          if (!id) return;
           const entry = sessions.get(id);
           if (entry) {
             sessions.delete(id);
-            void destroySession(entry);
-            reqLogger.info({ sessionId: id, sessionCount: sessions.size }, "MCP session closed");
+            // Server is closed by destroySession — but if the transport's own
+            // close path already disposed it, the second call is a no-op.
+            void entry.server.close().catch(() => undefined);
           }
-        },
-      });
-      transport.onclose = () => {
-        const id = transport.sessionId;
-        if (!id) return;
-        const entry = sessions.get(id);
-        if (entry) {
-          sessions.delete(id);
-          // Server is closed by destroySession — but if the transport's own
-          // close path already disposed it, the second call is a no-op.
-          void entry.server.close().catch(() => undefined);
-        }
-      };
+        };
 
-      const server = createServerFactory();
-      await server.connect(transport);
-      await transport.handleRequest(req, res, body);
+        const server = createServerFactory();
+        await server.connect(transport);
+        await transport.handleRequest(req, res, body);
+      });
     } catch (error) {
       reqLogger.error({ err: error }, "HTTP transport error");
       if (!res.headersSent) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,10 +23,16 @@ export interface JsonApiResponse {
   links?: Record<string, string>;
 }
 
+/**
+ * Async auth provider. Returning a fresh header on every call lets us
+ * support both static credentials (returns the same value forever) and
+ * OAuth2 (refreshes the access token transparently before expiry).
+ */
+export type BoondAuthProvider = () => Promise<{ name: string; value: string }>;
+
 export interface BoondConfig {
   baseUrl: string;
-  authHeaderName: string;
-  authHeaderValue: string;
+  auth: BoondAuthProvider;
 }
 
 export interface SearchParams {


### PR DESCRIPTION
## Summary

Rewrites the HTTP transport's authentication model: the MCP server is now an **OAuth2 protected resource** (per the MCP Authorization 2025-06-18 spec + RFC 9728), not an OAuth client. It holds no secrets, no refresh tokens, no per-user storage — each MCP request carries its own `Authorization: Bearer <boond_access_token>` and the server forwards it verbatim to BoondManager. Multi-tenant by construction; each user's actions are attributed to their own Boond identity in the audit log.

stdio transport is unchanged.

## Breaking change

- `MCP_HTTP_BEARER_TOKEN` is gone (replaced by per-user OAuth Bearer).
- The Docker image no longer reads Boond credentials from env vars on the HTTP path — purge any `BOOND_USER_TOKEN` / `BOOND_API_TOKEN` from your HTTP deployment env.
- See the *Migration depuis 1.x* block in `CHANGELOG.md` for the recipe.

## What's in the box

- **`src/services/oauth.ts`** — `oauthContext` (AsyncLocalStorage), `extractBearerToken` (O(n) string ops, no regex backtracking — passes CodeQL `js/polynomial-redos`), `buildProtectedResourceMetadata` (RFC 9728).
- **`src/transports/http.ts`** — extracts the Bearer, wraps the handler in `oauthContext.run(...)`, serves `/.well-known/oauth-protected-resource` (root + path-suffixed variant per RFC 9728 §3.2), returns RFC 6750 §3.1 challenges on missing/invalid tokens.
- **`src/services/boond-client.ts`** — `oauthContextAuth` reads the per-request context and forwards `Authorization: Bearer …` to Boond.
- **Stateless Docker** — `Dockerfile` drops the `/data` volume and the credentials file; `docker-compose.yml` reduces to a single service, no bootstrap profile.
- **Dual-registry publish** — `release.yml` pushes the multi-arch image to **GHCR** + **Docker Hub** (`docker.io/{DOCKERHUB_USERNAME}/boondmanager-mcp-server`); gated on `DOCKERHUB_TOKEN` presence so forks don't fail. New manual workflow `docker-publish.yml` (`workflow_dispatch`) for ad-hoc tags.
- **Prerelease handling** — version with `-foo` suffix → npm `--tag <id>`, Docker pinned-only (no `:latest` move), GitHub Release flagged as prerelease.
- **Docs** — `docs/oauth.md` (full flow, troubleshooting), `README.md` (HTTP section + dual-registry badges and links), `CLAUDE.md` (auth/CI sections rewritten), `CHANGELOG.md`.

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` (471 tests passing) on both Node 20 + 22 in CI
- [x] `npm run build && npm run docs:tools:check`
- [x] CodeQL clean (the ReDoS finding on the original regex is fixed in commit `3405bc3`)
- [x] **End-to-end smoke test**: `docker pull fauguste/boondmanager-mcp-server:2.0.0-alpha`, run on localhost, verified:
  - discovery endpoint (both root and path-suffixed) returns the expected RFC 9728 JSON
  - 401 + `WWW-Authenticate: Bearer realm="…", resource_metadata="…"` on missing Bearer
  - Non-Bearer scheme rejected
  - `initialize` handshake traverses end-to-end with a Bearer token (server announces `serverInfo: boondmanager-mcp-server 2.0.0-alpha`, protocol `2025-06-18`)
- [x] **2.0.0-alpha release shipped successfully** (run #26254840350): npm `@alpha` dist-tag, GHCR + Docker Hub `:2.0.0-alpha`, GitHub Release flagged prerelease, MCP Registry updated
- [ ] Merge → tag `v2.0.0` → `release.yml` ships the stable (npm `latest`, Docker `:latest` + `:2` + `:2.0` + `:2.0.0`, GitHub Release stable, MCP Registry)

## Commits

The branch is structured commit-by-commit so the merge keeps a readable history:

1. `b13f984` — initial OAuth2 plumbing (later iterated)
2. `3405bc3` — fix(oauth): O(n) Bearer extraction (CodeQL ReDoS)
3. `fccc633` — ci(release): prerelease tag handling (npm dist-tag, Docker pinned-only, GitHub Release prerelease)
4. `bae203e` — chore(release): 2.0.0-alpha
5. `41c1fa0` / `b9acdcd` — README polish (Docker badges + dual-registry section)
6. `e840dfd` — chore(release): 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)