### PR TITLE
fix: map opportunity `name` to API `title` attribute (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.6.2] - 2026-06-18
+
+Correctif de l'outil `boond_opportunities_create` (et `boond_opportunities_update`) qui échouait systématiquement. Aucun changement de catalogue — toujours **175 outils, 11 prompts, 22 ressources**.
+
+### Fixed
+
+- **`boond_opportunities_create` renvoyait toujours `422 — 1017 Missing required attribute /data/attributes/title`** ([#113](https://github.com/fauguste/boondmanager-mcp-server/issues/113)) : le champ `name` du schéma était transmis tel quel dans les attributs JSON:API, alors que l'API BoondManager attend le titre de l'opportunité sous `/data/attributes/title`. L'attribut `title` n'était donc jamais envoyé et la création échouait quel que soit l'input. Le handler mappe désormais `name` → `title` à la création et à la mise à jour (`boond_opportunities_update`). Lors d'un update, `title` reste omis si `name` n'est pas fourni, donc le titre existant n'est pas écrasé.
+
 ## [2.6.1] - 2026-06-15
 
 Correctif de packaging : le bundle `.mcpb` passe de ~40 Mo à ~3 Mo et redevient installable sur les hôtes qui appliquent une limite de taille (Claude Cowork / Claude Desktop). Aucun changement de comportement des outils — toujours **175 outils, 11 prompts, 22 ressources**.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.6.1/boondmanager-mcp-server-v2.6.1.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.6.2/boondmanager-mcp-server-v2.6.2.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/tools/opportunities.test.ts
+++ b/src/tools/opportunities.test.ts
@@ -1,11 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerOpportunityTools } from "./opportunities.js";
+import * as boondClient from "../services/boond-client.js";
 
 function createMockServer() {
   return {
     registerTool: vi.fn(),
   } as unknown as McpServer;
+}
+
+function getHandler(server: McpServer, name: string) {
+  const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === name);
+  if (!call) throw new Error(`tool ${name} not registered`);
+  return call[2] as (params: unknown) => Promise<unknown>;
 }
 
 describe("registerOpportunityTools", () => {
@@ -42,15 +49,19 @@ describe("registerOpportunityTools", () => {
 
   it("should register tab tools as readOnly and non-destructive", () => {
     registerOpportunityTools(server);
-    const tabCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && [
-        "boond_opportunities_information",
-        "boond_opportunities_actions",
-        "boond_opportunities_positionings",
-        "boond_opportunities_projects",
-        "boond_opportunities_simulation",
-      ].includes(c[0] as string)
-    );
+    const tabCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          [
+            "boond_opportunities_information",
+            "boond_opportunities_actions",
+            "boond_opportunities_positionings",
+            "boond_opportunities_projects",
+            "boond_opportunities_simulation",
+          ].includes(c[0] as string)
+      );
 
     expect(tabCalls).toHaveLength(5);
     for (const call of tabCalls) {
@@ -58,5 +69,72 @@ describe("registerOpportunityTools", () => {
       expect(metadata.annotations?.readOnlyHint).toBe(true);
       expect(metadata.annotations?.destructiveHint).toBe(false);
     }
+  });
+
+  // Regression for issue #113: `name` must be sent to the Boond API as
+  // `/data/attributes/title`, otherwise POST /opportunities returns
+  // "1017 - Missing required attribute (parameter: /data/attributes/title)".
+  describe("name → title mapping (issue #113)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("maps `name` to `title` on create and keeps relationships", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "7", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_create");
+      await handler({ name: "Test opportunity", companyId: "12", contactId: "34" });
+
+      const [path, method, body] = apiSpy.mock.calls[0];
+      expect(path).toBe("/opportunities");
+      expect(method).toBe("POST");
+      const data = (
+        body as {
+          data: {
+            attributes: Record<string, unknown>;
+            relationships: Record<string, unknown>;
+          };
+        }
+      ).data;
+      expect(data.attributes.title).toBe("Test opportunity");
+      expect(data.attributes.name).toBeUndefined();
+      expect(data.relationships.company).toEqual({ data: { id: "12", type: "company" } });
+      expect(data.relationships.contact).toEqual({ data: { id: "34", type: "contact" } });
+    });
+
+    it("maps `name` to `title` on update", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "7", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_update");
+      await handler({ id: "7", name: "Renamed" });
+
+      const [path, method, body] = apiSpy.mock.calls[0];
+      expect(path).toBe("/opportunities/7");
+      expect(method).toBe("PATCH");
+      const attrs = (body as { data: { attributes: Record<string, unknown> } }).data.attributes;
+      expect(attrs.title).toBe("Renamed");
+      expect(attrs.name).toBeUndefined();
+    });
+
+    it("omits `title` on update when `name` is not provided", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "7", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_update");
+      await handler({ id: "7", note: "just a note" });
+
+      const [, , body] = apiSpy.mock.calls[0];
+      const attrs = (body as { data: { attributes: Record<string, unknown> } }).data.attributes;
+      expect(attrs).not.toHaveProperty("title");
+      expect(attrs.note).toBe("just a note");
+    });
   });
 });

--- a/src/tools/opportunities.ts
+++ b/src/tools/opportunities.ts
@@ -120,8 +120,10 @@ export function registerOpportunityTools(server: McpServer): void {
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, OpportunityCreateSchema, (params) => {
-    const { companyId, contactId, ...attrs } = params;
-    const body = buildJsonApiBody("opportunity", attrs);
+    // The Boond API expects the opportunity name under `/data/attributes/title`,
+    // so the schema's `name` field must be mapped to `title` (see issue #113).
+    const { companyId, contactId, name, ...rest } = params;
+    const body = buildJsonApiBody("opportunity", { title: name, ...rest });
     const relationships: Record<string, unknown> = {};
     if (companyId) relationships.company = { data: { id: companyId, type: "company" } };
     if (contactId) relationships.contact = { data: { id: contactId, type: "contact" } };
@@ -132,8 +134,10 @@ export function registerOpportunityTools(server: McpServer): void {
   });
 
   registerUpdateTool(server, OPTS, OpportunityUpdateSchema, (params) => {
-    const { id, ...attrs } = params;
-    return buildJsonApiBody("opportunity", attrs, id as string);
+    // Same `name` → `title` mapping as create (issue #113). `title` stays
+    // undefined when `name` is omitted, so buildJsonApiBody drops it.
+    const { id, name, ...rest } = params;
+    return buildJsonApiBody("opportunity", { title: name, ...rest }, id as string);
   });
 
   registerDeleteTool(server, OPTS);


### PR DESCRIPTION
## Summary

Fixes #113 — `boond_opportunities_create` always returned `422 — 1017 Missing required attribute (parameter: /data/attributes/title)`.

The schema exposes a `name` field, but the BoondManager API expects the opportunity title under `/data/attributes/title`. The create/update body builders forwarded `name` verbatim as a JSON:API attribute, so `title` was never sent and every creation failed regardless of input.

## Changes

- `src/tools/opportunities.ts`: map `name` → `title` in both the create and update body builders. On update, `title` is omitted when `name` is absent so the existing title is not overwritten.
- Regression tests covering the mapping on create (with company/contact relationships preserved), update, and the omit-on-update case.
- Version bump to **2.6.2** (`package.json`, `manifest.json`, `server.json`, lockfile) + CHANGELOG entry.

## Validation

- `npm test` — 657 tests passing
- `npm run lint`, `npm run typecheck`, `npm run build` — clean
- `npm run docs:tools:check` — TOOLS.md up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)