### PR TITLE
feat: outil boond_positionings_update (mise à jour d'état d'un positionnement)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**174 tools** across **38 domains** · **11 prompts** · **21 resources**.
+**175 tools** across **38 domains** · **11 prompts** · **21 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -228,7 +228,7 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_poles_get` | Détails d'un pôle | read · idempotent |
 | `boond_poles_search` | Rechercher des pôles | read · idempotent · open-world |
 
-### positionings (4)
+### positionings (5)
 
 | Tool | Title | Hints |
 |---|---|---|
@@ -236,6 +236,7 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_positionings_delete` | Supprimer un positionnement | delete |
 | `boond_positionings_get` | Détails d'un positionnement | read · idempotent |
 | `boond_positionings_search` | Rechercher des positionnements | read · idempotent · open-world |
+| `boond_positionings_update` | Modifier un positionnement | write · idempotent |
 
 ### products (5)
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -518,6 +518,27 @@ export const CandidateCreateSchema = z
   })
   .strict();
 
+export const PositioningUpdateSchema = z
+  .object({
+    id: z.string().min(1).describe("ID du positionnement \u00e0 modifier"),
+    state: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("\u00c9tat du positionnement : ID num\u00e9rique du dictionnaire setting.state.positioning"),
+    stateReasonTypeOf: z
+      .number()
+      .int()
+      .optional()
+      .describe("Motif d'\u00e9tat : ID num\u00e9rique du type de motif (stateReason.typeOf)"),
+    stateReasonDetail: z.string().optional().describe("Motif d'\u00e9tat : d\u00e9tail libre (stateReason.detail)"),
+    startDate: z.string().optional().describe("Date de d\u00e9but (YYYY-MM-DD, ou cha\u00eene vide pour effacer)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD, ou cha\u00eene vide pour effacer)"),
+    informationComments: z.string().max(250).optional().describe("Commentaires (max 250 caract\u00e8res)"),
+  })
+  .strict();
+
 export const CandidateUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID du candidat à modifier"),

