### PR TITLE
fix: envoyer la relation dependsOn requise par l'API lors de la création d'action

### DIFF
--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -260,14 +260,32 @@ describe("ActionSearchSchema", () => {
 describe("ActionCreateSchema", () => {
   it("should accept valid action", () => {
     const result = ActionCreateSchema.safeParse({
-      typeOf: "call",
-      subject: "Appel de suivi",
+      typeOf: 1,
+      title: "Appel de suivi",
+      text: "Notes de meeting",
+      contactId: "6695",
     });
     expect(result.success).toBe(true);
   });
 
+  it("should coerce a numeric string typeOf to a number", () => {
+    const result = ActionCreateSchema.safeParse({ typeOf: "1", contactId: "6695" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.typeOf).toBe(1);
+    }
+  });
+
+  it("should reject a non-numeric typeOf", () => {
+    expect(ActionCreateSchema.safeParse({ typeOf: "call" }).success).toBe(false);
+  });
+
   it("should require typeOf", () => {
     expect(ActionCreateSchema.safeParse({}).success).toBe(false);
+  });
+
+  it("should reject legacy subject/content attributes", () => {
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, subject: "x", content: "y" }).success).toBe(false);
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -756,17 +756,32 @@ export const ActionSearchSchema = z
   })
   .strict();
 
+// POST /actions requires a polymorphic `dependsOn` relationship (the entity the
+// action is attached to) and a numeric `typeOf` (dictionary id, see
+// `setting.action.*` in /application/dictionary). Valid attributes are `title`
+// and `text` (not subject/content) — anything else triggers a 422.
 export const ActionCreateSchema = z
   .object({
-    typeOf: z.string().min(1).describe("Type d'action (ex: call, email, meeting, note)"),
-    subject: z.string().optional().describe("Sujet de l'action"),
-    content: z.string().optional().describe("Contenu / description"),
-    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD ou ISO)"),
-    endDate: z.string().optional().describe("Date de fin"),
-    candidateId: z.string().optional().describe("ID du candidat associé"),
-    resourceId: z.string().optional().describe("ID de la ressource associée"),
-    contactId: z.string().optional().describe("ID du contact associé"),
-    companyId: z.string().optional().describe("ID de la société associée"),
+    typeOf: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .describe(
+        "Type d'action : ID numérique du dictionnaire BoondManager (setting.action.*, via boond_application_dictionary)"
+      ),
+    title: z.string().optional().describe("Titre de l'action"),
+    text: z.string().optional().describe("Contenu / notes de l'action"),
+    startDate: z
+      .string()
+      .optional()
+      .describe("Date de début au format ISO avec timezone (ex: 2026-06-05T10:00:00+0200)"),
+    endDate: z.string().optional().describe("Date de fin (même format que startDate)"),
+    candidateId: z.string().optional().describe("ID du candidat auquel rattacher l'action (dependsOn)"),
+    resourceId: z.string().optional().describe("ID de la ressource à laquelle rattacher l'action (dependsOn)"),
+    contactId: z.string().optional().describe("ID du contact auquel rattacher l'action (dependsOn)"),
+    opportunityId: z.string().optional().describe("ID de l'opportunité à laquelle rattacher l'action (dependsOn)"),
+    projectId: z.string().optional().describe("ID du projet auquel rattacher l'action (dependsOn)"),
+    companyId: z.string().optional().describe("ID de la société associée (uniquement en complément d'un contactId)"),
   })
   .strict();
 

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerActionTools } from "./actions.js";
+import { apiRequest } from "../services/boond-client.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "123", type: "action" } }),
+  buildSearchQuery: vi.fn().mockReturnValue({}),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -31,9 +39,11 @@ describe("registerActionTools", () => {
 
   it("should register search and get as readOnly", () => {
     registerActionTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_actions_search", "boond_actions_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) => typeof c[0] === "string" && ["boond_actions_search", "boond_actions_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -41,9 +51,75 @@ describe("registerActionTools", () => {
 
   it("should register delete as destructive", () => {
     registerActionTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_actions_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_actions_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  describe("boond_actions_create handler", () => {
+    function getCreateHandler() {
+      registerActionTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_actions_create");
+      return call?.[2] as (params: Record<string, unknown>) => Promise<{
+        isError?: boolean;
+        content: Array<{ type: string; text: string }>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiRequest).mockClear();
+    });
+
+    it("should send a dependsOn relationship when contactId is provided", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 1, title: "Call", contactId: "6695" });
+      expect(apiRequest).toHaveBeenCalledWith("/actions", "POST", {
+        data: {
+          type: "action",
+          attributes: { typeOf: 1, title: "Call" },
+          relationships: {
+            dependsOn: { data: { id: "6695", type: "contact" } },
+          },
+        },
+      });
+    });
+
+    it("should add the company relationship alongside a contact dependsOn", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 1, contactId: "6695", companyId: "42" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { relationships: Record<string, unknown> };
+      };
+      expect(body.data.relationships.dependsOn).toEqual({
+        data: { id: "6695", type: "contact" },
+      });
+      expect(body.data.relationships.company).toEqual({
+        data: { id: "42", type: "company" },
+      });
+    });
+
+    it("should map candidateId to a candidate dependsOn", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 2, candidateId: "99" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { relationships: Record<string, unknown> };
+      };
+      expect(body.data.relationships.dependsOn).toEqual({
+        data: { id: "99", type: "candidate" },
+      });
+    });
+
+    it("should return an error without calling the API when no entity id is provided", async () => {
+      const handler = getCreateHandler();
+      const result = await handler({ typeOf: 1, title: "Orphan" });
+      expect(result.isError).toBe(true);
+      expect(apiRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return an error when only companyId is provided", async () => {
+      const handler = getCreateHandler();
+      const result = await handler({ typeOf: 1, companyId: "42" });
+      expect(result.isError).toBe(true);
+      expect(apiRequest).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -61,7 +61,16 @@ Returns: Liste des actions correspondantes.`,
     "boond_actions_create",
     {
       title: "Créer une action",
-      description: `Crée une nouvelle action (appel, email, RDV, note) dans BoondManager, optionnellement liée à un candidat, ressource, contact ou société.`,
+      description: `Crée une nouvelle action (appel, email, RDV, note) dans BoondManager, rattachée à un contact, candidat, ressource, opportunité ou projet (relation dependsOn, obligatoire).
+
+Args:
+  - typeOf (number, requis): ID numérique du type d'action (dictionnaire setting.action.*, via boond_application_dictionary)
+  - title, text (string, optional): Titre et contenu de l'action
+  - startDate, endDate (string, optional): Dates ISO avec timezone (ex: 2026-06-05T10:00:00+0200)
+  - contactId | candidateId | resourceId | opportunityId | projectId (string, un requis): Entité de rattachement
+  - companyId (string, optional): Société, uniquement en complément d'un contactId
+
+Returns: L'action créée avec son ID.`,
       inputSchema: ActionCreateSchema,
       annotations: {
         readOnlyHint: false,
@@ -71,23 +80,46 @@ Returns: Liste des actions correspondantes.`,
       },
     },
     async (params) => {
-      const { candidateId, resourceId, contactId, companyId, ...attrs } = params;
-      const body = buildJsonApiBody("action", attrs);
-      const relationships: Record<string, unknown> = {};
-      if (candidateId) relationships.candidate = { data: { id: candidateId, type: "candidate" } };
-      if (resourceId) relationships.resource = { data: { id: resourceId, type: "resource" } };
-      if (contactId) relationships.contact = { data: { id: contactId, type: "contact" } };
-      if (companyId) relationships.company = { data: { id: companyId, type: "company" } };
-      if (Object.keys(relationships).length > 0) {
-        (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
+      const { candidateId, resourceId, contactId, opportunityId, projectId, companyId, ...attrs } = params;
+      // The API requires a polymorphic `dependsOn` relationship pointing to the
+      // entity the action is attached to (422 "Missing required relationship"
+      // otherwise). `company` is only accepted alongside a contact `dependsOn`.
+      const dependsOnCandidates: Array<{ id: string | undefined; type: string }> = [
+        { id: contactId, type: "contact" },
+        { id: candidateId, type: "candidate" },
+        { id: resourceId, type: "resource" },
+        { id: opportunityId, type: "opportunity" },
+        { id: projectId, type: "project" },
+      ];
+      const dependsOn = dependsOnCandidates.find((c) => c.id);
+      if (!dependsOn) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "❌ L'API BoondManager exige de rattacher l'action à une entité (dependsOn). Fournissez l'un des paramètres : contactId, candidateId, resourceId, opportunityId ou projectId. (companyId seul ne suffit pas : une action ne peut pas être rattachée directement à une société, passez par un contact.)",
+            },
+          ],
+        };
       }
+      const body = buildJsonApiBody("action", attrs);
+      const relationships: Record<string, unknown> = {
+        dependsOn: { data: { id: dependsOn.id, type: dependsOn.type } },
+      };
+      if (companyId && dependsOn.type === "contact") {
+        relationships.company = { data: { id: companyId, type: "company" } };
+      }
+      (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
       const response = await apiRequest("/actions", "POST", body);
       const entity = Array.isArray(response.data) ? response.data[0] : response.data;
       return {
-        content: [{
-          type: "text" as const,
-          text: `✅ Action créée avec succès.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
-        }],
+        content: [
+          {
+            type: "text" as const,
+            text: `✅ Action créée avec succès.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+          },
+        ],
       };
     }
   );


### PR DESCRIPTION
## Description

Corrige #95 — `boond_actions_create` échouait systématiquement avec une erreur 422.

L'API BoondManager (`POST /actions`, cf. schéma `actions/bodyPost.json` de la doc officielle) exige une relation polymorphe **`dependsOn`** (contact, candidat, ressource, opportunité, projet...) ; l'outil envoyait à la place des relations `candidate`/`resource`/`contact`/`company`, toutes rejetées. Le schéma impose aussi `typeOf` en **entier** (dictionnaire `setting.action.*`) et les attributs `title`/`text` (`additionalProperties: false`), pas `subject`/`content`.

Changements :

- `src/tools/actions.ts` : le handler construit `relationships.dependsOn` à partir de `contactId`/`candidateId`/`resourceId`/`opportunityId`/`projectId` (premier fourni). `companyId` est ajouté en relation `company` uniquement avec un `contactId`. Si aucune entité n'est fournie, erreur explicite sans appel API.
- `src/schemas/index.ts` : `ActionCreateSchema` — `typeOf` en `z.coerce.number().int()`, `subject`/`content` remplacés par `title`/`text`, ajout de `opportunityId`/`projectId`, descriptions mises à jour.
- Tests : 5 tests du handler (payload `dependsOn`, relation `company`, erreur sans entité) + 3 tests de schéma.

Note : `typeOf` attend désormais un ID numérique — l'ancien format chaîne n'a jamais fonctionné (l'appel échouait toujours en 422), donc pas de régression en pratique.

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalite (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lance `npm run lint` et `npm run typecheck`
- [x] J'ai ajoute des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`) — 505 tests, ainsi que `npm run build` et `npm run docs:tools:check`
