### PR TITLE
feat: libellés de dictionnaire personnalisés via BOOND_DICTIONARY_OVERRIDES

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,25 @@ comptabilité), et/ou bloquer les écritures et suppressions.
 
 Guide complet, règles de résolution et exemples : [docs/access-control.md](docs/access-control.md).
 
+### Libellés personnalisés du dictionnaire
+
+Si votre instance BoondManager utilise des libellés de dictionnaire
+personnalisés (ex. types d'action ou états en anglais), vous pouvez déclarer
+le mapping libellé→ID via `BOOND_DICTIONARY_OVERRIDES` (JSON inline ou chemin
+vers un fichier JSON) :
+
+```bash
+export BOOND_DICTIONARY_OVERRIDES='{"action":{"contact":{"Call":61,"Email":63}},"state":{"candidate":{"Interviewed":2}}}'
+```
+
+Le serveur accepte alors ces libellés pour le `typeOf` de
+`boond_actions_create` et les champs `state` des créations/modifications, les
+résout automatiquement en IDs numériques, et enrichit les descriptions des
+outils avec les libellés disponibles. Sans cette variable, le comportement est
+strictement inchangé.
+
+Format complet, entités supportées et limites : [docs/dictionary-overrides.md](docs/dictionary-overrides.md).
+
 ## Transports
 
 Le serveur supporte deux transports MCP, selectionnables via la variable d'environnement `MCP_TRANSPORT`.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**174 tools** across **38 domains** · **11 prompts** · **21 resources**.
+**174 tools** across **38 domains** · **11 prompts** · **22 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -391,7 +391,7 @@ Pre-orchestrated workflows surfaced via the MCP prompts API.
 | `staffing_disponible` | Consultants disponibles pour un staffing | `start_date` `end_date` `competences?` `manager_id?` |
 | `synthese_equipe` | Synthèse d'une équipe | `manager_id?` `periode?` |
 
-## Resources (21)
+## Resources (22)
 
 Reference data exposed as MCP resources.
 
@@ -405,6 +405,7 @@ Reference data exposed as MCP resources.
 | `boond://dictionary/expertiseAreas` | Domaines d'expertise |
 | `boond://dictionary/languages` | Langues |
 | `boond://dictionary/mobilityAreas` | Mobilités |
+| `boond://dictionary/overrides` | Libellés personnalisés (overrides) |
 | `boond://dictionary/states/candidates` | États candidats |
 | `boond://dictionary/states/companies` | États sociétés |
 | `boond://dictionary/states/contacts` | États contacts |

--- a/docs/dictionary-overrides.md
+++ b/docs/dictionary-overrides.md
@@ -1,0 +1,106 @@
+# Libellés personnalisés du dictionnaire (dictionary overrides)
+
+L'API BoondManager exige des **IDs numériques** pour les champs pilotés par le
+dictionnaire de l'instance : le type d'une action (`typeOf`, cf.
+`setting.action.*`) et l'état d'une entité (`state`, cf. `setting.state.*`).
+Ces IDs varient d'une instance à l'autre dès que le dictionnaire a été
+personnalisé (libellés anglais, types d'action métier ajoutés, états
+réordonnés…). Le modèle doit alors d'abord interroger
+`boond_application_dictionary` pour retrouver le bon ID, ou risque d'envoyer
+un ID erroné.
+
+Les *dictionary overrides* permettent de déclarer une fois pour toutes le
+mapping **libellé → ID** propre à votre instance. Le serveur :
+
+- accepte alors ces libellés en entrée (`typeOf` de `boond_actions_create`,
+  champs `state` des créations/modifications) et les **résout automatiquement**
+  en ID numérique avant l'appel API ;
+- **enrichit les descriptions** des outils/champs concernés avec la liste des
+  libellés acceptés, pour que le modèle les utilise spontanément ;
+- expose le mapping chargé via la ressource MCP `boond://dictionary/overrides`.
+
+## Configuration
+
+Variable d'environnement `BOOND_DICTIONARY_OVERRIDES`, avec **deux modes** :
+
+1. **JSON inline** — la valeur commence par `{` :
+
+   ```bash
+   export BOOND_DICTIONARY_OVERRIDES='{"action":{"contact":{"Call":61,"Email":63}}}'
+   ```
+
+2. **Chemin de fichier** — toute autre valeur est interprétée comme le chemin
+   d'un fichier JSON UTF-8 :
+
+   ```bash
+   export BOOND_DICTIONARY_OVERRIDES="/etc/boond/dictionary-overrides.json"
+   ```
+
+Dans l'extension Claude Desktop (`.mcpb`), le champ « Libellés personnalisés
+du dictionnaire » de la configuration accepte les deux mêmes formes.
+
+## Format
+
+```json
+{
+  "action": {
+    "contact": { "Call": 61, "Email": 63, "Meeting": 62 },
+    "candidate": { "Call": 40, "Interview": 42 },
+    "resource": { "Call": 20 },
+    "opportunity": {},
+    "project": {}
+  },
+  "state": {
+    "candidate": { "Interviewed": 2, "Hired": 5 },
+    "opportunity": { "Won": 6, "Lost": 7 },
+    "project": { "In progress": 1 }
+  }
+}
+```
+
+- Les deux sections `action` et `state` sont **optionnelles** (déclarez
+  seulement ce dont vous avez besoin ; les sous-objets vides sont ignorés).
+- Entités valides pour `action` : `contact`, `candidate`, `resource`,
+  `opportunity`, `project` (les clés de `setting.action.*`).
+- Entités valides pour `state` : `candidate`, `resource`, `contact`,
+  `company`, `opportunity`, `project`, `positioning`, `quotation`, `product`,
+  `invoice`, `order`, `absence` (les clés de `setting.state.*`).
+- Les valeurs sont les **IDs numériques** (entiers ≥ 0) tels qu'ils
+  apparaissent dans `boond_application_dictionary` pour votre instance.
+- Une clé d'entité inconnue est **ignorée avec un avertissement** dans les
+  logs (les entrées valides restent actives).
+
+## Comportement
+
+- **`typeOf` de `boond_actions_create`** : accepte un ID numérique (inchangé)
+  ou un libellé déclaré. Le libellé est résolu selon l'entité de rattachement
+  (`contactId` → `action.contact`, `candidateId` → `action.candidate`, …),
+  sans sensibilité à la casse ni aux espaces de tête/queue. Libellé inconnu →
+  erreur explicite listant les libellés disponibles pour cette entité.
+- **Champs `state`** des créations/modifications de candidats, ressources,
+  sociétés, opportunités et projets : même résolution, au moment du parse.
+  Un libellé inconnu fait échouer la validation (l'ID numérique reste
+  toujours accepté).
+- **Descriptions enrichies** : quand des overrides sont configurés, les
+  descriptions des outils/champs concernés mentionnent les libellés acceptés
+  (ex. « Libellés personnalisés acceptés (résolus automatiquement) :
+  Call=61, Email=63 »). Sans overrides, les descriptions sont strictement
+  inchangées.
+- **Ressource MCP** : `boond://dictionary/overrides` renvoie le mapping chargé
+  (ou `{ "configured": false }` si rien n'est configuré) — pratique pour
+  vérifier ce que le serveur a réellement pris en compte.
+- **Fail-open** : toute erreur (fichier introuvable, JSON invalide, structure
+  invalide) est loguée en `warn` et désactive simplement les overrides. Le
+  serveur **démarre toujours** et se comporte alors exactement comme sans la
+  variable.
+
+## Limites
+
+- C'est une commodité **côté entrée** uniquement : les réponses de l'API ne
+  sont **pas** traduites (un `state: 2` dans une réponse reste `2` ; utilisez
+  les ressources `boond://dictionary/states/*` pour la correspondance).
+- Le mapping n'est **pas validé contre votre instance** : si vous déclarez
+  `"Call": 61` alors que l'ID réel est 16, l'API recevra 61. Vérifiez les IDs
+  via `boond_application_dictionary`.
+- Les filtres de recherche (`states`, `opportunityStates`…) continuent
+  d'attendre des IDs numériques.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
   "version": "2.4.0",
-  "description": "MCP Server for BoondManager API - 174 tools, 11 prompts, 21 resources (ERP/CRM)",
+  "description": "MCP Server for BoondManager API - 174 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",
     "url": "https://github.com/fauguste/boondmanager-mcp-server"
@@ -34,7 +34,8 @@
         "BOOND_MCP_EXCLUDE_DOMAINS": "${user_config.mcp_exclude_domains}",
         "BOOND_MCP_OPERATIONS": "${user_config.mcp_operations}",
         "BOOND_MCP_READ_ONLY": "${user_config.mcp_read_only}",
-        "BOOND_MCP_CONFIRM_DELETE": "${user_config.confirm_delete}"
+        "BOOND_MCP_CONFIRM_DELETE": "${user_config.confirm_delete}",
+        "BOOND_DICTIONARY_OVERRIDES": "${user_config.dictionary_overrides}"
       }
     }
   },
