### PR TITLE
feat: Cursor/VS Code install badges + Gemini CLI extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,13 @@ jobs:
           PKG_VERSION=$(node -p "require('./package.json').version")
           MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
           SERVER_VERSION=$(node -p "require('./server.json').version")
-          echo "package.json:  $PKG_VERSION"
-          echo "manifest.json: $MANIFEST_VERSION"
-          echo "server.json:   $SERVER_VERSION"
-          if [ "$PKG_VERSION" != "$MANIFEST_VERSION" ] || [ "$PKG_VERSION" != "$SERVER_VERSION" ]; then
-            echo "ERROR: Version mismatch between package.json, manifest.json and server.json"
+          GEMINI_VERSION=$(node -p "require('./gemini-extension.json').version")
+          echo "package.json:         $PKG_VERSION"
+          echo "manifest.json:        $MANIFEST_VERSION"
+          echo "server.json:          $SERVER_VERSION"
+          echo "gemini-extension.json: $GEMINI_VERSION"
+          if [ "$PKG_VERSION" != "$MANIFEST_VERSION" ] || [ "$PKG_VERSION" != "$SERVER_VERSION" ] || [ "$PKG_VERSION" != "$GEMINI_VERSION" ]; then
+            echo "ERROR: Version mismatch between package.json, manifest.json, server.json and gemini-extension.json"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,7 +539,7 @@ Behavior notes:
 ## Releasing
 
 1. Update `CHANGELOG.md` — add a new `## [X.Y.Z] - YYYY-MM-DD` section at the top with the human-written notes (in French if matching the rest of the changelog). The release body is auto-extracted from this section by `release.yml`.
