### PR TITLE
fix: permettre la relation positioning exigée par l'API pour certains types d'action

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -806,6 +806,12 @@ export const ActionCreateSchema = z
     opportunityId: z.string().optional().describe("ID de l'opportunité à laquelle rattacher l'action (dependsOn)"),
     projectId: z.string().optional().describe("ID du projet auquel rattacher l'action (dependsOn)"),
     companyId: z.string().optional().describe("ID de la société associée (uniquement en complément d'un contactId)"),
+    positioningId: z
+      .string()
+      .optional()
+      .describe(
+        "ID du positionnement à lier à l'action (relation positioning). Requis par l'API pour les types d'action liés aux positionnements (ex. RQ) — sans lui, erreur 422 « 1002 - Wrong or missing attribute (/data/relationships/positioning) »."
+      ),
   })
   .strict();
 

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -97,6 +97,30 @@ describe("registerActionTools", () => {
       });
     });
 
+    it("should send a positioning relationship when positioningId is provided", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 52, opportunityId: "345", positioningId: "11130" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { relationships: Record<string, unknown>; attributes: Record<string, unknown> };
+      };
+      expect(body.data.relationships.dependsOn).toEqual({
+        data: { id: "345", type: "opportunity" },
+      });
+      expect(body.data.relationships.positioning).toEqual({
+        data: { id: "11130", type: "positioning" },
+      });
+      expect(body.data.attributes.positioningId).toBeUndefined();
+    });
+
+    it("should not send a positioning relationship when positioningId is absent", async () => {
+      const handler = getCreateHandler();
+      await handler({ typeOf: 1, contactId: "6695" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { relationships: Record<string, unknown> };
+      };
+      expect(body.data.relationships.positioning).toBeUndefined();
+    });
+
     it("should map candidateId to a candidate dependsOn", async () => {
       const handler = getCreateHandler();
       await handler({ typeOf: 2, candidateId: "99" });

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -69,6 +69,7 @@ Args:
   - startDate, endDate (string, optional): Dates ISO avec timezone (ex: 2026-06-05T10:00:00+0200)
   - contactId | candidateId | resourceId | opportunityId | projectId (string, un requis): Entité de rattachement
   - companyId (string, optional): Société, uniquement en complément d'un contactId
+  - positioningId (string, optional): Positionnement à lier — requis par l'API pour les types d'action liés aux positionnements (ex. RQ)
 
 Returns: L'action créée avec son ID.`,
       inputSchema: ActionCreateSchema,
@@ -80,7 +81,8 @@ Returns: L'action créée avec son ID.`,
       },
     },
     async (params) => {
-      const { candidateId, resourceId, contactId, opportunityId, projectId, companyId, ...attrs } = params;
+      const { candidateId, resourceId, contactId, opportunityId, projectId, companyId, positioningId, ...attrs } =
+        params;
       // The API requires a polymorphic `dependsOn` relationship pointing to the
       // entity the action is attached to (422 "Missing required relationship"
       // otherwise). `company` is only accepted alongside a contact `dependsOn`.
@@ -109,6 +111,14 @@ Returns: L'action créée avec son ID.`,
       };
       if (companyId && dependsOn.type === "contact") {
         relationships.company = { data: { id: companyId, type: "company" } };
+      }
+      // Some action types (those bound to positionings in the Boond setup, e.g.
+      // "RQ"-style interviews) are rejected with a 422 "1002 - Wrong or missing
+      // attribute (/data/relationships/positioning)" unless a positioning
+      // relationship is sent. The official bodyPost.json schema does not
+      // document it, but the API enforces it for those types.
+      if (positioningId) {
+        relationships.positioning = { data: { id: positioningId, type: "positioning" } };
       }
       (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
       const response = await apiRequest("/actions", "POST", body);


### PR DESCRIPTION
## Description

Corrige #102  — les types d'action liés aux positionnements (ex. entretiens « RQ ») étaient impossibles à créer : l'API rejette `POST /actions` en 422 « 1002 - Wrong or missing attribute (/data/relationships/positioning) » pour ces types, alors que le schéma officiel `actions/bodyPost.json` ne documente pas cette relation.

Changements :

- `src/schemas/index.ts` : `ActionCreateSchema` — ajout du paramètre optionnel `positioningId` (description explicitant le cas d'usage et l'erreur 1002) ;
- `src/tools/actions.ts` : si `positioningId` est fourni, envoi de `relationships.positioning = { data: { id, type: "positioning" } }` ; sans lui, payload inchangé à l'octet près ;
- 2 tests (relation présente avec `positioningId`, absente sans).

Vérifié contre une instance réelle : sans la relation → 422 « 1002 » ; avec `positioningId` → création réussie. Bonus constaté : l'API crée automatiquement les actions liées sur le candidat et le contact (triplet « parent/child » via relatedActions), comme depuis l'interface, et la suppression du parent cascade proprement.

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalité (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lancé `npm run lint` et `npm run typecheck`
- [x] J'ai ajouté des tests couvrant mes changements
- [x] Tous les tests passent (`npm test` — 599 tests sur cette branche), ainsi que `npm run build` et `npm run docs:tools:check`

