### PR TITLE
feat: expose real per-endpoint filters on the 5 reporting tools

### DIFF
--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -41,6 +41,11 @@ import {
   PaymentSearchSchema,
   AdvantageSearchSchema,
   DictionaryGetSchema,
+  ReportingCompaniesSchema,
+  ReportingProjectsSchema,
+  ReportingResourcesSchema,
+  ReportingSynthesisSchema,
+  ReportingProductionPlansSchema,
 } from "./index.js";
 
 describe("SearchSchema", () => {
@@ -724,5 +729,68 @@ describe("state fields with dictionary overrides (stateField)", () => {
     delete process.env.BOOND_DICTIONARY_OVERRIDES;
     resetDictionaryOverridesForTests();
     expect(CandidateUpdateSchema.safeParse({ id: "1", state: "Interviewed" }).success).toBe(false);
+  });
+});
+
+describe("Reporting schemas", () => {
+  it("requires startDate + endDate for companies", () => {
+    expect(ReportingCompaniesSchema.safeParse({}).success).toBe(false);
+    expect(ReportingCompaniesSchema.safeParse({ startDate: "2026-01-01", endDate: "2026-03-31" }).success).toBe(true);
+  });
+
+  it("accepts companies-specific filters and perimeter", () => {
+    const result = ReportingCompaniesSchema.safeParse({
+      startDate: "2026-01-01",
+      endDate: "2026-03-31",
+      companiesStates: [1, 2],
+      maxCompanies: 5,
+      showPercentage: true,
+      perimeterDynamic: ["agencies"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown filter name (strict) — guards against silent drops", () => {
+    // `agencies` is the WRONG name; the correct perimeter filter is `perimeterAgencies`.
+    expect(
+      ReportingCompaniesSchema.safeParse({ startDate: "2026-01-01", endDate: "2026-03-31", agencies: [1] }).success
+    ).toBe(false);
+  });
+
+  it("rejects maxCompanies / maxResources / maxProjects above 10", () => {
+    expect(
+      ReportingCompaniesSchema.safeParse({ startDate: "2026-01-01", endDate: "2026-03-31", maxCompanies: 11 }).success
+    ).toBe(false);
+    expect(ReportingResourcesSchema.safeParse({ maxResources: 11 }).success).toBe(false);
+    expect(ReportingProjectsSchema.safeParse({ maxProjects: 11 }).success).toBe(false);
+  });
+
+  it("treats dates as optional for resources and projects", () => {
+    expect(ReportingResourcesSchema.safeParse({ resourceStates: [3], period: "monthly" }).success).toBe(true);
+    expect(ReportingProjectsSchema.safeParse({ projectTypes: [1], projects: [42] }).success).toBe(true);
+  });
+
+  it("constrains reportingCategory enums per endpoint", () => {
+    expect(ReportingResourcesSchema.safeParse({ reportingCategory: "showByPeriods" }).success).toBe(true);
+    expect(ReportingResourcesSchema.safeParse({ reportingCategory: "globalSynthesis" }).success).toBe(false);
+    expect(
+      ReportingSynthesisSchema.safeParse({ startDate: "2026-01-01", reportingCategory: "billingSynthesis" }).success
+    ).toBe(true);
+    expect(ReportingSynthesisSchema.safeParse({ startDate: "2026-01-01", reportingType: "targetsData" }).success).toBe(
+      true
+    );
+  });
+
+  it("accepts production-plan filters with required dates", () => {
+    expect(
+      ReportingProductionPlansSchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-03-31",
+        positioningStates: [1],
+        positioningPeriod: "running",
+        showContracts: true,
+      }).success
+    ).toBe(true);
+    expect(ReportingProductionPlansSchema.safeParse({ positioningStates: [1] }).success).toBe(false);
   });
 });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1259,52 +1259,185 @@ export const NotificationSearchSchema = z
   .strict();
 
 // ---- Reporting schemas ----
-// `/reporting-companies` and `/reporting-resources` require `startDate` +
-// `endDate` (YYYY-MM-DD); the others tolerate omission but still benefit from
-// a period filter.
-export const ReportingDateRequiredSchema = z
+// Sources (one search.raml per endpoint):
+//   https://doc.boondmanager.com/api-externe/raml-build/resources/reportingCompanies/search.raml
+//   .../reportingProjects/search.raml  .../reportingResources/search.raml
+//   .../reportingSynthesis/search.raml .../reportingProductionPlans/search.raml
+// Every reporting endpoint carries the `searchable` trait (perimeter filters)
+// plus endpoint-specific filters. These were previously dropped — only
+// startDate/endDate/keywords were forwarded — so a "filtered" reporting query
+// silently returned the full perimeter. Each tool now exposes its real filters.
+//
+// `period`/`periodDynamic` value sets are large and differ slightly per endpoint,
+// so they stay `z.string()` (documented in the description) rather than a strict
+// enum that could reject a value the API actually accepts. The small, stable
+// enums (reportingCategory, reportingType, positioningPeriod, useCache) are typed.
+const reportingPeriodField = z
+  .string()
+  .optional()
+  .describe(
+    "Découpage temporel : 'onePeriod' (unique, entre startDate/endDate), 'dynamicPeriod' (selon periodDynamic), " +
+      "'monthly' (6 mois depuis startDate), 'quarterly', 'semiAnnual', 'annual'. La synthèse accepte aussi 'weekly'."
+  );
+const reportingPeriodDynamicField = z
+  .string()
+  .optional()
+  .describe(
+    "Période dynamique relative à aujourd'hui (avec period='dynamicPeriod') : today, thisWeek, thisMonth, " +
+      "thisTrimester, thisSemester, thisYear, thisFiscalYear, yesterday, lastWeek, lastMonth, lastTrimester, " +
+      "lastSemester, lastYear, lastFiscalYear, tomorrow, nextWeek, nextMonth, nextTrimester, nextSemester, " +
+      "nextYear, nextFiscalYear, lastCustomPeriod, nextCustomPeriod."
+  );
+const reportingPeriodDynamicParametersField = z
+  .string()
+  .optional()
+  .describe("Paramètres de la période personnalisée (utilisé avec periodDynamic=lastCustomPeriod/nextCustomPeriod).");
+const reportingScorecardsField = strArray("IDs des scorecards (indicateurs) à retourner.");
+const reportingUseCacheField = z
+  .enum(["withCache", "withoutCache"])
+  .optional()
+  .describe("Cache de reporting : 'withCache' (valeurs mises en cache) ou 'withoutCache' (recalcul, défaut).");
+const reportingResourcesField = intArray("Filtrer sur ces IDs de ressources.");
+const reportingProjectsField = intArray("Filtrer sur ces IDs de projets.");
+const reportingContactsField = intArray("Filtrer sur ces IDs de contacts.");
+const reportingCompaniesField = intArray("Filtrer sur ces IDs de sociétés.");
+const reportingMaxField = (entity: string) =>
+  z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe(`Nombre de ${entity} par page (1-10, défaut 1). Le nombre de résultats = ${entity} × indicateurs.`);
+
+// Perimeter + period filters shared by every reporting endpoint (searchable trait).
+const reportingCommonFields = {
+  keywords: z.string().optional().describe("Mots-clés."),
+  perimeterManagers: perimeterManagersField,
+  perimeterAgencies: perimeterAgenciesField,
+  perimeterPoles: perimeterPolesField,
+  perimeterBusinessUnits: perimeterBusinessUnitsField,
+  perimeterDynamic: perimeterDynamicField,
+  narrowPerimeter: narrowPerimeterField,
+  periodDynamic: reportingPeriodDynamicField,
+  periodDynamicParameters: reportingPeriodDynamicParametersField,
+  scorecards: reportingScorecardsField,
+  useCache: reportingUseCacheField,
+  page: pageField,
+  pageSize: pageSizeField,
+};
+
+const requiredDate = (label: string) =>
+  z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .describe(`${label} (YYYY-MM-DD). Requis par l'API.`);
+const optionalDate = (label: string) =>
+  z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional()
+    .describe(`${label} (YYYY-MM-DD).`);
+
+export const ReportingCompaniesSchema = z
   .object({
-    startDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .describe("Date de début YYYY-MM-DD. Requis."),
-    endDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .describe("Date de fin YYYY-MM-DD. Requis."),
-    keywords: z.string().optional().describe("Mots-clés."),
-    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-    pageSize: z
-      .number()
-      .int()
-      .min(1)
-      .max(MAX_PAGE_SIZE)
-      .default(DEFAULT_PAGE_SIZE)
-      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+    ...reportingCommonFields,
+    startDate: requiredDate("Date de début"),
+    endDate: requiredDate("Date de fin"),
+    companiesStates: intArray("IDs d'états de sociétés (dictionnaire setting.state.company)."),
+    maxCompanies: reportingMaxField("sociétés"),
+    showPercentage: z.boolean().optional().describe("Afficher les valeurs en pourcentage plutôt qu'en valeur réelle."),
+    companies: reportingCompaniesField,
   })
   .strict();
 
-export const ReportingDateOptionalSchema = z
+export const ReportingProjectsSchema = z
   .object({
-    startDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
+    ...reportingCommonFields,
+    startDate: optionalDate("Date de début"),
+    endDate: optionalDate("Date de fin"),
+    projectTypes: intArray("IDs de types de projets (dictionnaire setting.typeOf.project)."),
+    projectStates: intArray("IDs d'états de projets (dictionnaire setting.state.project)."),
+    maxProjects: reportingMaxField("projets"),
+    resources: reportingResourcesField,
+    projects: reportingProjectsField,
+    contacts: reportingContactsField,
+    companies: reportingCompaniesField,
+  })
+  .strict();
+
+export const ReportingResourcesSchema = z
+  .object({
+    ...reportingCommonFields,
+    startDate: optionalDate("Date de début"),
+    endDate: optionalDate("Date de fin"),
+    reportingCategory: z
+      .enum(["showByResources", "showByPeriods"])
       .optional()
-      .describe("Date de début YYYY-MM-DD."),
-    endDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .describe("Vue : 'showByResources' (défaut, sans returnedPeriod) ou 'showByPeriods' (returnedPeriod requis)."),
+    maxResources: reportingMaxField("ressources"),
+    resourceTypes: intArray("IDs de types de ressources (dictionnaire setting.typeOf.resource)."),
+    resourceStates: intArray("IDs d'états de ressources (dictionnaire setting.state.resource)."),
+    period: reportingPeriodField,
+    resources: reportingResourcesField,
+    projects: reportingProjectsField,
+    contacts: reportingContactsField,
+    companies: reportingCompaniesField,
+  })
+  .strict();
+
+export const ReportingSynthesisSchema = z
+  .object({
+    ...reportingCommonFields,
+    startDate: requiredDate("Date de début"),
+    endDate: optionalDate("Date de fin"),
+    reportingType: z
+      .enum(["realData", "targetsData"])
       .optional()
-      .describe("Date de fin YYYY-MM-DD."),
-    keywords: z.string().optional().describe("Mots-clés."),
-    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-    pageSize: z
-      .number()
-      .int()
-      .min(1)
-      .max(MAX_PAGE_SIZE)
-      .default(DEFAULT_PAGE_SIZE)
-      .describe(`Nombre de résultats par page (max: ${MAX_PAGE_SIZE}, défaut: ${DEFAULT_PAGE_SIZE})`),
+      .describe("Type de données : 'realData' (défaut, réel) ou 'targetsData' (objectifs)."),
+    reportingCategory: z
+      .enum([
+        "commercialSynthesis",
+        "humanResourcesSynthesis",
+        "recruitmentSynthesis",
+        "activityExpensesSynthesis",
+        "billingSynthesis",
+        "globalSynthesis",
+      ])
+      .optional()
+      .describe(
+        "Catégorie de synthèse (défaut 'commercialSynthesis') : commercial, RH, recrutement, activité & frais, " +
+          "facturation, ou globale. `resources` n'est pas disponible hors d'une vue par ressources."
+      ),
+    period: reportingPeriodField,
+    resources: reportingResourcesField,
+    projects: reportingProjectsField,
+    contacts: reportingContactsField,
+    companies: reportingCompaniesField,
+    compareIndicators: strArray("Indicateurs à comparer entre deux périodes."),
+    compareIndicatorsPeriod: z
+      .string()
+      .optional()
+      .describe("Période de comparaison des indicateurs (défaut 'period')."),
+  })
+  .strict();
+
+export const ReportingProductionPlansSchema = z
+  .object({
+    ...reportingCommonFields,
+    startDate: requiredDate("Date de début"),
+    endDate: requiredDate("Date de fin"),
+    resourceTypes: intArray("IDs de types de ressources (dictionnaire setting.typeOf.resource)."),
+    resourceStates: intArray("IDs d'états de ressources (dictionnaire setting.state.resource)."),
+    positioningStates: intArray("IDs d'états de positionnement (dictionnaire setting.state.positioning)."),
+    positioningPeriod: z
+      .enum(["created", "running"])
+      .optional()
+      .describe("'created' (positionnements créés entre les dates, défaut) ou 'running' (en cours sur la période)."),
+    showContracts: z.boolean().optional().describe("Afficher les contrats associés."),
+    projects: reportingProjectsField,
+    contacts: reportingContactsField,
+    companies: reportingCompaniesField,
   })
   .strict();
 
@@ -1388,3 +1521,8 @@ export type ReferenceCreateInput = z.infer<typeof ReferenceCreateSchema>;
 export type ReferenceUpdateInput = z.infer<typeof ReferenceUpdateSchema>;
 export type ReferenceIdInput = z.infer<typeof ReferenceIdSchema>;
 export type DocumentCreateInput = z.infer<typeof DocumentCreateSchema>;
+export type ReportingCompaniesInput = z.infer<typeof ReportingCompaniesSchema>;
+export type ReportingProjectsInput = z.infer<typeof ReportingProjectsSchema>;
+export type ReportingResourcesInput = z.infer<typeof ReportingResourcesSchema>;
+export type ReportingSynthesisInput = z.infer<typeof ReportingSynthesisSchema>;
+export type ReportingProductionPlansInput = z.infer<typeof ReportingProductionPlansSchema>;

--- a/src/tools/reporting.test.ts
+++ b/src/tools/reporting.test.ts
@@ -36,4 +36,45 @@ describe("registerReportingTools", () => {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
   });
+
+  function shapeKeysFor(name: string): string[] {
+    if (vi.mocked(server.registerTool).mock.calls.length === 0) registerReportingTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === name);
+    if (!call) throw new Error(`tool ${name} not registered`);
+    // inputSchema is the full strict ZodObject; introspect its declared keys.
+    const schema = call[1].inputSchema as unknown as { shape: Record<string, unknown> };
+    return Object.keys(schema.shape);
+  }
+
+  it("should expose the shared perimeter + period filters on every endpoint", () => {
+    for (const name of [
+      "boond_reporting_companies",
+      "boond_reporting_projects",
+      "boond_reporting_resources",
+      "boond_reporting_synthesis",
+      "boond_reporting_production_plans",
+    ]) {
+      expect(shapeKeysFor(name)).toEqual(
+        expect.arrayContaining(["perimeterDynamic", "perimeterManagers", "perimeterAgencies", "periodDynamic"])
+      );
+    }
+  });
+
+  it("should wire each endpoint's specific filters (previously dropped)", () => {
+    expect(shapeKeysFor("boond_reporting_companies")).toEqual(
+      expect.arrayContaining(["companiesStates", "companies", "maxCompanies", "showPercentage"])
+    );
+    expect(shapeKeysFor("boond_reporting_projects")).toEqual(
+      expect.arrayContaining(["projectTypes", "projectStates", "maxProjects", "resources"])
+    );
+    expect(shapeKeysFor("boond_reporting_resources")).toEqual(
+      expect.arrayContaining(["reportingCategory", "resourceStates", "period", "maxResources"])
+    );
+    expect(shapeKeysFor("boond_reporting_synthesis")).toEqual(
+      expect.arrayContaining(["reportingType", "reportingCategory", "compareIndicators"])
+    );
+    expect(shapeKeysFor("boond_reporting_production_plans")).toEqual(
+      expect.arrayContaining(["positioningStates", "positioningPeriod", "showContracts"])
+    );
+  });
 });

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1,5 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ReportingDateOptionalSchema, ReportingDateRequiredSchema } from "../schemas/index.js";
+import type { ZodType } from "zod";
+import type { SearchParams } from "../types.js";
+import {
+  ReportingCompaniesSchema,
+  ReportingProjectsSchema,
+  ReportingResourcesSchema,
+  ReportingSynthesisSchema,
+  ReportingProductionPlansSchema,
+} from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse } from "../services/boond-client.js";
 
 interface ReportingEndpoint {
@@ -8,8 +16,12 @@ interface ReportingEndpoint {
   title: string;
   description: string;
   entity: string;
+  // Full strict ZodObject (preserves rejection of unknown filter names — see CLAUDE.md).
+  schema: ZodType;
   /** When true, the API rejects requests without `startDate` + `endDate` (422). */
   datesRequired: boolean;
+  /** Endpoint-specific filters surfaced in the tool description. */
+  filters: string;
 }
 
 export function registerReportingTools(server: McpServer): void {
@@ -18,46 +30,57 @@ export function registerReportingTools(server: McpServer): void {
       name: "companies",
       path: "/reporting-companies",
       title: "Reporting sociétés",
-      description: "Recherche le reporting des sociétés (CA, marge, activité...).",
+      description: "Reporting des sociétés (CA, marge, activité...).",
       entity: "reporting société",
+      schema: ReportingCompaniesSchema,
       datesRequired: true,
+      filters: "companiesStates, companies, maxCompanies, showPercentage",
     },
     {
       name: "projects",
       path: "/reporting-projects",
       title: "Reporting projets",
-      description: "Recherche le reporting des projets (CA, marge, rentabilité...).",
+      description: "Reporting des projets (CA, marge, rentabilité...).",
       entity: "reporting projet",
+      schema: ReportingProjectsSchema,
       datesRequired: false,
+      filters: "projectTypes, projectStates, resources, projects, contacts, companies, maxProjects",
     },
     {
       name: "resources",
       path: "/reporting-resources",
       title: "Reporting ressources",
-      description: "Recherche le reporting des ressources (taux d'occupation, CA, productivité...).",
+      description: "Reporting des ressources (taux d'occupation, CA, productivité...).",
       entity: "reporting ressource",
-      datesRequired: true,
+      schema: ReportingResourcesSchema,
+      datesRequired: false,
+      filters:
+        "reportingCategory, resourceTypes, resourceStates, period, resources/projects/contacts/companies, maxResources",
     },
     {
       name: "synthesis",
       path: "/reporting-synthesis",
       title: "Reporting synthèse",
-      description: "Recherche le reporting de synthèse globale.",
+      description: "Reporting de synthèse globale (commercial, RH, recrutement, facturation...).",
       entity: "reporting synthèse",
+      schema: ReportingSynthesisSchema,
       datesRequired: true,
+      filters: "reportingType, reportingCategory, period, resources/projects/contacts/companies, compareIndicators",
     },
     {
       name: "production_plans",
       path: "/reporting-production-plans",
       title: "Reporting plans de production",
-      description: "Recherche le reporting des plans de production.",
+      description: "Reporting des plans de production (disponibilités, positionnements...).",
       entity: "reporting plan de production",
+      schema: ReportingProductionPlansSchema,
       datesRequired: true,
+      filters:
+        "resourceTypes, resourceStates, positioningStates, positioningPeriod, showContracts, projects/contacts/companies",
     },
   ];
 
   for (const ep of reportingEndpoints) {
-    const schema = ep.datesRequired ? ReportingDateRequiredSchema : ReportingDateOptionalSchema;
     const datesNote = ep.datesRequired ? "\n⚠️ `startDate` + `endDate` (YYYY-MM-DD) sont REQUIS par l'API." : "";
     server.registerTool(
       `boond_reporting_${ep.name}`,
@@ -65,13 +88,11 @@ export function registerReportingTools(server: McpServer): void {
         title: ep.title,
         description: `${ep.description}${datesNote}
 
-Args:
-  - startDate, endDate (string${ep.datesRequired ? ", requis" : ", optional"}): YYYY-MM-DD
-  - keywords (string, optional): Termes de recherche
-  - page, pageSize: Pagination
+Filtres clés : périmètre (perimeterDynamic/perimeterManagers/perimeterAgencies...), période (period, periodDynamic), ${ep.filters}.
+Les états/types sont des IDs entiers issus de boond_application_dictionary. Sans filtre de périmètre, le reporting porte sur tout le périmètre autorisé.
 
 Returns: Données de reporting.`,
-        inputSchema: schema,
+        inputSchema: ep.schema,
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -79,8 +100,8 @@ Returns: Données de reporting.`,
           openWorldHint: true,
         },
       },
-      async (params: { startDate?: string; endDate?: string; keywords?: string; page?: number; pageSize?: number }) => {
-        const query = buildSearchQuery(params);
+      async (params: unknown) => {
+        const query = buildSearchQuery(params as SearchParams);
         const response = await apiRequest(ep.path, "GET", undefined, query);
         return {
           content: [{ type: "text" as const, text: formatListResponse(response, ep.entity) }],


### PR DESCRIPTION
## Problème

Les 5 outils `boond_reporting_*` ne transmettaient que `startDate/endDate/keywords/page/pageSize`. **Tous les autres `queryParameters` de la RAML étaient silencieusement ignorés** : une recherche reporting « filtrée » renvoyait en réalité tout le périmètre autorisé. Même classe de bug que les filtres de positionnements corrigés en #107.

Vérifié sur la RAML officielle (`resources/reporting{Companies,Projects,Resources,Synthesis,ProductionPlans}/search.raml`) : chaque endpoint porte le trait `searchable` (filtres de périmètre) + des filtres spécifiques.

## Changement

Chaque endpoint reçoit un schéma Zod `.strict()` dédié, modelé sur sa `search.raml` :

| Endpoint | Filtres spécifiques ajoutés | Dates |
|----------|------------------------------|-------|
| companies | `companiesStates`, `companies[]`, `maxCompanies`, `showPercentage` | requises |
| projects | `projectTypes`, `projectStates`, `maxProjects`, `resources/projects/contacts/companies[]` | optionnelles |
| resources | `reportingCategory`, `resourceTypes`, `resourceStates`, `period`, `maxResources`, ids entités | optionnelles |
| synthesis | `reportingType`, `reportingCategory`, `period`, `compareIndicators` | startDate requis |
| production-plans | `positioningStates`, `positioningPeriod`, `showContracts` | requises |

Filtres **communs à tous** : `perimeterDynamic`, `perimeterManagers`, `perimeterAgencies`, `perimeterPoles`, `perimeterBusinessUnits`, `narrowPerimeter`, `periodDynamic`, `periodDynamicParameters`, `scorecards`, `useCache`.

## Garde-fous

- Schémas `.strict()` : un nom de filtre erroné (ex. `agencies` au lieu de `perimeterAgencies`) est **rejeté** au lieu d'être silencieusement ignoré.
- L'objet `ZodObject` complet est passé en `inputSchema` (pas `.shape`) pour **préserver** ce rejet strict (`.shape` aurait ré-emballé sans strict → passthrough).
- `period`/`periodDynamic` restent `z.string()` (valeurs nombreuses et variables selon l'endpoint) ; les petits enums stables (`reportingCategory`, `reportingType`, `positioningPeriod`, `useCache`) sont typés.

## Tests / vérifications

- +9 tests (validation des schémas : dates requises, rejet strict, bornes `max*` 1-10, enums par endpoint ; câblage des filtres par outil). **654 tests** au total (était 645).
- `lint`, `typecheck`, `build`, `docs:tools:check` ✅
- **Aucun nouvel outil** (toujours 175) — TOOLS.md inchangé, pas de drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)