-2. Bump versions consistently: `package.json` + `manifest.json` + `server.json` (CI fails if any drift). Also bump the example URL inside `server.json.packages[1].identifier`.
+2. Bump versions consistently: `package.json` + `manifest.json` + `server.json` + `gemini-extension.json` (CI fails if any drift). Also bump the example URL inside `server.json.packages[1].identifier`.
 3. Sync `package-lock.json`: `npm install --package-lock-only`.
 4. Commit + tag + push: `git tag vX.Y.Z && git push origin main vX.Y.Z`. The `Release` workflow takes over.
 5. Post-tag, run the 6-point verification checklist in `docs/distribution.md` (npm version, MCP Registry, GitHub Release body, GHCR multi-arch pull, LobeHub mirror, Smithery refresh).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 [![GHCR](https://img.shields.io/badge/GHCR-fauguste%2Fboondmanager--mcp--server-181717?logo=github)](https://github.com/fauguste/boondmanager-mcp-server/pkgs/container/boondmanager-mcp-server)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+[![Add to Cursor](https://img.shields.io/badge/Add%20to-Cursor-000000?logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=boondmanager&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImJvb25kbWFuYWdlci1tY3Atc2VydmVyIl19)
+[![Install in VS Code](https://img.shields.io/badge/Install-VS%20Code-0098FF?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D)
+
 Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claude (Desktop, Cowork, Code) de rechercher, consulter, creer et modifier des enregistrements dans votre instance BoondManager.
 
 **175 outils** couvrant **38 domaines** de l'API BoondManager. Voir [TOOLS.md](./TOOLS.md) pour le catalogue auto-généré (outils + prompts + ressources).
@@ -356,6 +359,59 @@ Le serveur est listé sur le [marketplace MCP de LobeHub](https://lobehub.com/mc
 ```
 
 Ou utiliser le transport HTTP (voir section [Transports](#transports)) pour un deploiement partage en mode gateway.
+
+### Cursor
+
+Cliquez sur le badge **[Add to Cursor](https://cursor.com/install-mcp?name=boondmanager&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImJvb25kbWFuYWdlci1tY3Atc2VydmVyIl19)** en haut du README (ou ajoutez le serveur manuellement dans **Settings > MCP > Add new MCP server**). Renseignez ensuite l'authentification en ajoutant un bloc `env` au serveur dans `~/.cursor/mcp.json` :
+
+```json
+{
+  "mcpServers": {
+    "boondmanager": {
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_API_TOKEN": "votre_token_jwt"
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot / agent MCP)
+
+Cliquez sur le badge **[Install in VS Code](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D)** en haut du README, ou ajoutez le serveur a `.vscode/mcp.json` (par projet) ou a votre `settings.json` utilisateur :
+
+```json
+{
+  "servers": {
+    "boondmanager": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_API_TOKEN": "${input:boond_api_token}"
+      }
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+Le depot embarque un manifeste d'extension Gemini CLI (`gemini-extension.json`). Installez l'extension directement depuis GitHub :
+
+```bash
+gemini extensions install https://github.com/fauguste/boondmanager-mcp-server
+```
+
+Definissez ensuite l'authentification dans votre environnement (Gemini interpole `${VAR}` au demarrage) :
+
+```bash
+export BOOND_API_TOKEN="votre_token_jwt"
+# ou le trio JWT auto :
+export BOOND_USER_TOKEN="..." BOOND_CLIENT_TOKEN="..." BOOND_CLIENT_KEY="..."
+```
 
 ## Configuration
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -15,6 +15,8 @@ the reference for what gets pushed where on each release.
 | **GitHub Container Registry** | `ghcr.io/fauguste/boondmanager-mcp-server` | `docker/build-push-action@v6` in `release.yml`; multi-arch (amd64+arm64), tags `:latest`, `:X`, `:X.Y`, `:X.Y.Z` | every `v*` tag |
 | **LobeHub MCP marketplace** | [fauguste-boondmanager-mcp-server](https://lobehub.com/mcp/fauguste-boondmanager-mcp-server) | mirrors the MCP Registry (auto, ~24-48 h delay) | per release |
 | **Smithery** | [smithery.ai listing](https://smithery.ai/server/@fauguste/boondmanager-mcp-server) | reads `smithery.yaml` from this repo | per push to `main` |
+| **Gemini CLI extension** | `gemini extensions install https://github.com/fauguste/boondmanager-mcp-server` | reads `gemini-extension.json` from repo root | on install (reads the default branch) |
+| **Cursor / VS Code (install badges)** | deeplinks in `README.md` (no package) | static base64/url-encoded `npx` config baked into the badge URLs | manual (only if the `npx` invocation changes) |
 
 ## One-time setup (manual)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,18 @@
+{
+  "name": "boondmanager",
+  "version": "2.6.2",
+  "description": "Serveur MCP pour l'API BoondManager (ERP/CRM ESN) - 175 outils, 11 prompts, 22 ressources.",
+  "mcpServers": {
+    "boondmanager": {
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_BASE_URL": "${BOOND_BASE_URL}",
+        "BOOND_USER_TOKEN": "${BOOND_USER_TOKEN}",
+        "BOOND_CLIENT_TOKEN": "${BOOND_CLIENT_TOKEN}",
+        "BOOND_CLIENT_KEY": "${BOOND_CLIENT_KEY}",
+        "BOOND_API_TOKEN": "${BOOND_API_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Pourquoi

MCP est un protocole **agnostique du client** : le serveur fonctionne déjà tel quel avec n'importe quel hôte MCP, sans recompiler un « package par LLM ». Cette PR ajoute les **manifestes d'installation propres à chaque client** pour élargir la portée au-delà du `.mcpb` de Claude Desktop.

## Changements

- **README** — badges **Add to Cursor** et **Install in VS Code** (redirections HTTP hébergées, car GitHub neutralise les schémas `cursor://` / `vscode:`), plus sections d'installation Cursor, VS Code et Gemini CLI.
- **`gemini-extension.json`** (nouveau) — manifeste d'extension Gemini CLI, l'équivalent Google du bundle `.mcpb`. Installable via `gemini extensions install https://github.com/fauguste/boondmanager-mcp-server`.
- **`docs/distribution.md`** — traçabilité des nouveaux canaux.
- **CI** — le check *version consistency* couvre désormais `gemini-extension.json` (plus de dérive silencieuse de version).
- **CLAUDE.md** — `gemini-extension.json` ajouté au bump de version lors d'une release.

## Notes

- Aucun changement de surface MCP (outils/prompts/ressources) → `npm run docs:tools` non requis.
- Les badges utilisent une config `npx` statique encodée (base64 pour Cursor, URL-encoded pour VS Code) ; à régénérer uniquement si l'invocation `npx` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)