### PR TITLE
feat: env-driven access policy (domain + operation filtering)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,16 @@
 
 # Optional: custom Boond API base URL.
 # BOOND_BASE_URL=https://ui.boondmanager.com/api
+
+# ---- Access restriction (optional) -------------------------------------
+# Restrict what the AI sees/does, MCP-side. NOT a hard security boundary:
+# the underlying BoondManager account rights still apply. See docs/access-control.md.
+#
+# Allow-list of domains (CSV). Absent = all domains. Dashes or underscores ok.
+# BOOND_MCP_DOMAINS=invoices,provider-invoices,payments,orders,purchases,expenses,application
+# Deny-list of domains (CSV), applied after the allow-list.
+# BOOND_MCP_EXCLUDE_DOMAINS=candidates,resources
+# Allowed operations (CSV) among read,create,update,delete. Absent = all.
+# BOOND_MCP_OPERATIONS=read,create,update
+# Shortcut: true => read-only (equivalent to BOOND_MCP_OPERATIONS=read).
+# BOOND_MCP_READ_ONLY=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.2.0] - 2026-06-05
+
+Restriction d'accès configurable par variables d'environnement : limiter les domaines exposés et/ou bloquer les écritures, sans modifier le code.
+
+### Added
+
+- **Filtrage par domaine et par opération** (`src/config/access-policy.ts`). Quatre variables, toutes optionnelles (absentes = surface complète, comportement historique) :
+  - `BOOND_MCP_DOMAINS` : liste blanche de domaines (CSV). Tirets ou underscores acceptés.
+  - `BOOND_MCP_EXCLUDE_DOMAINS` : liste noire (CSV), appliquée après la liste blanche (la liste noire l'emporte).
+  - `BOOND_MCP_OPERATIONS` : opérations autorisées (CSV) parmi `read,create,update,delete`. Prioritaire sur le raccourci ci-dessous.
+  - `BOOND_MCP_READ_ONLY` : raccourci booléen (`1`/`true`/`yes`) equivalent a `BOOND_MCP_OPERATIONS=read`.
+- **Cohérence prompts / workflow-tools** : chaque prompt déclare les domaines qu'il orchestre (`domains[]`) ; un prompt et son outil miroir `boond_workflow_*` sont coupés ensemble dès qu'un de ces domaines est filtré, pour qu'aucun runbook ne pointe vers un outil absent.
+- **Exposition côté MCPB** : les quatre options sont disponibles dans `user_config` de `manifest.json` (toggles dans l'UI Claude Desktop).
+- **Documentation dédiée** : `docs/access-control.md` (règles de résolution, exemples, et avertissement de sécurité).
+
+### Changed
+
+- `REGISTERED_DOMAINS` déplacé dans `src/constants.ts` ; nouveau `TOOL_REGISTRARS` exporté depuis `src/server.ts` couplant chaque domaine à sa fonction d'enregistrement. La détection de domaine ne repose plus sur une analyse du nom d'outil (plus de faux positif entre `invoices` et `provider-invoices`). Le générateur de `TOOLS.md` réutilise cette liste unique.
+
+### Why
+
+Réduire la surface exposée au modèle économise des tokens de contexte et sert de garde-fou contre les actions accidentelles. Ce filtre n'est pas une frontière de sécurité dure : les droits du compte BoondManager restent la vraie barrière. Le filtre vit dans `createMcpServer` (signatures de policy optionnelles), donc `TOOLS.md` n'est jamais impacté et le drift-check CI reste vert.
+
 ## [2.1.0] - 2026-05-27
 
 Mécanisme de notification de mise à jour pour les installations `.mcpb` dans Claude Desktop (et tous les autres canaux : stdio CLI, transport HTTP, conteneur Docker).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,53 @@ Every tool must declare annotations:
 Prompts and resources don't take annotations — `title` and `description`
 are what the client surfaces.
 
+The access-control layer (below) classifies each tool's *operation* from
+these annotations, so they double as the source of truth for read-only /
+write / delete filtering. Keep them accurate.
+
+## Access Control (domain / operation restriction)
+
+Operator-side, env-driven filtering of the exposed surface. Implemented in
+`src/config/access-policy.ts` and wired in `src/server.ts::registerAll`. **Not
+a hard security boundary** — it hides tools/prompts from the model but the
+configured BoondManager credentials keep their rights (the real wall is the
+Boond account/role). Full guide: `docs/access-control.md`.
+
+Env vars (all optional, absent = full surface = legacy behaviour):
+
+| Var | Effect |
+|-----|--------|
+| `BOOND_MCP_DOMAINS` | CSV allow-list of domains. Absent = all. Dashes/underscores both accepted. |
+| `BOOND_MCP_EXCLUDE_DOMAINS` | CSV deny-list, applied after the allow-list (deny wins). |
+| `BOOND_MCP_OPERATIONS` | CSV of `read,create,update,delete`. Absent = all. Precedence over READ_ONLY. |
+| `BOOND_MCP_READ_ONLY` | Boolean (`1/true/yes`) shortcut for `OPERATIONS=read`. |
+
+Key design points (so future changes don't regress them):
+
+- **Domain filtering couples domain ↔ registrar** via the exported
+  `TOOL_REGISTRARS` array in `server.ts` (same list the TOOLS.md generator
+  consumes). No regex on tool names, so multi-word domains like
+  `provider-invoices` can't false-match `invoices`.
+- **Operation filtering is a `Proxy`** (`withPolicy`) around the McpServer that
+  drops a tool whose `operationOf(annotations)` is not allowed. Fast-path:
+  returns the server untouched when all operations are allowed. Operation is
+  derived from annotations: `readOnlyHint→read`, `destructiveHint→delete`,
+  `idempotentHint→update`, else `create`.
+- **Prompts** carry a `domains: DomainName[]` field (in `src/prompts/index.ts`);
+  a prompt is cut if any of its domains is disallowed. **Workflow tools**
+  (`boond_workflow_*`) mirror prompts 1:1 and follow the *same* rule (they are
+  NOT gated by allow-list membership of the `workflows` domain; a prompt and
+  its mirror appear/disappear together; an explicit `EXCLUDE_DOMAINS=workflows`
+  still drops the tool-form only).
+- **Resources are never filtered** (lookup substrate / dictionaries).
+- New signatures (`registerAllPrompts(server, policy?)`,
+  `registerWorkflowTools(server, policy?)`) keep `policy` **optional** so the
+  catalogue generator and existing tests register the full surface unchanged —
+  this is what keeps `TOOLS.md` from drifting.
+- The policy is resilient: unknown domains/operations are warned-and-ignored,
+  never fatal. Excluding `application` logs a guard-rail warning (it backs
+  dictionary/current-user resolution).
+
 ## Transports
 
 The server selects its transport from `MCP_TRANSPORT`:

--- a/README.md
+++ b/README.md
@@ -423,6 +423,27 @@ Pour eviter qu'une boucle d'outils emballee n'inonde l'API (et n'enchaine les `4
 | `BOOND_HTTP_RATE_LIMIT_RPS` | `10` | Debit soutenu (requetes/seconde). `0` desactive completement. |
 | `BOOND_HTTP_RATE_LIMIT_BURST` | `20` | Capacite du bucket = taille maximale de rafale immediate. |
 
+### Restriction d'accès (domaines / lecture seule)
+
+Vous pouvez restreindre **ce que l'IA voit et peut faire**, entièrement par
+variables d'environnement : exposer seulement certains domaines (ex. la
+comptabilité), et/ou bloquer les écritures et suppressions.
+
+| Variable | Effet |
+|----------|-------|
+| `BOOND_MCP_DOMAINS` | Liste blanche de domaines (CSV). Absente = tous. Ex. `invoices,payments,application` |
+| `BOOND_MCP_EXCLUDE_DOMAINS` | Liste noire de domaines (CSV), appliquée après la liste blanche. Ex. `candidates,resources` |
+| `BOOND_MCP_OPERATIONS` | Opérations autorisées (CSV) parmi `read,create,update,delete`. Absente = toutes. |
+| `BOOND_MCP_READ_ONLY` | Raccourci : `true` équivaut à `BOOND_MCP_OPERATIONS=read` (tout en lecture seule). |
+
+> ⚠️ **Ce n'est pas une frontière de sécurité dure.** Le filtre masque des
+> outils à l'IA mais n'altère pas les droits du compte BoondManager utilisé.
+> Pour un vrai cloisonnement, configurez d'abord les droits du compte/rôle
+> BoondManager (lecture seule, périmètre comptable…) ; ce filtre vient en
+> complément (économie de tokens, garde-fou anti-action accidentelle).
+
+Guide complet, règles de résolution et exemples : [docs/access-control.md](docs/access-control.md).
+
 ## Transports
 
 Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,156 @@
+# Contrôle d'accès (restriction par domaine et par opération)
+
+Ce serveur MCP expose par défaut l'intégralité de son catalogue (tous les
+domaines, lecture comme écriture). Pour beaucoup de déploiements, on veut
+**réduire ce que l'IA peut voir et faire** : exposer uniquement la
+comptabilité, ou passer tout en lecture seule, etc. Cela se configure
+entièrement par variables d'environnement, sans modifier le code.
+
+## ⚠️ Ce n'est pas une frontière de sécurité dure
+
+Ce filtre agit **côté MCP** : il décide quels outils/prompts sont *exposés au
+modèle*. Le serveur continue d'utiliser les identifiants BoondManager
+configurés. Si ces identifiants ont le droit d'écrire, le filtre ne révoque
+rien côté API : il **masque** simplement les outils au modèle.
+
+- **Frontière dure** = les droits du compte / rôle BoondManager (lecture
+  seule, périmètre comptable, etc.). C'est là qu'on garantit qu'une écriture
+  ou une lecture interdite sera **rejetée** (HTTP 403) quoi qu'il arrive.
+- **Filtre MCP (ce document)** = ergonomie, économie de tokens de contexte, et
+  garde-fou contre les actions accidentelles du modèle.
+
+Les deux sont **complémentaires**. Pour un vrai cloisonnement, configurez
+d'abord les droits BoondManager, puis utilisez ce filtre pour aligner la
+surface exposée à l'IA.
+
+## Variables d'environnement
+
+| Variable | Effet | Exemple |
+|----------|-------|---------|
+| `BOOND_MCP_DOMAINS` | Liste blanche de domaines (CSV). Absente = tous les domaines. | `invoices,payments,application` |
+| `BOOND_MCP_EXCLUDE_DOMAINS` | Liste noire de domaines (CSV). Appliquée **après** la liste blanche. | `candidates,resources` |
+| `BOOND_MCP_OPERATIONS` | Liste blanche d'opérations (CSV) parmi `read,create,update,delete`. Absente = toutes. | `read,create,update` |
+| `BOOND_MCP_READ_ONLY` | Raccourci booléen (`1`/`true`/`yes`). Équivaut à `BOOND_MCP_OPERATIONS=read`. | `true` |
+
+Règles de résolution :
+
+- **Domaines** : `effectif = (liste blanche ?? tous) − liste noire`. La liste
+  noire l'emporte toujours.
+- **Opérations** : si `BOOND_MCP_OPERATIONS` est défini, il prime ; sinon, si
+  `BOOND_MCP_READ_ONLY` est vrai → `read` seulement ; sinon toutes. Si les
+  deux sont définis, `BOOND_MCP_OPERATIONS` gagne (un `warn` est journalisé).
+- **Tolérance aux fautes** : un domaine ou une opération inconnus sont
+  **ignorés avec un avertissement** (le serveur ne plante pas). Si
+  `BOOND_MCP_OPERATIONS` ne contient *que* des valeurs invalides, on retombe
+  sur « toutes les opérations ».
+
+### Comment une opération est déterminée
+
+La catégorie d'un outil est déduite de ses annotations MCP (source de vérité,
+pas de devinette sur le nom) :
+
+| Opération | Annotations | Exemples d'outils |
+|-----------|-------------|-------------------|
+| `read` | `readOnlyHint: true` | `*_search`, `*_get`, onglets, `boond_workflow_*`, reporting |
+| `create` | `readOnlyHint: false`, `idempotentHint: false` | `*_create` |
+| `update` | `readOnlyHint: false`, `idempotentHint: true` | `*_update` |
+| `delete` | `destructiveHint: true` | `*_delete` |
+
+Un outil sans `readOnlyHint: true` est traité comme une écriture (défaut
+prudent : il est masqué en mode lecture seule).
+
+### Noms de domaines
+
+Les domaines correspondent à ceux listés dans [TOOLS.md](../TOOLS.md) (et
+`REGISTERED_DOMAINS`). Les domaines multi-mots s'écrivent indifféremment avec
+tiret ou underscore : `provider-invoices` ou `provider_invoices`. La détection
+ne repose **pas** sur une analyse du nom d'outil, donc `invoices` n'active
+jamais par erreur `provider-invoices`.
+
+## Effet sur les prompts, workflow-tools et resources
+
+- **Prompts** : un prompt est coupé dès qu'**un** des domaines qu'il orchestre
+  n'est pas autorisé, pour qu'un runbook ne pointe jamais vers un outil absent.
+  Exemple : avec `BOOND_MCP_DOMAINS=invoices,application`, le prompt
+  `factures_a_relancer` reste, mais `pipeline_commercial` (qui touche
+  `opportunities`) disparaît.
+- **Workflow-tools** (`boond_workflow_*`) : ce sont les miroirs 1:1 des
+  prompts. Ils suivent **exactement** la même règle que les prompts (un prompt
+  et son outil-miroir apparaissent ou disparaissent ensemble), et ne dépendent
+  donc pas de la présence de `workflows` dans la liste blanche. Pour supprimer
+  uniquement la forme « outil » tout en gardant les prompts :
+  `BOOND_MCP_EXCLUDE_DOMAINS=workflows`.
+- **Resources** (dictionnaires `boond://dictionary/*`, current-user) : **non
+  filtrées**. Elles sont en lecture seule par nature et servent de substrat de
+  résolution (libellés d'états/types). Elles restent disponibles quelle que
+  soit la policy.
+
+## Domaine `application` : un socle
+
+Le domaine `application` fournit les dictionnaires (résolution des
+états/types) et `current-user`. Beaucoup d'outils et de prompts s'appuient
+dessus. Il **n'est pas** forcé (vous gardez le contrôle total), mais si vous
+l'excluez, un avertissement est journalisé et la résolution des libellés sera
+dégradée. En pratique, incluez `application` dans presque toutes vos listes
+blanches.
+
+## Exemples
+
+### Comptabilité, en lecture seule
+
+```bash
+BOOND_MCP_READ_ONLY=true
+BOOND_MCP_DOMAINS=invoices,provider-invoices,payments,orders,purchases,expenses,application
+```
+
+### Comptabilité, écriture autorisée mais sans suppression
+
+```bash
+BOOND_MCP_OPERATIONS=read,create,update
+BOOND_MCP_DOMAINS=invoices,provider-invoices,payments,orders,purchases,expenses,application
+```
+
+### Gestion de projet uniquement
+
+```bash
+BOOND_MCP_DOMAINS=projects,deliveries,timesheets,resources,application
+```
+
+### Tout sauf le recrutement / RH
+
+```bash
+BOOND_MCP_EXCLUDE_DOMAINS=candidates,positionings
+```
+
+### Serveur 100 % lecture seule (tous domaines)
+
+```bash
+BOOND_MCP_READ_ONLY=true
+```
+
+## Exemple de configuration client (Claude Desktop / Cursor)
+
+```json
+{
+  "mcpServers": {
+    "boondmanager": {
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_USER_TOKEN": "…",
+        "BOOND_CLIENT_TOKEN": "…",
+        "BOOND_CLIENT_KEY": "…",
+        "BOOND_MCP_DOMAINS": "invoices,payments,application",
+        "BOOND_MCP_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
+
+## Vérification
+
+Le filtre s'applique au démarrage. Quand une restriction est active, un log
+`info` (`component: "access-policy"`) résume la policy effective. Côté client,
+la liste d'outils (`tools/list`) et de prompts (`prompts/list`) reflète
+directement la configuration.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",
@@ -29,7 +29,11 @@
         "BOOND_CLIENT_KEY": "${user_config.client_key}",
         "BOOND_API_TOKEN": "${user_config.api_token}",
         "BOOND_USER": "${user_config.user}",
-        "BOOND_PASSWORD": "${user_config.password}"
+        "BOOND_PASSWORD": "${user_config.password}",
+        "BOOND_MCP_DOMAINS": "${user_config.mcp_domains}",
+        "BOOND_MCP_EXCLUDE_DOMAINS": "${user_config.mcp_exclude_domains}",
+        "BOOND_MCP_OPERATIONS": "${user_config.mcp_operations}",
+        "BOOND_MCP_READ_ONLY": "${user_config.mcp_read_only}"
       }
     }
   },
@@ -80,6 +84,31 @@
       "title": "Mot de passe (Option 3 : BasicAuth)",
       "description": "Mot de passe BoondManager pour l'authentification BasicAuth.",
       "sensitive": true,
+      "required": false
+    },
+    "mcp_domains": {
+      "type": "string",
+      "title": "Restriction : domaines autorisés",
+      "description": "Liste blanche de domaines séparés par des virgules (ex: invoices,payments,application). Vide = tous les domaines. Voir docs/access-control.md.",
+      "required": false
+    },
+    "mcp_exclude_domains": {
+      "type": "string",
+      "title": "Restriction : domaines exclus",
+      "description": "Liste noire de domaines séparés par des virgules (ex: candidates,resources), appliquée après la liste blanche. Vide = aucune exclusion.",
+      "required": false
+    },
+    "mcp_operations": {
+      "type": "string",
+      "title": "Restriction : opérations autorisées",
+      "description": "Opérations autorisées séparées par des virgules parmi read,create,update,delete. Vide = toutes. Ignoré si 'Lecture seule' est activé.",
+      "required": false
+    },
+    "mcp_read_only": {
+      "type": "boolean",
+      "title": "Restriction : lecture seule",
+      "description": "Si activé, expose uniquement les outils de lecture (bloque création, modification et suppression). N'est pas une frontière de sécurité dure : les droits du compte BoondManager s'appliquent en plus.",
+      "default": false,
       "required": false
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/generate-tools-catalog.mjs
+++ b/scripts/generate-tools-catalog.mjs
@@ -29,10 +29,13 @@ if (!existsSync(DIST_DIR)) {
 }
 
 // Import everything we need from the compiled output.
-const tools = await import("../dist/tools/index.js");
 const { registerAllPrompts } = await import("../dist/prompts/index.js");
 const { registerAllResources } = await import("../dist/resources/index.js");
-const { REGISTERED_DOMAINS } = await import("../dist/server.js");
+// TOOL_REGISTRARS is the single source of truth for "which registrars run, in
+// what order" — shared with the real createMcpServer(). We call each registrar
+// WITHOUT an access policy so the catalogue always reflects the full surface,
+// regardless of any BOOND_MCP_* restriction set in the environment.
+const { REGISTERED_DOMAINS, TOOL_REGISTRARS } = await import("../dist/server.js");
 
 // Domains that span more than one underscore segment (e.g. `business_units`).
 // REGISTERED_DOMAINS uses dashes; tool names use underscores. Convert and
@@ -58,31 +61,14 @@ const stub = {
   },
 };
 
-// Mirror the order in src/server.ts so the captured set is identical to a
-// real createMcpServer() boot.
-const TOOL_REGISTRARS = [
-  "registerCandidateTools", "registerResourceTools", "registerContactTools",
-  "registerCompanyTools", "registerOpportunityTools", "registerActionTools",
-  "registerTimesheetTools", "registerProjectTools", "registerInvoiceTools",
-  "registerOrderTools", "registerDeliveryTools", "registerAbsenceTools",
-  "registerExpenseTools", "registerProductTools", "registerPositioningTools",
-  "registerPaymentTools", "registerAdvantageTools", "registerApplicationTools",
-  "registerContractTools", "registerPurchaseTools", "registerProviderInvoiceTools",
-  "registerAccountTools", "registerAgencyTools", "registerBusinessUnitTools",
-  "registerRoleTools", "registerLogTools", "registerNotificationTools",
-  "registerThreadTools", "registerTodolistTools", "registerFlagTools",
-  "registerCalendarTools", "registerWebhookTools", "registerValidationTools",
-  "registerPoleTools", "registerReportingTools", "registerPlanningAbsenceTools",
-  "registerWorkflowTools",
-];
-
-for (const fnName of TOOL_REGISTRARS) {
-  const fn = tools[fnName];
-  if (typeof fn !== "function") {
-    console.error(`ERROR: ${fnName} is not exported from dist/tools/index.js`);
+// Run the exact same registrars as createMcpServer(), in the same order,
+// against the stub — no policy, so we always capture the full surface.
+for (const [domain, register] of TOOL_REGISTRARS) {
+  if (typeof register !== "function") {
+    console.error(`ERROR: registrar for domain "${domain}" is not a function`);
     process.exit(1);
   }
-  fn(stub);
+  register(stub);
 }
 registerAllPrompts(stub);
 registerAllResources(stub);

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 167 tools, 11 prompts, 21 resources (ERP/CRM)",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.1.0/boondmanager-mcp-server-v2.1.0.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.2.0/boondmanager-mcp-server-v2.2.0.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/config/access-policy.test.ts
+++ b/src/config/access-policy.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  resolveAccessPolicy,
+  isDomainAllowed,
+  isOperationAllowed,
+  operationOf,
+  withPolicy,
+  ALL_OPERATIONS,
+  type AccessPolicy,
+  type ToolAnnotations,
+} from "./access-policy.js";
+
+/** Helper: build an env object (only the keys we set; rest undefined). */
+function env(overrides: Record<string, string>): NodeJS.ProcessEnv {
+  return overrides as NodeJS.ProcessEnv;
+}
+
+const READ: ToolAnnotations = { readOnlyHint: true, idempotentHint: true };
+const GET: ToolAnnotations = { readOnlyHint: true };
+const CREATE: ToolAnnotations = { readOnlyHint: false, idempotentHint: false };
+const UPDATE: ToolAnnotations = { readOnlyHint: false, idempotentHint: true };
+const DELETE: ToolAnnotations = { destructiveHint: true };
+
+describe("resolveAccessPolicy: defaults", () => {
+  it("with no env vars: no domain restriction, all operations", () => {
+    const p = resolveAccessPolicy(env({}));
+    expect(p.allowedDomains).toBeNull();
+    expect(p.excludedDomains.size).toBe(0);
+    expect([...p.operations].sort()).toEqual([...ALL_OPERATIONS].sort());
+  });
+
+  it("ignores unresolved placeholder values like ${VAR}", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "${SOMETHING}" }));
+    expect(p.allowedDomains).toBeNull();
+  });
+});
+
+describe("resolveAccessPolicy: domains", () => {
+  it("parses an allow-list (comma-separated)", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "invoices,payments,application" }));
+    expect(p.allowedDomains).not.toBeNull();
+    expect([...p.allowedDomains!].sort()).toEqual(["application", "invoices", "payments"]);
+  });
+
+  it("normalises underscores to dashes (provider_invoices -> provider-invoices)", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "provider_invoices,business_units" }));
+    expect(p.allowedDomains!.has("provider-invoices")).toBe(true);
+    expect(p.allowedDomains!.has("business-units")).toBe(true);
+  });
+
+  it("accepts whitespace separators too", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "invoices  payments" }));
+    expect([...p.allowedDomains!].sort()).toEqual(["invoices", "payments"]);
+  });
+
+  it("drops unknown domains (typos) without throwing", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "invoices,invoicez,nope" }));
+    expect([...p.allowedDomains!]).toEqual(["invoices"]);
+  });
+
+  it("parses a deny-list", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_EXCLUDE_DOMAINS: "candidates,resources" }));
+    expect(p.allowedDomains).toBeNull();
+    expect([...p.excludedDomains].sort()).toEqual(["candidates", "resources"]);
+  });
+});
+
+describe("resolveAccessPolicy: operations", () => {
+  it("BOOND_MCP_READ_ONLY=true → only read", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "true" }));
+    expect([...p.operations]).toEqual(["read"]);
+  });
+
+  it("accepts 1/yes as truthy for read-only", () => {
+    expect([...resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "1" })).operations]).toEqual(["read"]);
+    expect([...resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "yes" })).operations]).toEqual(["read"]);
+  });
+
+  it("BOOND_MCP_OPERATIONS allow-list is honoured", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_OPERATIONS: "read,create,update" }));
+    expect([...p.operations].sort()).toEqual(["create", "read", "update"]);
+  });
+
+  it("BOOND_MCP_OPERATIONS takes precedence over BOOND_MCP_READ_ONLY", () => {
+    const p = resolveAccessPolicy(
+      env({ BOOND_MCP_OPERATIONS: "read,create,update,delete", BOOND_MCP_READ_ONLY: "true" })
+    );
+    expect([...p.operations].sort()).toEqual([...ALL_OPERATIONS].sort());
+  });
+
+  it("falls back to all operations when only invalid values are given", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_OPERATIONS: "bogus,nonsense" }));
+    expect([...p.operations].sort()).toEqual([...ALL_OPERATIONS].sort());
+  });
+
+  it("keeps valid operations and drops invalid ones", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_OPERATIONS: "read,bogus,delete" }));
+    expect([...p.operations].sort()).toEqual(["delete", "read"]);
+  });
+});
+
+describe("isDomainAllowed", () => {
+  it("allows everything when no allow-list and no deny-list", () => {
+    const p = resolveAccessPolicy(env({}));
+    expect(isDomainAllowed(p, "candidates")).toBe(true);
+    expect(isDomainAllowed(p, "provider-invoices")).toBe(true);
+  });
+
+  it("allow-list: only listed domains pass", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "invoices,payments" }));
+    expect(isDomainAllowed(p, "invoices")).toBe(true);
+    expect(isDomainAllowed(p, "candidates")).toBe(false);
+  });
+
+  it("deny-list wins over allow-list", () => {
+    const p = resolveAccessPolicy(
+      env({ BOOND_MCP_DOMAINS: "invoices,payments", BOOND_MCP_EXCLUDE_DOMAINS: "payments" })
+    );
+    expect(isDomainAllowed(p, "invoices")).toBe(true);
+    expect(isDomainAllowed(p, "payments")).toBe(false);
+  });
+
+  it("accepts the underscore form of a multi-word domain at query time", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "provider-invoices" }));
+    expect(isDomainAllowed(p, "provider_invoices")).toBe(true);
+    expect(isDomainAllowed(p, "provider-invoices")).toBe(true);
+  });
+});
+
+describe("operationOf", () => {
+  it("classifies each annotation shape", () => {
+    expect(operationOf(READ)).toBe("read");
+    expect(operationOf(GET)).toBe("read");
+    expect(operationOf(CREATE)).toBe("create");
+    expect(operationOf(UPDATE)).toBe("update");
+    expect(operationOf(DELETE)).toBe("delete");
+  });
+
+  it("treats a tool with no read-only hint as a write (safe default)", () => {
+    expect(operationOf(undefined)).toBe("create");
+    expect(operationOf({})).toBe("create");
+  });
+
+  it("read-only wins even if other hints are set", () => {
+    expect(operationOf({ readOnlyHint: true, destructiveHint: true })).toBe("read");
+  });
+});
+
+describe("isOperationAllowed", () => {
+  it("respects a read-only policy", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "true" }));
+    expect(isOperationAllowed(p, READ)).toBe(true);
+    expect(isOperationAllowed(p, CREATE)).toBe(false);
+    expect(isOperationAllowed(p, UPDATE)).toBe(false);
+    expect(isOperationAllowed(p, DELETE)).toBe(false);
+  });
+
+  it("read+create+update keeps writes but drops deletes", () => {
+    const p = resolveAccessPolicy(env({ BOOND_MCP_OPERATIONS: "read,create,update" }));
+    expect(isOperationAllowed(p, CREATE)).toBe(true);
+    expect(isOperationAllowed(p, UPDATE)).toBe(true);
+    expect(isOperationAllowed(p, DELETE)).toBe(false);
+  });
+});
+
+describe("withPolicy (Proxy)", () => {
+  function fakeServer() {
+    return { registerTool: vi.fn(), registerPrompt: vi.fn() } as unknown as McpServer;
+  }
+
+  it("returns the same instance when all operations are allowed (fast path)", () => {
+    const s = fakeServer();
+    const p = resolveAccessPolicy(env({}));
+    expect(withPolicy(s, p)).toBe(s);
+  });
+
+  it("drops disallowed-operation tools and keeps allowed ones", () => {
+    const s = fakeServer();
+    const p = resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "true" }));
+    const wrapped = withPolicy(s, p);
+
+    wrapped.registerTool("boond_x_search", { annotations: READ } as never, (() => {}) as never);
+    wrapped.registerTool("boond_x_create", { annotations: CREATE } as never, (() => {}) as never);
+    wrapped.registerTool("boond_x_delete", { annotations: DELETE } as never, (() => {}) as never);
+
+    const names = vi.mocked(s.registerTool).mock.calls.map((c) => c[0]);
+    expect(names).toEqual(["boond_x_search"]);
+  });
+
+  it("passes registerPrompt straight through", () => {
+    const s = fakeServer();
+    const p = resolveAccessPolicy(env({ BOOND_MCP_READ_ONLY: "true" }));
+    const wrapped = withPolicy(s, p);
+    wrapped.registerPrompt("p1", {} as never, (() => {}) as never);
+    expect(vi.mocked(s.registerPrompt)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AccessPolicy shape", () => {
+  it("is a plain serialisable structure", () => {
+    const p: AccessPolicy = resolveAccessPolicy(env({ BOOND_MCP_DOMAINS: "invoices" }));
+    expect(p.operations instanceof Set).toBe(true);
+    expect(p.excludedDomains instanceof Set).toBe(true);
+  });
+});

--- a/src/config/access-policy.ts
+++ b/src/config/access-policy.ts
@@ -1,0 +1,237 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { REGISTERED_DOMAINS } from "../constants.js";
+import { logger } from "../services/logger.js";
+
+/**
+ * Access policy: operator-side restriction of what the MCP server exposes,
+ * driven entirely by environment variables. Two orthogonal axes:
+ *
+ *  1. Domain filtering (allow-list + deny-list): restrict the server to a
+ *     subset of business domains (e.g. accounting only).
+ *  2. Operation filtering: restrict which kinds of action are exposed
+ *     (`read` / `create` / `update` / `delete`), e.g. read-only mode.
+ *
+ * ⚠️ This is NOT a hard security boundary. The server keeps using the
+ * configured BoondManager credentials; if those credentials may write, this
+ * filter only HIDES the tools from the model; it does not revoke anything
+ * API-side. The real boundary is the BoondManager account/role rights. The
+ * two are complementary: Boond rights = hard wall; this filter = ergonomics,
+ * token economy, and a guard-rail against accidental actions.
+ *
+ * Env vars (all optional; absent = no restriction = current behaviour):
+ *  - `BOOND_MCP_DOMAINS`         CSV allow-list of domains. Absent = all.
+ *  - `BOOND_MCP_EXCLUDE_DOMAINS` CSV deny-list. Applied AFTER the allow-list.
+ *  - `BOOND_MCP_OPERATIONS`      CSV of `read,create,update,delete`. Absent = all.
+ *  - `BOOND_MCP_READ_ONLY`       Boolean shortcut, equivalent to OPERATIONS=read.
+ */
+
+export type Operation = "read" | "create" | "update" | "delete";
+
+export const ALL_OPERATIONS: readonly Operation[] = ["read", "create", "update", "delete"];
+
+/** Subset of the MCP tool annotations we use to classify a tool's operation. */
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface AccessPolicy {
+  /** `null` = all domains allowed (no allow-list). Otherwise the set of allowed canonical (dash) domain names. */
+  allowedDomains: Set<string> | null;
+  /** Canonical (dash) domain names explicitly denied. Applied after the allow-list. */
+  excludedDomains: Set<string>;
+  /** Operations the server is allowed to expose. */
+  operations: Set<Operation>;
+}
+
+// --- Env parsing helpers (mirroring the patterns already used across the
+// codebase: see transports/http.ts, services/oauth.ts, services/update-checker.ts) ---
+
+function readEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const raw = env[key];
+  if (raw === undefined) return undefined;
+  // Ignore unresolved placeholders like "${SOMETHING}" (same guard as http.ts).
+  if (raw.startsWith("${")) return undefined;
+  return raw;
+}
+
+/** Split a CSV / whitespace-separated env value into trimmed, non-empty tokens. */
+function parseList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseBoolean(raw: string | undefined): boolean {
+  const v = (raw ?? "").toLowerCase().trim();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+/** Normalise a user-supplied domain to the canonical (dash, lowercase) form. */
+function normalizeDomain(domain: string): string {
+  return domain.toLowerCase().trim().replace(/_/g, "-");
+}
+
+function normalizeAndValidateDomains(
+  items: string[],
+  known: ReadonlySet<string>,
+  varName: string,
+  log: typeof logger
+): Set<string> {
+  const out = new Set<string>();
+  for (const raw of items) {
+    const norm = normalizeDomain(raw);
+    if (known.has(norm)) {
+      out.add(norm);
+    } else {
+      log.warn(
+        { value: raw, normalized: norm, var: varName },
+        `${varName}: unknown domain "${raw}" ignored (not one of the ${known.size} known domains)`
+      );
+    }
+  }
+  return out;
+}
+
+function validateOperations(items: string[], log: typeof logger): Set<Operation> {
+  const out = new Set<Operation>();
+  for (const raw of items) {
+    const op = raw.toLowerCase() as Operation;
+    if ((ALL_OPERATIONS as readonly string[]).includes(op)) {
+      out.add(op);
+    } else {
+      log.warn(
+        { value: raw },
+        `BOOND_MCP_OPERATIONS: unknown operation "${raw}" ignored (expected read/create/update/delete)`
+      );
+    }
+  }
+  // If the operator provided only invalid values, fall back to "all" rather
+  // than silently exposing zero tools (that would look like a broken server).
+  if (out.size === 0) {
+    log.warn("BOOND_MCP_OPERATIONS contained no valid operation; defaulting to all operations");
+    return new Set<Operation>(ALL_OPERATIONS);
+  }
+  return out;
+}
+
+/**
+ * Build the effective access policy from the environment. Resilient: unknown
+ * domains/operations are warned-and-ignored, never fatal.
+ */
+export function resolveAccessPolicy(env: NodeJS.ProcessEnv = process.env): AccessPolicy {
+  const log = logger.child({ component: "access-policy" });
+  const known = new Set<string>(REGISTERED_DOMAINS);
+
+  // --- Domains ---
+  const allowItems = parseList(readEnv(env, "BOOND_MCP_DOMAINS"));
+  const excludeItems = parseList(readEnv(env, "BOOND_MCP_EXCLUDE_DOMAINS"));
+
+  const allowedDomains =
+    allowItems.length > 0 ? normalizeAndValidateDomains(allowItems, known, "BOOND_MCP_DOMAINS", log) : null;
+  const excludedDomains = normalizeAndValidateDomains(excludeItems, known, "BOOND_MCP_EXCLUDE_DOMAINS", log);
+
+  // --- Operations ---
+  const opItems = parseList(readEnv(env, "BOOND_MCP_OPERATIONS"));
+  const readOnlyShortcut = parseBoolean(readEnv(env, "BOOND_MCP_READ_ONLY"));
+
+  let operations: Set<Operation>;
+  if (opItems.length > 0) {
+    operations = validateOperations(opItems, log);
+    if (readOnlyShortcut) {
+      log.warn("Both BOOND_MCP_OPERATIONS and BOOND_MCP_READ_ONLY are set; BOOND_MCP_OPERATIONS takes precedence");
+    }
+  } else if (readOnlyShortcut) {
+    operations = new Set<Operation>(["read"]);
+  } else {
+    operations = new Set<Operation>(ALL_OPERATIONS);
+  }
+
+  const policy: AccessPolicy = { allowedDomains, excludedDomains, operations };
+
+  // --- Surface the effective policy + a guard-rail warning for `application` ---
+  const restricted = allowedDomains !== null || excludedDomains.size > 0 || operations.size !== ALL_OPERATIONS.length;
+  if (restricted) {
+    if (!isDomainAllowed(policy, "application")) {
+      log.warn(
+        "Domain `application` is filtered out; dictionary lookups (state/type labels) and current-user resolution will be unavailable, degrading many tools/resources"
+      );
+    }
+    log.info(
+      {
+        allowedDomains: allowedDomains ? [...allowedDomains] : "all",
+        excludedDomains: [...excludedDomains],
+        operations: [...operations],
+      },
+      "Access policy active: the exposed tool/prompt surface is restricted"
+    );
+  }
+
+  return policy;
+}
+
+/** Is a business domain allowed by the policy? (deny-list wins over allow-list.) */
+export function isDomainAllowed(policy: AccessPolicy, domain: string): boolean {
+  const norm = normalizeDomain(domain);
+  if (policy.excludedDomains.has(norm)) return false;
+  if (policy.allowedDomains !== null && !policy.allowedDomains.has(norm)) return false;
+  return true;
+}
+
+/**
+ * Classify a tool into a single operation from its MCP annotations.
+ * Order matters: read-only first, then destructive (delete), then idempotent
+ * writes (update), else non-idempotent writes (create). A tool with no
+ * `readOnlyHint:true` is treated as a write (the safe default in read-only mode).
+ */
+export function operationOf(annotations: ToolAnnotations | undefined): Operation {
+  if (annotations?.readOnlyHint === true) return "read";
+  if (annotations?.destructiveHint === true) return "delete";
+  if (annotations?.idempotentHint === true) return "update";
+  return "create";
+}
+
+/** Is a tool (by its annotations) allowed under the policy's operation set? */
+export function isOperationAllowed(policy: AccessPolicy, annotations: ToolAnnotations | undefined): boolean {
+  return policy.operations.has(operationOf(annotations));
+}
+
+/**
+ * Wrap an McpServer so that `registerTool` silently drops tools whose operation
+ * is not allowed by the policy. Implemented as a Proxy (no mutation of the
+ * instance, typing preserved). Methods are bound to the real target so the
+ * SDK's private fields keep working. Other methods (`registerPrompt`,
+ * `registerResource`, …) pass straight through.
+ *
+ * Fast path: when all operations are allowed, the original server is returned
+ * untouched (zero overhead in the default, unrestricted case).
+ */
+export function withPolicy(server: McpServer, policy: AccessPolicy): McpServer {
+  if (policy.operations.size === ALL_OPERATIONS.length) return server;
+
+  return new Proxy(server, {
+    get(target, prop) {
+      // receiver = target so any getters/private fields resolve against the real instance.
+      const value = Reflect.get(target, prop, target) as unknown;
+      if (typeof value !== "function") return value;
+
+      if (prop === "registerTool") {
+        return (...args: unknown[]) => {
+          const config = args[1] as { annotations?: ToolAnnotations } | undefined;
+          if (!isOperationAllowed(policy, config?.annotations)) {
+            return undefined; // skip registration; callers ignore the return value
+          }
+          return (value as (...a: unknown[]) => unknown).apply(target, args);
+        };
+      }
+
+      // Bind every other method to the real target (avoids private-field errors
+      // that occur when an unbound method runs with `this` = Proxy).
+      return (value as (...a: unknown[]) => unknown).bind(target);
+    },
+  });
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,14 +75,90 @@ export const API_PATHS = {
   reportingProductionPlans: "/reporting-production-plans",
 } as const;
 
+// Canonical list of tool domains exposed by the server, in registration order.
+// Domain names use dashes; the matching tool-name prefix replaces them with
+// underscores (e.g. `provider-invoices` -> `boond_provider_invoices_*`).
+// Lives here (not in server.ts) so the access-policy layer can validate
+// configured domains without importing server.ts (avoids an import cycle).
+export const REGISTERED_DOMAINS = [
+  "candidates",
+  "resources",
+  "contacts",
+  "companies",
+  "opportunities",
+  "actions",
+  "timesheets",
+  "projects",
+  "invoices",
+  "orders",
+  "deliveries",
+  "absences",
+  "expenses",
+  "products",
+  "positionings",
+  "payments",
+  "advantages",
+  "application",
+  "contracts",
+  "purchases",
+  "provider-invoices",
+  "accounts",
+  "agencies",
+  "business-units",
+  "roles",
+  "logs",
+  "notifications",
+  "threads",
+  "todolists",
+  "flags",
+  "calendars",
+  "webhooks",
+  "validations",
+  "poles",
+  "reporting",
+  "planning-absences",
+  "workflows",
+] as const;
+
+export type DomainName = (typeof REGISTERED_DOMAINS)[number];
+
 // Tab names available on entities (matching actual API endpoints)
 export const ENTITY_TABS = {
   candidates: ["information", "technical-data", "administrative", "actions", "positionings"] as const,
-  resources: ["information", "technical-data", "administrative", "advantages", "actions", "positionings", "projects", "times-reports", "expenses-reports", "absences-reports"] as const,
+  resources: [
+    "information",
+    "technical-data",
+    "administrative",
+    "advantages",
+    "actions",
+    "positionings",
+    "projects",
+    "times-reports",
+    "expenses-reports",
+    "absences-reports",
+  ] as const,
   contacts: ["information", "actions", "opportunities", "projects", "orders", "invoices"] as const,
-  companies: ["information", "contacts", "actions", "opportunities", "projects", "orders", "invoices", "purchases", "provider-invoices"] as const,
+  companies: [
+    "information",
+    "contacts",
+    "actions",
+    "opportunities",
+    "projects",
+    "orders",
+    "invoices",
+    "purchases",
+    "provider-invoices",
+  ] as const,
   opportunities: ["information", "actions", "positionings", "projects", "simulation"] as const,
-  projects: ["information", "actions", "simulation", "deliveries-groupments", "orders", "purchases", "productivity"] as const,
+  projects: [
+    "information",
+    "actions",
+    "simulation",
+    "deliveries-groupments",
+    "orders",
+    "purchases",
+    "productivity",
+  ] as const,
   invoices: ["information", "actions", "billable-items"] as const,
   orders: ["information", "actions", "invoices"] as const,
 } as const;

--- a/src/prompts/index.test.ts
+++ b/src/prompts/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerAllPrompts, REGISTERED_PROMPTS } from "./index.js";
+import { registerAllPrompts, REGISTERED_PROMPTS, PROMPTS } from "./index.js";
+import { REGISTERED_DOMAINS } from "../constants.js";
+import { resolveAccessPolicy } from "../config/access-policy.js";
 
 function createMockServer() {
   return { registerPrompt: vi.fn() } as unknown as McpServer;
@@ -338,6 +340,42 @@ describe("registerAllPrompts", () => {
       expect(text).not.toContain("Préalable");
       expect(text).not.toContain("<RESOURCE_ID>");
       expect(text).toContain("18081");
+    });
+  });
+
+  describe("domain metadata + access-policy filtering", () => {
+    const known = new Set<string>(REGISTERED_DOMAINS);
+
+    it("every prompt declares a non-empty domains array of known domains", () => {
+      for (const p of PROMPTS) {
+        expect(p.domains.length).toBeGreaterThan(0);
+        for (const d of p.domains) {
+          expect(known.has(d)).toBe(true);
+        }
+      }
+    });
+
+    it("no policy → all prompts registered (back-compat)", () => {
+      registerAllPrompts(server);
+      expect(server.registerPrompt).toHaveBeenCalledTimes(PROMPTS.length);
+    });
+
+    it("allow-list keeps only prompts whose domains are fully allowed", () => {
+      const policy = resolveAccessPolicy({ BOOND_MCP_DOMAINS: "invoices,application" } as NodeJS.ProcessEnv);
+      registerAllPrompts(server, policy);
+      const names = vi.mocked(server.registerPrompt).mock.calls.map((c) => c[0]);
+      expect(names).toContain("factures_a_relancer");
+      expect(names).not.toContain("synthese_equipe");
+      expect(names).not.toContain("pipeline_commercial");
+    });
+
+    it("excluding a transversal domain (application) cuts the prompts that rely on it", () => {
+      const policy = resolveAccessPolicy({ BOOND_MCP_EXCLUDE_DOMAINS: "application" } as NodeJS.ProcessEnv);
+      registerAllPrompts(server, policy);
+      const names = vi.mocked(server.registerPrompt).mock.calls.map((c) => c[0]);
+      // fiche_consultant is the only prompt that does not depend on `application`.
+      expect(names).toContain("fiche_consultant");
+      expect(names).not.toContain("synthese_equipe");
     });
   });
 });

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,5 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { DomainName } from "../constants.js";
+import { isDomainAllowed, type AccessPolicy } from "../config/access-policy.js";
 
 /**
  * Pre-orchestrated MCP prompts for the most common Boond workflows.
@@ -26,6 +28,16 @@ export interface PromptDefinition {
   title: string;
   description: string;
   argsSchema: z.ZodRawShape;
+  /**
+   * Business domains this prompt's runbook orchestrates. Used by the access
+   * policy: the prompt (and its mirror workflow tool in `tools/workflows.ts`)
+   * is cut when ANY of these domains is filtered out, so a surfaced runbook
+   * never points the model at tools that aren't registered. Optional
+   * name-resolution helpers (e.g. resolving a manager name via
+   * `boond_resources_search`) are intentionally NOT listed: if their domain
+   * is filtered, the user simply passes a numeric id instead.
+   */
+  domains: readonly DomainName[];
   build: (args: Record<string, string | undefined>) => string;
 }
 
@@ -107,6 +119,7 @@ export const PROMPTS: PromptDefinition[] = [
         .optional()
         .describe("Période d'analyse libre (ex: 'cette semaine', 'avril 2026'). Défaut: mois en cours."),
     },
+    domains: ["resources", "application"],
     build: ({ manager_id, periode }) => {
       const periodeText = periode || "le mois en cours";
       let preamble = "";
@@ -158,6 +171,7 @@ export const PROMPTS: PromptDefinition[] = [
             " Si absent, scope = équipe de l'utilisateur courant via `perimeterDynamic: ['data']`."
         ),
     },
+    domains: ["opportunities", "application"],
     build: ({ date_debut, date_fin, manager_id }) => {
       let preamble = "";
       let scopeFilter: string;
@@ -203,6 +217,7 @@ export const PROMPTS: PromptDefinition[] = [
         .optional()
         .describe("Société ciblée pour la relance. " + ID_OR_NAME_HINT_SOCIETY),
     },
+    domains: ["invoices", "application"],
     build: ({ society_id }) => {
       let preamble = "";
       let filterLine: string;
@@ -238,6 +253,7 @@ export const PROMPTS: PromptDefinition[] = [
     argsSchema: {
       opportunity_id: z.string().describe("Opportunité à pourvoir. " + ID_OR_NAME_HINT_OPPORTUNITY),
     },
+    domains: ["candidates", "opportunities", "application"],
     build: ({ opportunity_id }) => {
       const r = resolveEntity(opportunity_id ?? "", "opportunity", "<OPPORTUNITY_ID>");
       const oppLit = r.idForFilter;
@@ -268,6 +284,7 @@ export const PROMPTS: PromptDefinition[] = [
     argsSchema: {
       resource_id: z.string().describe("Ressource ciblée. " + ID_OR_NAME_HINT_RESOURCE),
     },
+    domains: ["resources"],
     build: ({ resource_id }) => {
       const r = resolveEntity(resource_id ?? "", "resource", "<RESOURCE_ID>");
       const idLit = r.idForFilter;
@@ -314,6 +331,7 @@ export const PROMPTS: PromptDefinition[] = [
             " Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
         ),
     },
+    domains: ["resources", "application"],
     build: ({ start_date, end_date, competences, manager_id }) => {
       let preamble = "";
       let scope: string;
@@ -376,6 +394,7 @@ export const PROMPTS: PromptDefinition[] = [
             " Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
         ),
     },
+    domains: ["resources", "application"],
     build: ({ horizon_jours, manager_id }) => {
       const horizon = horizon_jours || "60";
       let preamble = "";
@@ -437,6 +456,7 @@ export const PROMPTS: PromptDefinition[] = [
         .describe("Agence pour cartographier toute une agence (alternatif à `manager_id`). " + ID_OR_NAME_HINT_AGENCY),
       top_n: z.string().optional().describe("Nombre de compétences à mettre en avant dans le top (défaut: 20)."),
     },
+    domains: ["resources", "opportunities", "application"],
     build: ({ manager_id, agency_id, top_n }) => {
       const top = top_n || "20";
       let preamble = "";
@@ -500,6 +520,7 @@ export const PROMPTS: PromptDefinition[] = [
             " Si absent, scope = mon équipe via `perimeterDynamic: ['managers']`."
         ),
     },
+    domains: ["resources", "application"],
     build: ({ seuil_mois, manager_id }) => {
       const seuil = seuil_mois || "12";
       let preamble = "";
@@ -579,6 +600,7 @@ export const PROMPTS: PromptDefinition[] = [
             " Sinon scope ouvert (toute l'organisation accessible)."
         ),
     },
+    domains: ["resources", "candidates", "application"],
     build: ({ competences, experience_min, dispo_avant, inclure_candidats, manager_id }) => {
       const includeCandidates = (inclure_candidats || "oui").toLowerCase() !== "non";
       let preamble = "";
@@ -641,6 +663,7 @@ export const PROMPTS: PromptDefinition[] = [
         .optional()
         .describe("Semaine ciblée (ex: 'cette semaine', 'la semaine prochaine'). Défaut: cette semaine."),
     },
+    domains: ["resources", "opportunities", "projects", "application"],
     build: ({ semaine }) => {
       const semaineText = semaine || "cette semaine";
       return [
@@ -664,8 +687,11 @@ export const PROMPTS: PromptDefinition[] = [
   },
 ];
 
-export function registerAllPrompts(server: McpServer): void {
+export function registerAllPrompts(server: McpServer, policy?: AccessPolicy): void {
   for (const p of PROMPTS) {
+    // Cut a prompt when any domain it orchestrates is filtered out, so the
+    // surfaced runbook never references tools that aren't registered.
+    if (policy && !p.domains.every((d) => isDomainAllowed(policy, d))) continue;
     server.registerPrompt(
       p.name,
       {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,8 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { createMcpServer, REGISTERED_DOMAINS, SERVER_NAME, SERVER_VERSION } from "./server.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  createMcpServer,
+  registerAll,
+  TOOL_REGISTRARS,
+  REGISTERED_DOMAINS,
+  SERVER_NAME,
+  SERVER_VERSION,
+} from "./server.js";
+import { resolveAccessPolicy } from "./config/access-policy.js";
+
+/** Counting stub that records every registration call. */
+function createCountingServer() {
+  return {
+    registerTool: vi.fn(),
+    registerPrompt: vi.fn(),
+    registerResource: vi.fn(),
+  } as unknown as McpServer;
+}
+
+function fakeEnv(overrides: Record<string, string>): NodeJS.ProcessEnv {
+  return overrides as NodeJS.ProcessEnv;
+}
+
+function registeredToolNames(server: McpServer): string[] {
+  return vi.mocked(server.registerTool).mock.calls.map((c) => c[0] as string);
+}
+
+function registeredPromptNames(server: McpServer): string[] {
+  return vi.mocked(server.registerPrompt).mock.calls.map((c) => c[0] as string);
+}
 
 describe("createMcpServer", () => {
   it("returns an McpServer instance with the expected name", () => {
@@ -36,5 +66,94 @@ describe("SERVER_VERSION", () => {
   it("is not the legacy hardcoded placeholder", () => {
     expect(SERVER_VERSION).not.toBe("1.0.0");
     expect(SERVER_VERSION).not.toBe("0.0.0-unknown");
+  });
+});
+
+describe("TOOL_REGISTRARS", () => {
+  it("lists the same domains, in the same order, as REGISTERED_DOMAINS", () => {
+    expect(TOOL_REGISTRARS.map(([d]) => d)).toEqual([...REGISTERED_DOMAINS]);
+  });
+});
+
+describe("registerAll — access policy filtering", () => {
+  it("unrestricted policy registers the full surface (writes + all domains + prompts)", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({})));
+    const tools = registeredToolNames(s);
+    expect(tools.length).toBeGreaterThan(150);
+    // A spread of domains is present.
+    expect(tools).toContain("boond_candidates_create");
+    expect(tools).toContain("boond_invoices_search");
+    expect(tools).toContain("boond_provider_invoices_search");
+    // Prompts and resources too.
+    expect(registeredPromptNames(s).length).toBeGreaterThanOrEqual(11);
+    expect(vi.mocked(s.registerResource).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("domain allow-list exposes only the listed domains (no false positives on multi-word domains)", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_DOMAINS: "invoices,application" })));
+    const tools = registeredToolNames(s);
+    expect(tools.length).toBeGreaterThan(0);
+    for (const name of tools) {
+      // Allowed surface: the two listed domains, plus the workflow mirrors
+      // (gated by their source prompt's domains, which are ⊆ {invoices, application}).
+      expect(
+        name.startsWith("boond_invoices_") ||
+          name.startsWith("boond_application_") ||
+          name.startsWith("boond_workflow_")
+      ).toBe(true);
+    }
+    // `provider-invoices` must NOT leak in just because it shares the `invoices` substring.
+    expect(tools.some((n) => n.startsWith("boond_provider_invoices_"))).toBe(false);
+  });
+
+  it("domain deny-list removes exactly that domain", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_EXCLUDE_DOMAINS: "candidates" })));
+    const tools = registeredToolNames(s);
+    expect(tools.some((n) => n.startsWith("boond_candidates_"))).toBe(false);
+    expect(tools).toContain("boond_invoices_search");
+  });
+
+  it("read-only policy registers zero write/delete tools across every domain", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_READ_ONLY: "true" })));
+    const calls = vi.mocked(s.registerTool).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const annotations = (call[1] as { annotations?: { readOnlyHint?: boolean } }).annotations;
+      expect(annotations?.readOnlyHint).toBe(true);
+    }
+  });
+
+  it("operations=read,create,update keeps writes but drops deletes", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_OPERATIONS: "read,create,update" })));
+    const calls = vi.mocked(s.registerTool).mock.calls;
+    const hasDelete = calls.some(
+      (c) => (c[1] as { annotations?: { destructiveHint?: boolean } }).annotations?.destructiveHint === true
+    );
+    const hasCreate = registeredToolNames(s).some((n) => n.endsWith("_create"));
+    expect(hasDelete).toBe(false);
+    expect(hasCreate).toBe(true);
+  });
+
+  it("cuts prompts whose domains are not fully allowed (cross-domain coherence)", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_DOMAINS: "invoices,application" })));
+    const prompts = registeredPromptNames(s);
+    // factures_a_relancer needs only invoices+application → kept.
+    expect(prompts).toContain("factures_a_relancer");
+    // synthese_equipe needs resources → cut.
+    expect(prompts).not.toContain("synthese_equipe");
+  });
+
+  it("cuts the mirror workflow tool when its prompt's domain is filtered out", () => {
+    const s = createCountingServer();
+    registerAll(s, resolveAccessPolicy(fakeEnv({ BOOND_MCP_DOMAINS: "invoices,application" })));
+    const tools = registeredToolNames(s);
+    expect(tools).toContain("boond_workflow_factures_a_relancer");
+    expect(tools).not.toContain("boond_workflow_synthese_equipe");
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,12 @@ import {
 } from "./tools/index.js";
 import { registerAllPrompts } from "./prompts/index.js";
 import { registerAllResources } from "./resources/index.js";
+import type { DomainName } from "./constants.js";
+import { resolveAccessPolicy, isDomainAllowed, withPolicy, type AccessPolicy } from "./config/access-policy.js";
+
+// Re-exported for the catalogue generator and tests that import it from here.
+export { REGISTERED_DOMAINS } from "./constants.js";
+export type { DomainName } from "./constants.js";
 
 export const SERVER_NAME = "boondmanager-mcp-server";
 
@@ -70,45 +76,88 @@ function readPackageVersion(): string {
 
 export const SERVER_VERSION = readPackageVersion();
 
-export const REGISTERED_DOMAINS = [
-  "candidates",
-  "resources",
-  "contacts",
-  "companies",
-  "opportunities",
-  "actions",
-  "timesheets",
-  "projects",
-  "invoices",
-  "orders",
-  "deliveries",
-  "absences",
-  "expenses",
-  "products",
-  "positionings",
-  "payments",
-  "advantages",
-  "application",
-  "contracts",
-  "purchases",
-  "provider-invoices",
-  "accounts",
-  "agencies",
-  "business-units",
-  "roles",
-  "logs",
-  "notifications",
-  "threads",
-  "todolists",
-  "flags",
-  "calendars",
-  "webhooks",
-  "validations",
-  "poles",
-  "reporting",
-  "planning-absences",
-  "workflows",
-] as const;
+/**
+ * Domain → registration function, in the canonical order of REGISTERED_DOMAINS.
+ * Coupling the domain name to its registrar lets the access policy filter by
+ * domain WITHOUT parsing tool names (no fragile regex on multi-word domains
+ * like `provider-invoices`). Each registrar accepts an optional policy; only
+ * `registerWorkflowTools` uses it (to mirror the prompt-level domain filter),
+ * the others ignore the extra argument.
+ *
+ * Exported so the TOOLS.md generator can reuse the exact same list/order
+ * instead of duplicating it.
+ */
+export const TOOL_REGISTRARS: ReadonlyArray<readonly [DomainName, (server: McpServer, policy?: AccessPolicy) => void]> =
+  [
+    ["candidates", registerCandidateTools],
+    ["resources", registerResourceTools],
+    ["contacts", registerContactTools],
+    ["companies", registerCompanyTools],
+    ["opportunities", registerOpportunityTools],
+    ["actions", registerActionTools],
+    ["timesheets", registerTimesheetTools],
+    ["projects", registerProjectTools],
+    ["invoices", registerInvoiceTools],
+    ["orders", registerOrderTools],
+    ["deliveries", registerDeliveryTools],
+    ["absences", registerAbsenceTools],
+    ["expenses", registerExpenseTools],
+    ["products", registerProductTools],
+    ["positionings", registerPositioningTools],
+    ["payments", registerPaymentTools],
+    ["advantages", registerAdvantageTools],
+    ["application", registerApplicationTools],
+    ["contracts", registerContractTools],
+    ["purchases", registerPurchaseTools],
+    ["provider-invoices", registerProviderInvoiceTools],
+    ["accounts", registerAccountTools],
+    ["agencies", registerAgencyTools],
+    ["business-units", registerBusinessUnitTools],
+    ["roles", registerRoleTools],
+    ["logs", registerLogTools],
+    ["notifications", registerNotificationTools],
+    ["threads", registerThreadTools],
+    ["todolists", registerTodolistTools],
+    ["flags", registerFlagTools],
+    ["calendars", registerCalendarTools],
+    ["webhooks", registerWebhookTools],
+    ["validations", registerValidationTools],
+    ["poles", registerPoleTools],
+    ["reporting", registerReportingTools],
+    ["planning-absences", registerPlanningAbsenceTools],
+    ["workflows", registerWorkflowTools],
+  ];
+
+/**
+ * Register the full (policy-filtered) tool/prompt/resource surface onto a
+ * server. Extracted from createMcpServer so tests can exercise the exact same
+ * wiring against a stub server with an arbitrary policy.
+ *
+ * - `target` is either the server itself (no operation filter) or a Proxy that
+ *   drops disallowed-operation tools at registration time.
+ * - Tool domains are skipped wholesale when the domain is disallowed.
+ * - Prompts are domain-filtered (a prompt is cut if any domain it orchestrates
+ *   is disallowed, so the runbook never points at missing tools).
+ * - Resources (reference dictionaries) are left intact (the lookup substrate).
+ */
+export function registerAll(server: McpServer, policy: AccessPolicy): void {
+  const target = withPolicy(server, policy);
+
+  for (const [domain, register] of TOOL_REGISTRARS) {
+    // `workflows` is the tool-form mirror of the MCP prompts (1:1). It is
+    // therefore gated like the prompts themselves: each workflow tool is kept
+    // only when its source prompt's domains are all allowed (that per-prompt
+    // filter lives inside registerWorkflowTools), and is NOT subject to
+    // allow-list membership, so a prompt and its mirror tool always appear or
+    // disappear together. An explicit deny (`BOOND_MCP_EXCLUDE_DOMAINS=workflows`)
+    // still suppresses the whole tool-form mirror (e.g. "prompts only").
+    const allowed = domain === "workflows" ? !policy.excludedDomains.has("workflows") : isDomainAllowed(policy, domain);
+    if (allowed) register(target, policy);
+  }
+
+  registerAllPrompts(target, policy);
+  registerAllResources(target);
+}
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -116,46 +165,8 @@ export function createMcpServer(): McpServer {
     version: SERVER_VERSION,
   });
 
-  registerCandidateTools(server);
-  registerResourceTools(server);
-  registerContactTools(server);
-  registerCompanyTools(server);
-  registerOpportunityTools(server);
-  registerActionTools(server);
-  registerTimesheetTools(server);
-  registerProjectTools(server);
-  registerInvoiceTools(server);
-  registerOrderTools(server);
-  registerDeliveryTools(server);
-  registerAbsenceTools(server);
-  registerExpenseTools(server);
-  registerProductTools(server);
-  registerPositioningTools(server);
-  registerPaymentTools(server);
-  registerAdvantageTools(server);
-  registerApplicationTools(server);
-  registerContractTools(server);
-  registerPurchaseTools(server);
-  registerProviderInvoiceTools(server);
-  registerAccountTools(server);
-  registerAgencyTools(server);
-  registerBusinessUnitTools(server);
-  registerRoleTools(server);
-  registerLogTools(server);
-  registerNotificationTools(server);
-  registerThreadTools(server);
-  registerTodolistTools(server);
-  registerFlagTools(server);
-  registerCalendarTools(server);
-  registerWebhookTools(server);
-  registerValidationTools(server);
-  registerPoleTools(server);
-  registerReportingTools(server);
-  registerPlanningAbsenceTools(server);
-  registerWorkflowTools(server);
-
-  registerAllPrompts(server);
-  registerAllResources(server);
+  // Operator-configured restrictions (env-driven). Absent config = full surface.
+  registerAll(server, resolveAccessPolicy());
 
   return server;
 }

--- a/src/tools/workflows.test.ts
+++ b/src/tools/workflows.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerWorkflowTools } from "./workflows.js";
 import { PROMPTS } from "../prompts/index.js";
+import { resolveAccessPolicy } from "../config/access-policy.js";
 
 function createMockServer() {
   return { registerTool: vi.fn() } as unknown as McpServer;
@@ -93,5 +94,20 @@ describe("registerWorkflowTools", () => {
       expect(config.description).toContain(p.description);
       expect(config.description).toContain(p.name);
     }
+  });
+
+  describe("access-policy domain filtering", () => {
+    it("no policy → one tool per prompt (back-compat)", () => {
+      registerWorkflowTools(server);
+      expect(server.registerTool).toHaveBeenCalledTimes(PROMPTS.length);
+    });
+
+    it("keeps only workflow tools whose source prompt's domains are fully allowed", () => {
+      const policy = resolveAccessPolicy({ BOOND_MCP_DOMAINS: "invoices,application" } as NodeJS.ProcessEnv);
+      registerWorkflowTools(server, policy);
+      const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
+      expect(names).toContain("boond_workflow_factures_a_relancer");
+      expect(names).not.toContain("boond_workflow_synthese_equipe");
+    });
   });
 });

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PROMPTS } from "../prompts/index.js";
+import { isDomainAllowed, type AccessPolicy } from "../config/access-policy.js";
 
 /**
  * Workflow tools — same runbooks as the MCP prompts in `src/prompts/index.ts`,
@@ -19,8 +20,12 @@ import { PROMPTS } from "../prompts/index.js";
  * Same args, same output. The runbook returned in the tool result is
  * exactly the text the prompt would have produced.
  */
-export function registerWorkflowTools(server: McpServer): void {
+export function registerWorkflowTools(server: McpServer, policy?: AccessPolicy): void {
   for (const p of PROMPTS) {
+    // Mirror the prompt-level domain filter: cut a workflow tool when any
+    // domain its source prompt orchestrates is filtered out (keeps the
+    // workflow tools and the MCP prompts perfectly in sync).
+    if (policy && !p.domains.every((d) => isDomainAllowed(policy, d))) continue;
     server.registerTool(
       `boond_workflow_${p.name}`,
       {


### PR DESCRIPTION
## Description

Ajoute une **restriction d'accès configurable par variables d'environnement**, sans modification de code, pour limiter ce que l'IA voit et peut faire :

- `BOOND_MCP_DOMAINS` : liste blanche de domaines (CSV). Absente = tous.
- `BOOND_MCP_EXCLUDE_DOMAINS` : liste noire (CSV), appliquée après la liste blanche.
- `BOOND_MCP_OPERATIONS` : opérations autorisées (CSV) parmi `read,create,update,delete`.
- `BOOND_MCP_READ_ONLY` : raccourci booléen équivalent à `BOOND_MCP_OPERATIONS=read`.

### Conception

- **Filtrage par domaine sans regex** : couplage domaine ↔ fonction d'enregistrement via `TOOL_REGISTRARS` (exporté depuis `server.ts`, réutilisé par le générateur de `TOOLS.md`). Plus de faux positif entre `invoices` et `provider-invoices`.
- **Filtrage par opération** : `Proxy` autour du `McpServer` (`withPolicy`) qui retire à l'enregistrement tout outil dont l'opération n'est pas autorisée. L'opération est déduite des annotations MCP (`readOnlyHint`/`destructiveHint`/`idempotentHint`), pas du nom.
- **Cohérence prompts ↔ workflow-tools** : chaque prompt déclare ses `domains` ; un prompt et son outil miroir `boond_workflow_*` sont coupés ensemble dès qu'un domaine orchestré est filtré, pour qu'aucun runbook ne pointe vers un outil absent.
- **Resources non filtrées** (dictionnaires : substrat de résolution).
- Signatures de policy **optionnelles** ⇒ `TOOLS.md` n'est jamais impacté et le drift-check CI reste vert.

> ⚠️ Ce n'est **pas une frontière de sécurité dure** : le filtre masque des outils à l'IA mais n'altère pas les droits du compte BoondManager (la vraie barrière). Les deux sont complémentaires. Détails : `docs/access-control.md`.

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalité (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [x] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lancé `npm run lint` et `npm run typecheck`
- [x] J'ai ajouté des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`) — **537 tests** (+40)
- [x] J'ai mis à jour la documentation si nécessaire

Vérifs additionnelles vertes : `npm run docs:tools:check` (TOOLS.md non impacté), `npx @anthropic-ai/mcpb validate .`, cohérence des versions (bump **2.2.0** sur package.json / manifest.json / server.json + lock + entrée CHANGELOG).

## Tests manuels (smoke)

Pré-requis : `npm run build`, puis (PowerShell) définir les variables et compter la surface exposée :

```powershell
$env:BOOND_MCP_DOMAINS=""; $env:BOOND_MCP_EXCLUDE_DOMAINS=""; $env:BOOND_MCP_OPERATIONS=""; $env:BOOND_MCP_READ_ONLY=""
node --input-type=module -e "import {registerAll} from './dist/server.js'; import {resolveAccessPolicy} from './dist/config/access-policy.js'; const c={t:[],p:[]}; const s={registerTool:(n)=>c.t.push(n),registerPrompt:(n)=>c.p.push(n),registerResource:()=>{}}; registerAll(s, resolveAccessPolicy(process.env)); console.log('outils=',c.t.length,'prompts=',c.p.length);"
```

| Configuration | Attendu |
|---------------|---------|
| (aucune variable) | `outils=171 prompts=11` (surface complète, comportement historique) |
| `BOOND_MCP_READ_ONLY=true` | aucun outil d'écriture/suppression ; prompts conservés |
| `BOOND_MCP_OPERATIONS=read,create,update` | aucun `*_delete` ; `*_create`/`*_update` présents |
| `BOOND_MCP_DOMAINS=invoices,application` | uniquement `boond_invoices_*` / `boond_application_*` (+ `boond_workflow_factures_a_relancer`) ; prompts = `factures_a_relancer` |
| `BOOND_MCP_DOMAINS=invoices` | aucun `boond_provider_invoices_*` (pas de faux positif multi-mot) |
| `BOOND_MCP_EXCLUDE_DOMAINS=workflows` | aucun `boond_workflow_*`, `prompts=11` |
| `BOOND_MCP_DOMAINS=invoicez` (faute) | warning `unknown domain`, pas de crash |
