### PR TITLE
ci: add Node 24 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add Node 24 alongside 20 and 22 in the CI build/test matrix to catch compatibility issues against the latest LTS line ahead of releases.

## Test plan
- [ ] CI workflow runs successfully on Node 20, 22, and 24
- [ ] Single-version-gated steps (MCPB validate, TOOLS.md drift check, version consistency, coverage upload) still execute only on Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)