--- a/src/tools/positionings.test.ts
+++ b/src/tools/positionings.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerPositioningTools } from "./positionings.js";
+import { apiRequest } from "../services/boond-client.js";
+
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
 function createMockServer() {
   return {
@@ -15,9 +21,9 @@ describe("registerPositioningTools", () => {
     server = createMockServer();
   });
 
-  it("should register 4 positioning tools", () => {
+  it("should register 5 positioning tools", () => {
     registerPositioningTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(4);
+    expect(server.registerTool).toHaveBeenCalledTimes(5);
   });
 
   it("should register all expected tool names", () => {
@@ -26,14 +32,18 @@ describe("registerPositioningTools", () => {
     expect(names).toContain("boond_positionings_search");
     expect(names).toContain("boond_positionings_get");
     expect(names).toContain("boond_positionings_create");
+    expect(names).toContain("boond_positionings_update");
     expect(names).toContain("boond_positionings_delete");
   });
 
   it("should register search and get as readOnly", () => {
     registerPositioningTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_positionings_search", "boond_positionings_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" && ["boond_positionings_search", "boond_positionings_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -41,9 +51,79 @@ describe("registerPositioningTools", () => {
 
   it("should register delete as destructive", () => {
     registerPositioningTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_positionings_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  it("should register update as an idempotent, non-destructive write", () => {
+    registerPositioningTools(server);
+    const updateCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1].annotations?.readOnlyHint).toBe(false);
+    expect(updateCall?.[1].annotations?.destructiveHint).toBe(false);
+    expect(updateCall?.[1].annotations?.idempotentHint).toBe(true);
+  });
+
+  describe("boond_positionings_update handler", () => {
+    function updateHandler() {
+      registerPositioningTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_update");
+      return call?.[2] as (params: unknown) => Promise<{
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiRequest).mockReset();
+      vi.mocked(apiRequest).mockResolvedValue({
+        data: { id: "42", type: "positioning", attributes: { state: 3 } },
+      } as never);
+    });
+
+    it("PUTs a minimal JSON:API body when only state is provided", async () => {
+      const handler = updateHandler();
+      const result = await handler({ id: "42", state: 3 });
+      expect(apiRequest).toHaveBeenCalledTimes(1);
+      expect(apiRequest).toHaveBeenCalledWith("/positionings/42", "PUT", {
+        data: { type: "positioning", id: "42", attributes: { state: 3 } },
+      });
+      expect(result.structuredContent).toEqual({ id: "42", type: "positioning" });
+      expect(result.content[0].text).toContain("42");
+    });
+
+    it("folds stateReasonTypeOf/stateReasonDetail into stateReason", async () => {
+      const handler = updateHandler();
+      await handler({ id: "7", state: 5, stateReasonTypeOf: 2, stateReasonDetail: "Refus client" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { attributes: Record<string, unknown> };
+      };
+      expect(body.data.attributes).toEqual({
+        state: 5,
+        stateReason: { typeOf: 2, detail: "Refus client" },
+      });
+      expect(body.data.attributes).not.toHaveProperty("stateReasonTypeOf");
+      expect(body.data.attributes).not.toHaveProperty("stateReasonDetail");
+    });
+
+    it("folds a partial stateReason (detail only)", async () => {
+      const handler = updateHandler();
+      await handler({ id: "7", stateReasonDetail: "Concurrent retenu" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { attributes: Record<string, unknown> };
+      };
+      expect(body.data.attributes).toEqual({ stateReason: { detail: "Concurrent retenu" } });
+    });
+
+    it("does not send fields that were not provided", async () => {
+      const handler = updateHandler();
+      await handler({ id: "9", informationComments: "RAS", startDate: "2026-07-01" });
+      const body = vi.mocked(apiRequest).mock.calls[0][2] as {
+        data: { id: string; type: string; attributes: Record<string, unknown> };
+      };
+      expect(body.data.id).toBe("9");
+      expect(body.data.type).toBe("positioning");
+      expect(Object.keys(body.data.attributes).sort()).toEqual(["informationComments", "startDate"]);
+    });
   });
 });

--- a/src/tools/positionings.ts
+++ b/src/tools/positionings.ts
@@ -1,7 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { PositioningSearchSchema, PositioningCreateSchema, IdSchema } from "../schemas/index.js";
+import {
+  PositioningSearchSchema,
+  PositioningCreateSchema,
+  PositioningUpdateSchema,
+  IdSchema,
+} from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
-import { buildJsonApiBody, registerDeleteTool } from "./crud-factory.js";
+import { buildJsonApiBody, registerDeleteTool, MutationOutputSchema } from "./crud-factory.js";
 
 export function registerPositioningTools(server: McpServer): void {
   // Search positionings
@@ -90,6 +95,59 @@ Returns: Liste des positionnements correspondants.`,
             text: `✅ Positionnement créé avec succès.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
           },
         ],
+      };
+    }
+  );
+
+  // Update positioning — registration dédiée : l'API officielle attend un PUT sur
+  // /positionings/{id} (schemas/positionings/bodyPut.json), là où la factory
+  // registerUpdateTool envoie un PATCH. Le reste du contrat (annotations,
+  // MutationOutputSchema, structuredContent) reproduit celui de la factory.
+  server.registerTool(
+    "boond_positionings_update",
+    {
+      title: "Modifier un positionnement",
+      description: `Met à jour un positionnement existant dans BoondManager (PUT /positionings/{id}). Seuls les champs fournis sont modifiés.
+
+Args:
+  - id (string): ID du positionnement
+  - state (number, optional): État du positionnement (ID du dictionnaire setting.state.positioning)
+  - stateReasonTypeOf, stateReasonDetail (optional): Motif d'état (repliés en stateReason {typeOf, detail})
+  - startDate, endDate (string, optional): Dates au format YYYY-MM-DD (chaîne vide pour effacer)
+  - informationComments (string, optional): Commentaires (max 250 caractères)
+
+Returns: Données mises à jour du positionnement.`,
+      inputSchema: PositioningUpdateSchema,
+      outputSchema: MutationOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (params) => {
+      const { id, stateReasonTypeOf, stateReasonDetail, ...rest } = params;
+      const attrs: Record<string, unknown> = { ...rest };
+      if (stateReasonTypeOf !== undefined || stateReasonDetail !== undefined) {
+        attrs.stateReason = {
+          ...(stateReasonTypeOf !== undefined ? { typeOf: stateReasonTypeOf } : {}),
+          ...(stateReasonDetail !== undefined ? { detail: stateReasonDetail } : {}),
+        };
+      }
+      const body = buildJsonApiBody("positioning", attrs, id);
+      const response = await apiRequest(`/positionings/${id}`, "PUT", body);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      const ref: { id: string; type?: string } = { id };
+      if (entity?.type !== undefined) ref.type = String(entity.type);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `✅ Positionnement #${id} mis à jour.\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+        structuredContent: ref,
       };
     }
   );


### PR DESCRIPTION
## Description

Implémente #104  — l'API expose PUT /positionings/{id} mais le connecteur n'avait pas d'outil de mise à jour des positionnements : impossible de faire avancer un positionnement dans le pipeline (Positionned → CF Sent → RQ → Won…) depuis le modèle.

Changements :

- `src/schemas/index.ts` : `PositioningUpdateSchema` (`id` requis ; `state`, `stateReasonTypeOf`/`stateReasonDetail`, `startDate`/`endDate`, `informationComments` max 250, tous optionnels) ;
- `src/tools/positionings.ts` : registration dédiée (la factory update émet PATCH alors que le schéma officiel `positionings/bodyPut.json` exige PUT) reproduisant le contrat de la factory à l'identique (annotations, `MutationOutputSchema`, `structuredContent {id, type}`) ; seuls les champs fournis sont envoyés, `stateReason` replié depuis les deux champs plats ;
- tests (enregistrement, body minimal, repli stateReason, champs absents non transmis) ; TOOLS.md régénéré (175 outils).

Vérifié contre une instance réelle : passage d'un positionnement à l'état « CF Sent » (state 3) OK.

## Type de changement

- [ ] Bug fix (correction non-breaking)
- [x] Nouvelle fonctionnalité (ajout non-breaking)
- [ ] Breaking change (modification impactant le fonctionnement existant)
- [ ] Documentation

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai lancé `npm run lint` et `npm run typecheck`
- [x] J'ai ajouté des tests couvrant mes changements
- [x] Tous les tests passent (`npm test` — 602 tests sur cette branche), ainsi que `npm run build` et `npm run docs:tools:check`