@@ -117,6 +118,12 @@
       "title": "Confirmer les suppressions",
       "description": "Si activé (défaut), une confirmation est demandée avant chaque suppression lorsque le client MCP supporte l'élicitation. Désactiver pour retrouver le comportement historique (suppression directe).",
       "default": true,
+      "required": false
+    },
+    "dictionary_overrides": {
+      "type": "string",
+      "title": "Libellés personnalisés du dictionnaire",
+      "description": "Mapping libellé→ID pour les instances BoondManager aux dictionnaires personnalisés : JSON inline (commence par {) ou chemin vers un fichier JSON UTF-8. Ex: {\"action\":{\"contact\":{\"Call\":61}},\"state\":{\"candidate\":{\"Interviewed\":2}}}. Voir docs/dictionary-overrides.md.",
       "required": false
     }
   },

--- a/src/config/dictionary-overrides.test.ts
+++ b/src/config/dictionary-overrides.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadDictionaryOverrides,
+  getDictionaryOverrides,
+  resetDictionaryOverridesForTests,
+  resolveLabel,
+  availableLabels,
+  formatOverridesSummary,
+  appendOverridesToDescription,
+} from "./dictionary-overrides.js";
+import { logger } from "../services/logger.js";
+
+vi.mock("../services/logger.js", () => {
+  const mock: Record<string, unknown> = {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+  mock.child = vi.fn(() => mock);
+  return { logger: mock };
+});
+
+/** Helper: build an env object (only the keys we set; rest undefined). */
+function env(value?: string): NodeJS.ProcessEnv {
+  return (value === undefined ? {} : { BOOND_DICTIONARY_OVERRIDES: value }) as NodeJS.ProcessEnv;
+}
+
+const VALID = JSON.stringify({
+  action: { contact: { Call: 61, Email: 63 }, candidate: { Interview: 40 } },
+  state: { candidate: { Interviewed: 2 } },
+});
+
+beforeEach(() => {
+  vi.mocked(logger.warn).mockClear();
+  delete process.env.BOOND_DICTIONARY_OVERRIDES;
+  resetDictionaryOverridesForTests();
+});
+
+afterEach(() => {
+  delete process.env.BOOND_DICTIONARY_OVERRIDES;
+  resetDictionaryOverridesForTests();
+});
+
+describe("loadDictionaryOverrides", () => {
+  it("returns null when the env var is absent", () => {
+    expect(loadDictionaryOverrides(env())).toBeNull();
+  });
+
+  it("ignores unresolved placeholder values like ${VAR}", () => {
+    expect(loadDictionaryOverrides(env("${user_config.dictionary_overrides}"))).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("parses valid inline JSON", () => {
+    const overrides = loadDictionaryOverrides(env(VALID));
+    expect(overrides).not.toBeNull();
+    expect(overrides!.action["contact"]).toEqual({ Call: 61, Email: 63 });
+    expect(overrides!.state["candidate"]).toEqual({ Interviewed: 2 });
+  });
+
+  it("parses a JSON file when the value is a path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "boond-overrides-"));
+    const file = join(dir, "overrides.json");
+    try {
+      writeFileSync(file, VALID, "utf-8");
+      const overrides = loadDictionaryOverrides(env(file));
+      expect(overrides).not.toBeNull();
+      expect(overrides!.action["candidate"]).toEqual({ Interview: 40 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null (and warns) when the file does not exist", () => {
+    expect(loadDictionaryOverrides(env("/nonexistent/overrides.json"))).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("returns null (and warns, no throw) on invalid JSON", () => {
+    expect(() => loadDictionaryOverrides(env("{not json"))).not.toThrow();
+    expect(loadDictionaryOverrides(env("{not json"))).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("returns null (and warns) on an invalid structure (non-integer id)", () => {
+    const bad = JSON.stringify({ action: { contact: { Call: "sixty-one" } } });
+    expect(loadDictionaryOverrides(env(bad))).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("returns null (and warns) on an unknown top-level section", () => {
+    const bad = JSON.stringify({ actions: { contact: { Call: 61 } } });
+    expect(loadDictionaryOverrides(env(bad))).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("warns and ignores an unknown entity, keeping the valid ones", () => {
+    const mixed = JSON.stringify({ action: { contact: { Call: 61 }, spaceship: { Launch: 1 } } });
+    const overrides = loadDictionaryOverrides(env(mixed));
+    expect(overrides).not.toBeNull();
+    expect(overrides!.action["contact"]).toEqual({ Call: 61 });
+    expect(overrides!.action["spaceship"]).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ section: "action", entity: "spaceship" }),
+      expect.stringContaining("spaceship")
+    );
+  });
+
+  it("returns null when nothing usable remains after validation", () => {
+    expect(loadDictionaryOverrides(env("{}"))).toBeNull();
+    expect(loadDictionaryOverrides(env(JSON.stringify({ action: { spaceship: { Launch: 1 } } })))).toBeNull();
+  });
+});
+
+describe("getDictionaryOverrides (singleton)", () => {
+  it("lazily loads from process.env and caches the result", () => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = VALID;
+    resetDictionaryOverridesForTests();
+    const first = getDictionaryOverrides();
+    expect(first).not.toBeNull();
+    // Mutating the env without resetting must NOT change the cached value.
+    delete process.env.BOOND_DICTIONARY_OVERRIDES;
+    expect(getDictionaryOverrides()).toBe(first);
+    resetDictionaryOverridesForTests();
+    expect(getDictionaryOverrides()).toBeNull();
+  });
+});
+
+describe("resolveLabel", () => {
+  beforeEach(() => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = VALID;
+    resetDictionaryOverridesForTests();
+  });
+
+  it("resolves an exact label", () => {
+    expect(resolveLabel("action", "contact", "Call")).toBe(61);
+    expect(resolveLabel("state", "candidate", "Interviewed")).toBe(2);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(resolveLabel("action", "contact", "  cAlL ")).toBe(61);
+    expect(resolveLabel("state", "candidate", "INTERVIEWED")).toBe(2);
+  });
+
+  it("returns undefined for an unknown label or entity", () => {
+    expect(resolveLabel("action", "contact", "Visio")).toBeUndefined();
+    expect(resolveLabel("action", "project", "Call")).toBeUndefined();
+  });
+
+  it("returns undefined when no overrides are configured", () => {
+    delete process.env.BOOND_DICTIONARY_OVERRIDES;
+    resetDictionaryOverridesForTests();
+    expect(resolveLabel("action", "contact", "Call")).toBeUndefined();
+  });
+});
+
+describe("availableLabels", () => {
+  it("lists the labels with their original casing", () => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = VALID;
+    resetDictionaryOverridesForTests();
+    expect(availableLabels("action", "contact")).toEqual(["Call", "Email"]);
+    expect(availableLabels("action", "project")).toEqual([]);
+  });
+
+  it("returns [] when no overrides are configured", () => {
+    expect(availableLabels("action", "contact")).toEqual([]);
+  });
+});
+
+describe("formatOverridesSummary / appendOverridesToDescription", () => {
+  it("appends the accepted labels when overrides exist", () => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = VALID;
+    resetDictionaryOverridesForTests();
+    expect(formatOverridesSummary("action", "contact")).toBe("Call=61, Email=63");
+    const out = appendOverridesToDescription("Base.", "action", "contact");
+    expect(out).toBe("Base.\nLibellés personnalisés acceptés (résolus automatiquement) : Call=61, Email=63");
+  });
+
+  it("returns the base string unchanged without overrides", () => {
+    expect(formatOverridesSummary("action", "contact")).toBeNull();
+    expect(appendOverridesToDescription("Base.", "action", "contact")).toBe("Base.");
+  });
+
+  it("returns the base string unchanged for an entity without overrides", () => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = VALID;
+    resetDictionaryOverridesForTests();
+    expect(appendOverridesToDescription("Base.", "action", "opportunity")).toBe("Base.");
+  });
+});

--- a/src/config/dictionary-overrides.ts
+++ b/src/config/dictionary-overrides.ts
@@ -1,0 +1,232 @@
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { logger } from "../services/logger.js";
+
+/**
+ * Dictionary overrides: let operators whose BoondManager instance uses
+ * customised dictionary labels (e.g. English action types or states) declare
+ * a label→id mapping, so the model can pass human labels instead of opaque
+ * numeric dictionary ids.
+ *
+ * Env var (optional):
+ *  - `BOOND_DICTIONARY_OVERRIDES` Either inline JSON (the value starts with
+ *    `{`) or a path to a UTF-8 JSON file. Expected shape:
+ *
+ *    {
+ *      "action": { "contact": { "Call": 61, "Email": 63 }, "candidate": { ... } },
+ *      "state":  { "candidate": { "Interviewed": 2 }, "opportunity": { ... } }
+ *    }
+ *
+ * Both sections are optional. Unknown entity keys are warned-and-ignored.
+ * Any hard error (unreadable file, invalid JSON, invalid structure) is logged
+ * as a warning and the overrides are simply disabled: the server ALWAYS
+ * starts (fail-open, same philosophy as services/update-checker.ts).
+ *
+ * This is a pure input-side convenience: it never translates API responses.
+ */
+
+/** Entities that can carry an action `typeOf` (see `setting.action.*`). */
+export const ACTION_ENTITIES = ["contact", "candidate", "resource", "opportunity", "project"] as const;
+
+/** Entities that carry a `state` attribute (see `setting.state.*`). */
+export const STATE_ENTITIES = [
+  "candidate",
+  "resource",
+  "contact",
+  "company",
+  "opportunity",
+  "project",
+  "positioning",
+  "quotation",
+  "product",
+  "invoice",
+  "order",
+  "absence",
+] as const;
+
+export type OverrideSection = "action" | "state";
+
+/** Custom label → numeric dictionary id. */
+export type LabelMap = Record<string, number>;
+
+export interface DictionaryOverrides {
+  action: Partial<Record<string, LabelMap>>;
+  state: Partial<Record<string, LabelMap>>;
+}
+
+// Values must be numeric dictionary ids (>= 0).
+const LabelMapSchema = z.record(z.string().min(1), z.number().int().min(0));
+
+// Top-level shape. `.strict()` so a typo like "actions" fails loudly (warn +
+// disabled) instead of being silently dropped.
+const OverridesFileSchema = z
+  .object({
+    action: z.record(z.string(), LabelMapSchema).optional(),
+    state: z.record(z.string(), LabelMapSchema).optional(),
+  })
+  .strict();
+
+// --- Env parsing helper (mirroring config/access-policy.ts) ---
+
+function readEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const raw = env[key];
+  if (raw === undefined) return undefined;
+  // Ignore unresolved placeholders like "${SOMETHING}" (same guard as http.ts).
+  if (raw.startsWith("${")) return undefined;
+  if (raw.trim().length === 0) return undefined;
+  return raw;
+}
+
+/** Keep only known entity keys; warn-and-ignore the rest (never fatal). */
+function filterKnownEntities(
+  section: OverrideSection,
+  raw: Record<string, LabelMap>,
+  known: readonly string[],
+  log: typeof logger
+): Partial<Record<string, LabelMap>> {
+  const out: Partial<Record<string, LabelMap>> = {};
+  for (const [entity, labels] of Object.entries(raw)) {
+    if (known.includes(entity)) {
+      if (Object.keys(labels).length > 0) out[entity] = labels;
+    } else {
+      log.warn(
+        { section, entity, known: [...known] },
+        `BOOND_DICTIONARY_OVERRIDES: unknown ${section} entity "${entity}" ignored`
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Load and validate the overrides from the environment. Resilient: any error
+ * is logged as a warning and `null` is returned — the server always starts.
+ */
+export function loadDictionaryOverrides(env: NodeJS.ProcessEnv = process.env): DictionaryOverrides | null {
+  const log = logger.child({ component: "dictionary-overrides" });
+  const raw = readEnv(env, "BOOND_DICTIONARY_OVERRIDES");
+  if (raw === undefined) return null;
+
+  // Inline JSON if the value starts with "{", otherwise a file path.
+  let text = raw;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    try {
+      text = readFileSync(trimmed, "utf-8");
+    } catch (err) {
+      log.warn(
+        { path: trimmed, err: err instanceof Error ? err.message : String(err) },
+        "BOOND_DICTIONARY_OVERRIDES: cannot read overrides file; custom labels disabled"
+      );
+      return null;
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "BOOND_DICTIONARY_OVERRIDES: invalid JSON; custom labels disabled"
+    );
+    return null;
+  }
+
+  const result = OverridesFileSchema.safeParse(parsed);
+  if (!result.success) {
+    log.warn({ issues: result.error.issues }, "BOOND_DICTIONARY_OVERRIDES: invalid structure; custom labels disabled");
+    return null;
+  }
+
+  const overrides: DictionaryOverrides = {
+    action: filterKnownEntities("action", result.data.action ?? {}, ACTION_ENTITIES, log),
+    state: filterKnownEntities("state", result.data.state ?? {}, STATE_ENTITIES, log),
+  };
+
+  if (Object.keys(overrides.action).length === 0 && Object.keys(overrides.state).length === 0) {
+    log.warn("BOOND_DICTIONARY_OVERRIDES: no usable entry after validation; custom labels disabled");
+    return null;
+  }
+
+  log.info(
+    {
+      actionEntities: Object.keys(overrides.action),
+      stateEntities: Object.keys(overrides.state),
+    },
+    "Dictionary overrides active: custom labels will be resolved to numeric ids"
+  );
+  return overrides;
+}
+
+// --- Lazy singleton over process.env ---
+// Loaded on first use (NOT at import time) so tests can set the env var after
+// importing modules that depend on this one.
+
+let cached: DictionaryOverrides | null = null;
+let loaded = false;
+
+export function getDictionaryOverrides(): DictionaryOverrides | null {
+  if (!loaded) {
+    cached = loadDictionaryOverrides(process.env);
+    loaded = true;
+  }
+  return cached;
+}
+
+/** Reset the singleton (tests only). */
+export function resetDictionaryOverridesForTests(): void {
+  cached = null;
+  loaded = false;
+}
+
+// --- Resolution helpers ---
+
+function normalizeLabel(label: string): string {
+  return label.trim().toLowerCase();
+}
+
+function labelMapFor(section: OverrideSection, entity: string): LabelMap | undefined {
+  const overrides = getDictionaryOverrides();
+  return overrides?.[section][entity];
+}
+
+/**
+ * Resolve a custom label to its numeric dictionary id. Matching is
+ * case-insensitive and ignores leading/trailing whitespace.
+ */
+export function resolveLabel(section: OverrideSection, entity: string, label: string): number | undefined {
+  const map = labelMapFor(section, entity);
+  if (!map) return undefined;
+  const wanted = normalizeLabel(label);
+  for (const [key, id] of Object.entries(map)) {
+    if (normalizeLabel(key) === wanted) return id;
+  }
+  return undefined;
+}
+
+/** Labels declared for a section/entity (original casing), or [] if none. */
+export function availableLabels(section: OverrideSection, entity: string): string[] {
+  const map = labelMapFor(section, entity);
+  return map ? Object.keys(map) : [];
+}
+
+/** Compact "Label=id, Label=id" summary for a section/entity, or null if none. */
+export function formatOverridesSummary(section: OverrideSection, entity: string): string | null {
+  const map = labelMapFor(section, entity);
+  if (!map) return null;
+  const entries = Object.entries(map);
+  if (entries.length === 0) return null;
+  return entries.map(([label, id]) => `${label}=${id}`).join(", ");
+}
+
+/**
+ * Append the accepted custom labels to a schema/tool description. Returns the
+ * base string unchanged (byte-for-byte) when no override is configured for
+ * this section/entity.
+ */
+export function appendOverridesToDescription(base: string, section: OverrideSection, entity: string): string {
+  const summary = formatOverridesSummary(section, entity);
+  if (summary === null) return base;
+  return `${base}\nLibellés personnalisés acceptés (résolus automatiquement) : ${summary}`;
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apiRequest } from "../services/boond-client.js";
 import { getDictionary, resolveDictionaryPath } from "../services/dictionary.js";
+import { getDictionaryOverrides } from "../config/dictionary-overrides.js";
 
 /**
  * MCP resources for BoondManager reference data.
@@ -161,6 +162,8 @@ const DICTIONARIES: DictionaryEntry[] = [
 const DICTIONARY_URI_PREFIX = "boond://dictionary/";
 /** URI of the cached identity resource. */
 const CURRENT_USER_URI = "boond://application/current-user";
+/** URI of the static dictionary-overrides resource (no API call behind it). */
+const OVERRIDES_URI = "boond://dictionary/overrides";
 
 function buildResourceUri(slug: string): string {
   return `${DICTIONARY_URI_PREFIX}${slug}`;
@@ -173,6 +176,7 @@ export const REGISTERED_RESOURCES = [
     uri: buildResourceUri(d.slug),
     title: d.title,
   })),
+  { name: "dictionary/overrides", uri: OVERRIDES_URI, title: "Libellés personnalisés (overrides)" },
   { name: "application/current-user", uri: CURRENT_USER_URI, title: "Utilisateur courant" },
 ];
 
@@ -208,6 +212,34 @@ export function registerAllResources(server: McpServer): void {
       }
     );
   }
+
+  // Static resource: the label→id overrides configured by the operator via
+  // BOOND_DICTIONARY_OVERRIDES (see docs/dictionary-overrides.md). No API call:
+  // the body reflects exactly what the server resolved at startup, so the
+  // model (and the user) can check which custom labels are usable.
+  server.registerResource(
+    "dictionary/overrides",
+    OVERRIDES_URI,
+    {
+      title: "Libellés personnalisés (overrides)",
+      description:
+        "Mapping libellé→ID configuré via BOOND_DICTIONARY_OVERRIDES (types d'action et états). " +
+        'Renvoie { "configured": false } si aucun override n\'est configuré.',
+      mimeType: "application/json",
+    },
+    () => {
+      const overrides = getDictionaryOverrides();
+      return Promise.resolve({
+        contents: [
+          {
+            uri: OVERRIDES_URI,
+            mimeType: "application/json",
+            text: JSON.stringify(overrides ?? { configured: false }, null, 2),
+          },
+        ],
+      });
+    }
+  );
 
   // The current-user resource is a convenience for prompts/tools that need
   // the caller's userId without first issuing a tool call. The body is the

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resetDictionaryOverridesForTests } from "../config/dictionary-overrides.js";
 import {
   SearchSchema,
   IdSchema,
@@ -292,8 +293,15 @@ describe("ActionCreateSchema", () => {
     }
   });
 
-  it("should reject a non-numeric typeOf", () => {
-    expect(ActionCreateSchema.safeParse({ typeOf: "call" }).success).toBe(false);
+  it("should accept a non-numeric typeOf as a custom label (resolved in the handler)", () => {
+    // Custom labels (BOOND_DICTIONARY_OVERRIDES) are resolved — or rejected
+    // with an explicit message — by the boond_actions_create handler, which
+    // knows the dependsOn entity. The schema only validates the shape.
+    const result = ActionCreateSchema.safeParse({ typeOf: "Call", contactId: "6695" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.typeOf).toBe("Call");
+    }
   });
 
   it("should require typeOf", () => {
@@ -651,5 +659,63 @@ describe("DictionaryGetSchema", () => {
 
   it("should reject missing dictionary type", () => {
     expect(DictionaryGetSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("state fields with dictionary overrides (stateField)", () => {
+  beforeEach(() => {
+    process.env.BOOND_DICTIONARY_OVERRIDES = JSON.stringify({
+      state: { candidate: { Interviewed: 2, Hired: 5 }, opportunity: { Won: 6 } },
+    });
+    resetDictionaryOverridesForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.BOOND_DICTIONARY_OVERRIDES;
+    resetDictionaryOverridesForTests();
+  });
+
+  it("resolves a known label to its numeric id at parse time", () => {
+    const result = CandidateUpdateSchema.safeParse({ id: "1", state: "Interviewed" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.state).toBe(2);
+    }
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    const result = CandidateCreateSchema.safeParse({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      state: "  hired ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.state).toBe(5);
+    }
+  });
+
+  it("rejects an unknown label", () => {
+    expect(CandidateUpdateSchema.safeParse({ id: "1", state: "Telepathic" }).success).toBe(false);
+  });
+
+  it("does not leak labels across entities", () => {
+    // "Won" is declared for opportunities only.
+    expect(OpportunityUpdateSchema.safeParse({ id: "1", state: "Won" }).success).toBe(true);
+    expect(CandidateUpdateSchema.safeParse({ id: "1", state: "Won" }).success).toBe(false);
+  });
+
+  it("still accepts a numeric state unchanged", () => {
+    const result = CandidateUpdateSchema.safeParse({ id: "1", state: 1 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.state).toBe(1);
+    }
+  });
+
+  it("rejects a label when no overrides are configured", () => {
+    delete process.env.BOOND_DICTIONARY_OVERRIDES;
+    resetDictionaryOverridesForTests();
+    expect(CandidateUpdateSchema.safeParse({ id: "1", state: "Interviewed" }).success).toBe(false);
   });
 });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
+import { appendOverridesToDescription, resolveLabel } from "../config/dictionary-overrides.js";
 
 // Common search schema
 export const SearchSchema = z
@@ -501,6 +502,25 @@ export const IdTabSchema = z
   })
   .strict();
 
+// ---- Dictionary-override-aware `state` field ----
+// Accepts the usual numeric dictionary id, plus a custom label when the
+// operator configured BOOND_DICTIONARY_OVERRIDES (see docs/dictionary-overrides.md).
+// IMPORTANT: the label is resolved inside `z.preprocess`, i.e. at PARSE time,
+// not at schema definition time -- so overrides injected after this module is
+// imported (tests, late env) are honoured. Unknown labels are left as-is so
+// the integer validation fails with an explicit error.
+export const stateField = (entity: string, baseDescription: string) =>
+  z
+    .preprocess((value) => {
+      if (typeof value === "string") {
+        const resolved = resolveLabel("state", entity, value);
+        if (resolved !== undefined) return resolved;
+      }
+      return value;
+    }, z.coerce.number().int())
+    .optional()
+    .describe(appendOverridesToDescription(baseDescription, "state", entity));
+
 // ---- Candidate schemas ----
 
 export const CandidateCreateSchema = z
@@ -512,7 +532,7 @@ export const CandidateCreateSchema = z
     city: z.string().optional().describe("Ville"),
     country: z.string().optional().describe("Pays"),
     title: z.string().optional().describe("Titre du poste / fonction"),
-    state: z.number().int().optional().describe("État du candidat (0=en cours, 1=placé, 2=archivé...)"),
+    state: stateField("candidate", "État du candidat (0=en cours, 1=placé, 2=archivé...)"),
     mainSkills: z.string().optional().describe("Compétences principales (texte libre)"),
     note: z.string().optional().describe("Notes / commentaires"),
   })
@@ -528,7 +548,7 @@ export const CandidateUpdateSchema = z
     city: z.string().optional().describe("Ville"),
     country: z.string().optional().describe("Pays"),
     title: z.string().optional().describe("Titre / fonction"),
-    state: z.number().int().optional().describe("État du candidat"),
+    state: stateField("candidate", "État du candidat"),
     mainSkills: z.string().optional().describe("Compétences principales"),
     note: z.string().optional().describe("Notes"),
   })
@@ -545,7 +565,7 @@ export const ResourceCreateSchema = z
     city: z.string().optional().describe("Ville"),
     country: z.string().optional().describe("Pays"),
     title: z.string().optional().describe("Titre / poste"),
-    state: z.number().int().optional().describe("État de la ressource"),
+    state: stateField("resource", "État de la ressource"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -560,7 +580,7 @@ export const ResourceUpdateSchema = z
     city: z.string().optional().describe("Ville"),
     country: z.string().optional().describe("Pays"),
     title: z.string().optional().describe("Titre / poste"),
-    state: z.number().int().optional().describe("État"),
+    state: stateField("resource", "État"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -721,7 +741,7 @@ export const CompanyCreateSchema = z
     country: z.string().optional().describe("Pays"),
     website: z.string().optional().describe("Site web"),
     siret: z.string().optional().describe("Numéro SIRET"),
-    state: z.number().int().optional().describe("État de la société"),
+    state: stateField("company", "État de la société"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -736,7 +756,7 @@ export const CompanyUpdateSchema = z
     country: z.string().optional().describe("Pays"),
     website: z.string().optional().describe("Site web"),
     siret: z.string().optional().describe("Numéro SIRET"),
-    state: z.number().int().optional().describe("État"),
+    state: stateField("company", "État"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -748,7 +768,7 @@ export const OpportunityCreateSchema = z
     name: z.string().min(1).describe("Nom / titre de l'opportunité"),
     companyId: z.string().optional().describe("ID de la société cliente"),
     contactId: z.string().optional().describe("ID du contact associé"),
-    state: z.number().int().optional().describe("État de l'opportunité"),
+    state: stateField("opportunity", "État de l'opportunité"),
     startDate: z.string().optional().describe("Date de début prévue (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin prévue (YYYY-MM-DD)"),
     note: z.string().optional().describe("Notes / description"),
@@ -759,7 +779,7 @@ export const OpportunityUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID de l'opportunité à modifier"),
     name: z.string().optional().describe("Nom / titre"),
-    state: z.number().int().optional().describe("État"),
+    state: stateField("opportunity", "État"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
     note: z.string().optional().describe("Notes"),
@@ -786,12 +806,11 @@ export const ActionSearchSchema = z
 // and `text` (not subject/content) — anything else triggers a 422.
 export const ActionCreateSchema = z
   .object({
-    typeOf: z.coerce
-      .number()
-      .int()
-      .min(0)
+    typeOf: z
+      .union([z.coerce.number().int().min(0), z.string().min(1)])
       .describe(
-        "Type d'action : ID numérique du dictionnaire BoondManager (setting.action.*, via boond_application_dictionary)"
+        "Type d'action : ID numérique du dictionnaire (setting.action.*, via boond_application_dictionary) " +
+          "ou libellé personnalisé si BOOND_DICTIONARY_OVERRIDES est configuré"
       ),
     title: z.string().optional().describe("Titre de l'action"),
     text: z.string().optional().describe("Contenu / notes de l'action"),
@@ -858,7 +877,7 @@ export const ProjectCreateSchema = z
     companyId: z.string().optional().describe("ID de la société cliente"),
     contactId: z.string().optional().describe("ID du contact associé"),
     opportunityId: z.string().optional().describe("ID de l'opportunité liée"),
-    state: z.number().int().optional().describe("État du projet (0=en cours, 1=terminé, 2=archivé...)"),
+    state: stateField("project", "État du projet (0=en cours, 1=terminé, 2=archivé...)"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
     note: z.string().optional().describe("Notes / description du projet"),
@@ -869,7 +888,7 @@ export const ProjectUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID du projet à modifier"),
     name: z.string().optional().describe("Nom du projet"),
-    state: z.number().int().optional().describe("État du projet"),
+    state: stateField("project", "État du projet"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
     note: z.string().optional().describe("Notes"),

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerActionTools } from "./actions.js";
 import { apiRequest } from "../services/boond-client.js";
+import { resetDictionaryOverridesForTests } from "../config/dictionary-overrides.js";
 
 vi.mock("../services/boond-client.js", () => ({
   apiRequest: vi.fn().mockResolvedValue({ data: { id: "123", type: "action" } }),
@@ -120,6 +121,102 @@ describe("registerActionTools", () => {
       const result = await handler({ typeOf: 1, companyId: "42" });
       expect(result.isError).toBe(true);
       expect(apiRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return an error mentioning BOOND_DICTIONARY_OVERRIDES for a label typeOf without overrides", async () => {
+      // No overrides configured: a string typeOf cannot be resolved.
+      resetDictionaryOverridesForTests();
+      const handler = getCreateHandler();
+      const result = await handler({ typeOf: "Call", contactId: "6695" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("BOOND_DICTIONARY_OVERRIDES");
+      expect(result.content[0].text).toContain("boond_application_dictionary");
+      expect(apiRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("boond_actions_create with dictionary overrides", () => {
+    const OVERRIDES = JSON.stringify({
+      action: { contact: { Call: 61, Email: 63 }, candidate: { Call: 40 } },
+    });
+
+    function getCreateRegistration() {
+      registerActionTools(server);
+      return vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_actions_create");
+    }
+
+    function getCreateHandler() {
+      return getCreateRegistration()?.[2] as (params: Record<string, unknown>) => Promise<{
+        isError?: boolean;
+        content: Array<{ type: string; text: string }>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiRequest).mockClear();
+      process.env.BOOND_DICTIONARY_OVERRIDES = OVERRIDES;
+      resetDictionaryOverridesForTests();
+    });
+
+    afterEach(() => {
+      delete process.env.BOOND_DICTIONARY_OVERRIDES;
+      resetDictionaryOverridesForTests();
+    });
+
+    it("resolves a typeOf label against the dependsOn entity (contact)", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: "Call", title: "Suivi", contactId: "6695" });
+      expect(apiRequest).toHaveBeenCalledWith("/actions", "POST", {
+        data: {
+          type: "action",
+          attributes: { typeOf: 61, title: "Suivi" },
+          relationships: {
+            dependsOn: { data: { id: "6695", type: "contact" } },
+          },
+        },
+      });
+    });
+
+    it("resolves labels case-insensitively and per entity", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: " call ", candidateId: "99" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { attributes: Record<string, unknown> };
+      };
+      expect(body.data.attributes.typeOf).toBe(40);
+    });
+
+    it("returns an error listing the available labels for an unknown label", async () => {
+      const handler = getCreateHandler();
+      const result = await handler({ typeOf: "Visio", contactId: "6695" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('"Visio"');
+      expect(result.content[0].text).toContain("Call");
+      expect(result.content[0].text).toContain("Email");
+      expect(apiRequest).not.toHaveBeenCalled();
+    });
+
+    it("keeps a numeric typeOf strictly unchanged", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 7, contactId: "6695" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { attributes: Record<string, unknown> };
+      };
+      expect(body.data.attributes.typeOf).toBe(7);
+    });
+
+    it("enriches the tool description with the configured labels", () => {
+      const description = getCreateRegistration()?.[1].description as string;
+      expect(description).toContain("Libellés personnalisés acceptés pour typeOf");
+      expect(description).toContain("Contact : Call=61, Email=63");
+      expect(description).toContain("Candidat : Call=40");
+    });
+
+    it("leaves the tool description untouched without overrides", () => {
+      delete process.env.BOOND_DICTIONARY_OVERRIDES;
+      resetDictionaryOverridesForTests();
+      const description = getCreateRegistration()?.[1].description as string;
+      expect(description).not.toContain("Libellés personnalisés");
     });
   });
 });

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -2,6 +2,31 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ActionSearchSchema, ActionCreateSchema, IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 import { buildJsonApiBody, registerDeleteTool } from "./crud-factory.js";
+import { availableLabels, formatOverridesSummary, resolveLabel } from "../config/dictionary-overrides.js";
+
+/** Display labels for the five entities an action can be attached to. */
+const ACTION_ENTITY_LABELS: ReadonlyArray<readonly [string, string]> = [
+  ["Contact", "contact"],
+  ["Candidat", "candidate"],
+  ["Ressource", "resource"],
+  ["Opportunité", "opportunity"],
+  ["Projet", "project"],
+];
+
+/**
+ * Append the custom typeOf labels (BOOND_DICTIONARY_OVERRIDES) to the create
+ * tool description, as one compact block. Without overrides the base
+ * description is returned unchanged (byte-for-byte).
+ */
+function buildActionCreateDescription(base: string): string {
+  const parts: string[] = [];
+  for (const [label, entity] of ACTION_ENTITY_LABELS) {
+    const summary = formatOverridesSummary("action", entity);
+    if (summary !== null) parts.push(`${label} : ${summary}`);
+  }
+  if (parts.length === 0) return base;
+  return `${base}\nLibellés personnalisés acceptés pour typeOf (résolus automatiquement) : ${parts.join(" / ")}`;
+}
 
 export function registerActionTools(server: McpServer): void {
   // Search actions
@@ -61,7 +86,8 @@ Returns: Liste des actions correspondantes.`,
     "boond_actions_create",
     {
       title: "Créer une action",
-      description: `Crée une nouvelle action (appel, email, RDV, note) dans BoondManager, rattachée à un contact, candidat, ressource, opportunité ou projet (relation dependsOn, obligatoire).
+      description:
+        buildActionCreateDescription(`Crée une nouvelle action (appel, email, RDV, note) dans BoondManager, rattachée à un contact, candidat, ressource, opportunité ou projet (relation dependsOn, obligatoire).
 
 Args:
   - typeOf (number, requis): ID numérique du type d'action (dictionnaire setting.action.*, via boond_application_dictionary)
@@ -70,7 +96,7 @@ Args:
   - contactId | candidateId | resourceId | opportunityId | projectId (string, un requis): Entité de rattachement
   - companyId (string, optional): Société, uniquement en complément d'un contactId
 
-Returns: L'action créée avec son ID.`,
+Returns: L'action créée avec son ID.`),
       inputSchema: ActionCreateSchema,
       annotations: {
         readOnlyHint: false,
@@ -102,6 +128,29 @@ Returns: L'action créée avec son ID.`,
             },
           ],
         };
+      }
+      // Resolve a custom typeOf label (BOOND_DICTIONARY_OVERRIDES) to its
+      // numeric dictionary id. The labels are declared per attached entity
+      // (setting.action.<entity>), hence the resolution after dependsOn.
+      if (typeof attrs.typeOf === "string") {
+        const resolved = resolveLabel("action", dependsOn.type, attrs.typeOf);
+        if (resolved === undefined) {
+          const labels = availableLabels("action", dependsOn.type);
+          const hint =
+            labels.length > 0
+              ? `Libellés personnalisés disponibles pour ${dependsOn.type} : ${labels.join(", ")}. Sinon, utilisez l'ID numérique du dictionnaire (setting.action.*, via boond_application_dictionary).`
+              : `Aucun libellé personnalisé n'est configuré pour ${dependsOn.type} : utilisez l'ID numérique du dictionnaire (setting.action.*, via boond_application_dictionary), ou déclarez vos libellés via BOOND_DICTIONARY_OVERRIDES (voir docs/dictionary-overrides.md).`;
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Type d'action inconnu : "${attrs.typeOf}". ${hint}`,
+              },
+            ],
+          };
+        }
+        attrs.typeOf = resolved;
       }
       const body = buildJsonApiBody("action", attrs);
       const relationships: Record<string, unknown> = {


### PR DESCRIPTION
## Description

Implémente #101  — prise en charge des dictionnaires BoondManager personnalisés.

L'API exige des IDs numériques (`typeOf`, `state`) ; sur les instances dont les libellés sont personnalisés, le modèle n'a aucun moyen fiable de les connaître (le dictionnaire API renvoie d'ailleurs des libellés qui peuvent différer de l'UI). Cette PR ajoute une variable d'environnement optionnelle `BOOND_DICTIONARY_OVERRIDES` (JSON inline ou chemin de fichier) déclarant le mapping label → ID par section (`action` / `state`) et par entité.

Quand elle est configurée :

- `src/config/dictionary-overrides.ts` (nouveau) : chargement + validation Zod, fail-open (config absente/invalide → warn + comportement historique), résolution insensible à la casse ;
- `boond_actions_create` : `typeOf` accepte un libellé, résolu selon l'entité `dependsOn` ; libellé inconnu → erreur explicite avec les libellés disponibles ; `typeOf` numérique strictement inchangé ;
- champs `state` des create/update de candidates, resources, companies, opportunities, projects : libellé accepté (résolution au parse via `z.preprocess`) ;
- descriptions d'outils enrichies avec les tables label=ID ;
- nouvelle ressource MCP `boond://dictionary/overrides` ;
- `user_config.dictionary_overrides` dans `manifest.json` (même pattern que l'access policy) ;
- documentation : `docs/dictionary-overrides.md` + section README.

Sans la variable, descriptions et comportements sont inchangés à l'octet près.

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalité (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [x] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lancé `npm run lint` et `npm run typecheck`
- [x] J'ai ajouté des tests couvrant mes changements (33 nouveaux tests)
- [x] Tous les tests passent (`npm test` — 630 tests), ainsi que `npm run build` et `npm run docs:tools:check`
