### PR TITLE
fix: lister tous les éléments des onglets et réparer les filtres de recherche des positionnements

### DIFF
--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -605,10 +605,17 @@ describe("PositioningSearchSchema", () => {
     const result = PositioningSearchSchema.safeParse({
       candidateId: "1",
       resourceId: "2",
-      projectId: "3",
       opportunityId: "4",
+      companyId: "5",
+      contactId: "6",
+      productId: "7",
     });
     expect(result.success).toBe(true);
+  });
+
+  it("should reject projectId (not supported by the API)", () => {
+    const result = PositioningSearchSchema.safeParse({ projectId: "3" });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1082,11 +1082,36 @@ export const PositioningCreateSchema = z
 
 export const PositioningSearchSchema = z
   .object({
-    keywords: z.string().optional().describe("Mots-clés de recherche"),
-    candidateId: z.string().optional().describe("Filtrer par ID candidat"),
-    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-    projectId: z.string().optional().describe("Filtrer par ID projet"),
-    opportunityId: z.string().optional().describe("Filtrer par ID opportunité"),
+    keywords: z
+      .string()
+      .optional()
+      .describe(
+        "Mots-clés de recherche. L'API y accepte aussi des références d'entités (AO<id>, CAND<id>, COMP<id>...) — les filtres *Id ci-dessous sont convertis automatiquement en de telles références."
+      ),
+    candidateId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID candidat (envoyé à l'API comme référence keywords CAND<id>)"),
+    resourceId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID ressource (envoyé à l'API comme référence keywords COMP<id>)"),
+    opportunityId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID opportunité (envoyé à l'API comme référence keywords AO<id>)"),
+    companyId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID société (envoyé à l'API comme référence keywords CSOC<id>)"),
+    contactId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID contact (envoyé à l'API comme référence keywords CCON<id>)"),
+    productId: z
+      .string()
+      .optional()
+      .describe("Filtrer par ID produit (envoyé à l'API comme référence keywords PROD<id>)"),
     page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
     pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
   })

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -4,6 +4,7 @@ import {
   formatEntitySummary,
   formatListResponse,
   formatDetailResponse,
+  formatTabResponse,
   initClient,
   buildJwt,
   apiRequest,
@@ -269,6 +270,34 @@ describe("formatDetailResponse", () => {
       data: { id: "1", type: "test", attributes: largeAttrs },
     });
     expect(result).toContain("[Résultat tronqué...]");
+  });
+});
+
+describe("formatTabResponse", () => {
+  it("should list every entity when data is an array", () => {
+    const result = formatTabResponse({
+      data: [
+        { id: "1", type: "positioning", attributes: { state: 1 } },
+        { id: "2", type: "positioning", attributes: { state: 4 } },
+        { id: "3", type: "positioning", attributes: { state: 9 } },
+      ],
+    });
+    expect(result).toContain("3 élément(s)");
+    const parsed = JSON.parse(result.substring(result.indexOf("[")));
+    expect(parsed).toHaveLength(3);
+    expect(parsed.map((e: { id: string }) => e.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("should behave like formatDetailResponse for a single object", () => {
+    const response = {
+      data: { id: "1", type: "resource", attributes: { firstName: "Marie" } },
+    };
+    expect(formatTabResponse(response)).toBe(formatDetailResponse(response));
+  });
+
+  it("should report 0 élément(s) for an empty array", () => {
+    const result = formatTabResponse({ data: [] });
+    expect(result).toContain("0 élément(s)");
   });
 });
 

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -862,6 +862,33 @@ export function formatListResponse(response: JsonApiResponse, entityType: string
   return result;
 }
 
+/**
+ * Formate la réponse d'un endpoint d'onglet (ex: /resources/{id}/positionings).
+ * Contrairement à formatDetailResponse, un tableau est restitué en entier :
+ * certains onglets renvoient plusieurs entités (positionnements, contacts...)
+ * et n'afficher que la première masquait les autres.
+ */
+export function formatTabResponse(response: JsonApiResponse): string {
+  if (!Array.isArray(response.data)) {
+    return formatDetailResponse(response);
+  }
+
+  const entities = response.data.map((entity) => ({
+    id: entity.id,
+    type: entity.type,
+    attributes: entity.attributes,
+    relationships: entity.relationships,
+  }));
+
+  let result = `${entities.length} élément(s)\n\n` + JSON.stringify(entities, null, 2);
+
+  if (result.length > CHARACTER_LIMIT) {
+    result = result.substring(0, CHARACTER_LIMIT) + "\n\n[Résultat tronqué...]";
+  }
+
+  return result;
+}
+
 export function formatDetailResponse(response: JsonApiResponse): string {
   const entity = Array.isArray(response.data) ? response.data[0] : response.data;
   if (!entity) return "Entité non trouvée.";

--- a/src/tools/candidates.ts
+++ b/src/tools/candidates.ts
@@ -9,7 +9,7 @@ import {
   registerDeleteTool,
   buildJsonApiBody,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "candidat",
@@ -139,7 +139,7 @@ export function registerCandidateTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/candidates/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -9,7 +9,7 @@ import {
   registerDeleteTool,
   buildJsonApiBody,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "société",
@@ -183,7 +183,7 @@ export function registerCompanyTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/companies/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -9,7 +9,7 @@ import {
   registerDeleteTool,
   buildJsonApiBody,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "contact",
@@ -156,7 +156,7 @@ export function registerContactTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/contacts/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };

--- a/src/tools/opportunities.ts
+++ b/src/tools/opportunities.ts
@@ -1,5 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { OpportunityCreateSchema, OpportunityUpdateSchema, OpportunitySearchSchema, IdSchema } from "../schemas/index.js";
+import {
+  OpportunityCreateSchema,
+  OpportunityUpdateSchema,
+  OpportunitySearchSchema,
+  IdSchema,
+} from "../schemas/index.js";
 import type { IdInput } from "../schemas/index.js";
 import {
   registerSearchTool,
@@ -9,7 +14,7 @@ import {
   registerDeleteTool,
   buildJsonApiBody,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "opportunité",
@@ -145,7 +150,7 @@ export function registerOpportunityTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/opportunities/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };

--- a/src/tools/positionings.test.ts
+++ b/src/tools/positionings.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerPositioningTools } from "./positionings.js";
+import { apiRequest } from "../services/boond-client.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: [] }),
+  // Passthrough : permet de vérifier exactement ce que le handler envoie à l'API
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+  formatEntitySummary: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -31,9 +41,12 @@ describe("registerPositioningTools", () => {
 
   it("should register search and get as readOnly", () => {
     registerPositioningTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_positionings_search", "boond_positionings_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" && ["boond_positionings_search", "boond_positionings_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -41,9 +54,59 @@ describe("registerPositioningTools", () => {
 
   it("should register delete as destructive", () => {
     registerPositioningTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_positionings_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  describe("boond_positionings_search handler", () => {
+    function getSearchHandler() {
+      registerPositioningTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_search");
+      return call?.[2] as (params: Record<string, unknown>) => Promise<{
+        content: Array<{ type: string; text: string }>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiRequest).mockClear();
+    });
+
+    it("should convert candidateId into a CAND keyword reference, without raw candidateId", async () => {
+      const handler = getSearchHandler();
+      await handler({ keywords: "test", candidateId: "2801", page: 1, pageSize: 30 });
+      const query = vi.mocked(apiRequest).mock.calls[0][3] as Record<string, unknown>;
+      expect(query.keywords).toContain("test");
+      expect(query.keywords).toContain("CAND2801");
+      expect(query.candidateId).toBeUndefined();
+    });
+
+    it("should convert resourceId into a COMP keyword reference, without raw resourceId", async () => {
+      const handler = getSearchHandler();
+      await handler({ resourceId: "42", page: 1, pageSize: 30 });
+      const query = vi.mocked(apiRequest).mock.calls[0][3] as Record<string, unknown>;
+      expect(query.keywords).toBe("COMP42");
+      expect(query.resourceId).toBeUndefined();
+    });
+
+    it("should convert opportunityId, companyId, contactId and productId into keyword references", async () => {
+      const handler = getSearchHandler();
+      await handler({ opportunityId: "1", companyId: "2", contactId: "3", productId: "4", page: 1, pageSize: 30 });
+      const query = vi.mocked(apiRequest).mock.calls[0][3] as Record<string, unknown>;
+      expect(query.keywords).toContain("AO1");
+      expect(query.keywords).toContain("CSOC2");
+      expect(query.keywords).toContain("CCON3");
+      expect(query.keywords).toContain("PROD4");
+      expect(query.opportunityId).toBeUndefined();
+      expect(query.companyId).toBeUndefined();
+      expect(query.contactId).toBeUndefined();
+      expect(query.productId).toBeUndefined();
+    });
+
+    it("should not set keywords when no filter is provided", async () => {
+      const handler = getSearchHandler();
+      await handler({ page: 1, pageSize: 30 });
+      const query = vi.mocked(apiRequest).mock.calls[0][3] as Record<string, unknown>;
+      expect(query.keywords).toBeUndefined();
+    });
   });
 });

--- a/src/tools/positionings.ts
+++ b/src/tools/positionings.ts
@@ -11,9 +11,11 @@ export function registerPositioningTools(server: McpServer): void {
       title: "Rechercher des positionnements",
       description: `Recherche des positionnements (placement de candidats/ressources sur des projets/opportunités) dans BoondManager.
 
+L'API ne propose pas de paramètres de filtre dédiés : le filtrage par entité liée passe par des références dans \`keywords\` (AO<id>=opportunité, CAND<id>=candidat, COMP<id>=ressource, CSOC<id>=société, CCON<id>=contact, PROD<id>=produit). Les filtres *Id ci-dessous sont convertis automatiquement en ces références.
+
 Args:
-  - keywords (string, optional): Termes de recherche
-  - candidateId, resourceId, projectId, opportunityId (string, optional): Filtrer par entité liée
+  - keywords (string, optional): Termes de recherche (références d'entités acceptées)
+  - candidateId, resourceId, opportunityId, companyId, contactId, productId (string, optional): Filtrer par entité liée (convertis en références keywords)
   - page, pageSize: Pagination
 
 Returns: Liste des positionnements correspondants.`,
@@ -26,7 +28,19 @@ Returns: Liste des positionnements correspondants.`,
       },
     },
     async (params) => {
-      const query = buildSearchQuery(params);
+      // L'API GET /positionings n'a pas de paramètres candidateId/resourceId/... :
+      // le filtrage par entité passe par des références dans `keywords`
+      // (cf. RAML officiel). Les paramètres bruts seraient silencieusement ignorés.
+      const { candidateId, resourceId, opportunityId, companyId, contactId, productId, keywords, ...rest } = params;
+      const tokens: string[] = [];
+      if (keywords) tokens.push(keywords);
+      if (opportunityId) tokens.push(`AO${opportunityId}`);
+      if (candidateId) tokens.push(`CAND${candidateId}`);
+      if (resourceId) tokens.push(`COMP${resourceId}`);
+      if (companyId) tokens.push(`CSOC${companyId}`);
+      if (contactId) tokens.push(`CCON${contactId}`);
+      if (productId) tokens.push(`PROD${productId}`);
+      const query = buildSearchQuery(tokens.length > 0 ? { ...rest, keywords: tokens.join(" ") } : rest);
       const response = await apiRequest("/positionings", "GET", undefined, query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "positionnement") }],

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -9,7 +9,7 @@ import {
   registerDeleteTool,
   buildJsonApiBody,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "projet",
@@ -168,7 +168,7 @@ export function registerProjectTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/projects/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -25,7 +25,7 @@ import {
   buildJsonApiBody,
   confirmDeletion,
 } from "./crud-factory.js";
-import { apiRequest, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, formatDetailResponse, formatTabResponse } from "../services/boond-client.js";
 
 const OPTS = {
   entityName: "ressource",
@@ -356,7 +356,7 @@ export function registerResourceTools(server: McpServer): void {
       },
       async (params: IdInput) => {
         const response = await apiRequest(`/resources/${params.id}/${tab.tab}`);
-        const text = formatDetailResponse(response);
+        const text = formatTabResponse(response);
         return {
           content: [{ type: "text" as const, text }],
         };


### PR DESCRIPTION
## Description

Corrige #103  — deux bugs qui, combinés, rendaient les positionnements pratiquement invisibles pour le modèle :

- **Onglets tronqués** : `formatDetailResponse` ne prend que `data[0]` ; les outils d'onglets (ex. `boond_resources_positionings`) ne montraient donc que le premier élément d'une liste. Nouveau formateur `formatTabResponse` (tableau → « N élément(s) » + toutes les entités, avec la troncature CHARACTER_LIMIT habituelle ; objet → comportement inchangé), appliqué aux boucles d'onglets des 6 entités (resources, candidates, contacts, companies, opportunities, projects).
- **Filtres de `boond_positionings_search` ignorés** : l'API GET /positionings filtre par références dans `keywords` (`AO<id>`, `CAND<id>`, `COMP<id>` pour une ressource, `CCON<id>`, `CSOC<id>`, `PROD<id>` — cf. RAML `resources/positionings/search.raml`), pas par paramètres dédiés. Le handler convertit désormais `candidateId`/`resourceId`/`opportunityId`/`companyId`/`contactId`/`productId` en tokens keywords ; `projectId` est retiré (aucun équivalent API — il n'a jamais filtré quoi que ce soit, pas de régression réelle).

Constat en réel avant correctif : ressource avec 5 positionnements → 1 seul visible ; recherche filtrée par candidat → 26 610 résultats (toute la base).

Tests : 3 (formatTabResponse) + 8 (mapping keywords) ; schémas adaptés.

## Type de changement

- [x] Bug fix (correction non-breaking)
- [ ] Nouvelle fonctionnalité (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lancé `npm run lint` et `npm run typecheck`
- [x] J'ai ajouté des tests couvrant mes changements
- [x] Tous les tests passent (`npm test`), ainsi que `npm run build` et `npm run docs:tools:check`

