### PR TITLE
ci: add Docker and pip ecosystems to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,27 @@ updates:
       - "fauguste"
     labels:
       - "ci"
+
+  # Docker base image
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "fauguste"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # Python dependencies (GitHub Actions)
+  - package-ecosystem: "pip"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "fauguste"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary
- Ajout supervision Docker base image (node:22.13-alpine)
- Ajout supervision pip (dépendances Python des GitHub Actions)

Complète la config Dependabot existante (npm + GitHub Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)