### PR TITLE
feat: LM Studio + Goose buttons, non-Claude host docs, HTTP auth fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,18 @@
 [![GHCR](https://img.shields.io/badge/GHCR-fauguste%2Fboondmanager--mcp--server-181717?logo=github)](https://github.com/fauguste/boondmanager-mcp-server/pkgs/container/boondmanager-mcp-server)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+**Installation 1-clic :**
+
 [![Add to Cursor](https://img.shields.io/badge/Add%20to-Cursor-000000?logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=boondmanager&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImJvb25kbWFuYWdlci1tY3Atc2VydmVyIl19)
 [![Install in VS Code](https://img.shields.io/badge/Install-VS%20Code-0098FF?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/Install-VS%20Code%20Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D&quality=insiders)
+[![Add to LM Studio](https://files.lmstudio.ai/deeplink/mcp-install-light.svg)](lmstudio://add_mcp?name=boondmanager&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImJvb25kbWFuYWdlci1tY3Atc2VydmVyIl19)
+[![Add to Goose](https://img.shields.io/badge/Add%20to-Goose-26B5A4)](goose://extension?cmd=npx&arg=-y&arg=boondmanager-mcp-server&id=boondmanager&name=BoondManager&description=Serveur%20MCP%20BoondManager%20%28ERP%2FCRM%20ESN%29)
+
+[![Smithery](https://smithery.ai/badge/@fauguste/boondmanager-mcp-server)](https://smithery.ai/server/@fauguste/boondmanager-mcp-server)
+[![Glama](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server/badge)](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server)
+
+> Les boutons **LM Studio** et **Goose** utilisent leurs schémas d'application natifs (`lmstudio://`, `goose://`). GitHub n'autorise pas les liens à schéma non-HTTP : l'image s'affiche mais le clic peut être inopérant depuis github.com. Utilisez alors la configuration copier-coller des sections [Installation](#installation) ci-dessous.
 
 Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claude (Desktop, Cowork, Code) de rechercher, consulter, creer et modifier des enregistrements dans votre instance BoondManager.
 
@@ -397,6 +407,32 @@ Cliquez sur le badge **[Install in VS Code](https://insiders.vscode.dev/redirect
 }
 ```
 
+### LM Studio
+
+Cliquez sur le badge **Add to LM Studio** en haut du README, ou dans LM Studio : **Program > Install > Edit `mcp.json`** et ajoutez :
+
+```json
+{
+  "mcpServers": {
+    "boondmanager": {
+      "command": "npx",
+      "args": ["-y", "boondmanager-mcp-server"],
+      "env": {
+        "BOOND_API_TOKEN": "votre_token_jwt"
+      }
+    }
+  }
+}
+```
+
+### Goose
+
+Cliquez sur le badge **Add to Goose** en haut du README (deeplink `goose://`), ou ajoutez une extension de type **STDIO** dans **Settings > Extensions > Add** avec la commande `npx -y boondmanager-mcp-server` et la variable d'environnement `BOOND_API_TOKEN`. En CLI :
+
+```bash
+goose session --with-extension "npx -y boondmanager-mcp-server"
+```
+
 ### Gemini CLI
 
 Le depot embarque un manifeste d'extension Gemini CLI (`gemini-extension.json`). Installez l'extension directement depuis GitHub :
@@ -649,6 +685,18 @@ docker compose logs -f mcp
 
 > **Securite** : le serveur HTTP est stateless et ne stocke aucun secret BoondManager. Chaque utilisateur authentifie le serveur via son propre token OAuth2 (issu de sa propre App BoondManager), et toutes les actions sont attribuees a son identite dans l'audit log Boond. Derriere un reverse proxy : terminez TLS (HTTPS), forwardez l'en-tete `Authorization`, et reglez `MCP_HTTP_PUBLIC_URL` sur l'URL publique pour que la discovery soit coherente.
 
+### Clients distants non-Claude (ChatGPT, OpenAI / Gemini Agents SDK)
+
+MCP est un protocole **agnostique du modele** : le meme endpoint HTTP/OAuth2 est consomme tel quel par tout hote compatible MCP, pas seulement Claude. **Aucun package ni build specifique a un LLM n'est requis** — il suffit de pointer l'hote sur votre URL `MCP_HTTP_PUBLIC_URL`.
+
+| Hote | Comment brancher le serveur |
+|------|-----------------------------|
+| **ChatGPT (connecteurs / Developer mode)** | Ajouter un connecteur MCP distant pointant sur l'URL HTTP ; l'OAuth2 est decouvert via la metadata `/.well-known/oauth-protected-resource`. |
+| **OpenAI Agents SDK** | Declarer un `HostedMCPTool` / serveur MCP distant avec l'URL HTTP et le flux OAuth2. |
+| **Google Gemini (Agents SDK / Vertex)** | Enregistrer le serveur MCP distant cote SDK ; en local, l'extension Gemini CLI (voir [Installation](#gemini-cli)) couvre le transport stdio. |
+
+Le contrat est identique a celui de Claude Code en HTTP (voir l'exemple `claude mcp add --transport http` ci-dessus) : seule la maniere de declarer le serveur cote client change.
+
 ## Exemples d'utilisation
 
 Une fois configure, vous pouvez demander a Claude :
@@ -758,7 +806,7 @@ boondmanager-mcp-server/
 
 - Les credentials BoondManager (JWT ou BasicAuth) ne transitent jamais via le protocole MCP -- ils sont configures en variables d'environnement cote serveur uniquement
 - En mode **stdio**, le serveur tourne en local, aucun port reseau n'est expose
-- En mode **streamable HTTP**, protegez l'endpoint avec `MCP_HTTP_BEARER_TOKEN` + TLS (HTTPS via reverse proxy) et restreignez l'acces reseau a votre gateway
+- En mode **streamable HTTP**, l'authentification est un **OAuth2 protected resource** : chaque requete MCP porte son propre `Authorization: Bearer <token>` (le serveur ne stocke aucun secret). Terminez TLS (HTTPS via reverse proxy), forwardez l'en-tete `Authorization`, reglez `MCP_HTTP_PUBLIC_URL` sur l'URL publique, et activez la protection anti DNS rebinding via `MCP_HTTP_ALLOWED_HOSTS`. Restreignez aussi l'acces reseau a votre gateway. Voir [docs/oauth.md](docs/oauth.md).
 - Compatible avec les exigences ISO 27001
 - L'API BoondManager est hebergee en France et conforme RGPD
 - Authentification BoondManager : JWT (recommande), BasicAuth, ou JWT construit automatiquement a partir des composants

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -16,7 +16,9 @@ the reference for what gets pushed where on each release.
 | **LobeHub MCP marketplace** | [fauguste-boondmanager-mcp-server](https://lobehub.com/mcp/fauguste-boondmanager-mcp-server) | mirrors the MCP Registry (auto, ~24-48 h delay) | per release |
 | **Smithery** | [smithery.ai listing](https://smithery.ai/server/@fauguste/boondmanager-mcp-server) | reads `smithery.yaml` from this repo | per push to `main` |
 | **Gemini CLI extension** | `gemini extensions install https://github.com/fauguste/boondmanager-mcp-server` | reads `gemini-extension.json` from repo root | on install (reads the default branch) |
-| **Cursor / VS Code (install badges)** | deeplinks in `README.md` (no package) | static base64/url-encoded `npx` config baked into the badge URLs | manual (only if the `npx` invocation changes) |
+| **Install badges (Cursor, VS Code, VS Code Insiders, LM Studio, Goose)** | deeplinks in `README.md` (no package) | static base64/url-encoded `npx` config baked into the badge URLs | manual (only if the `npx` invocation changes) |
+| **Glama badge** | [glama.ai/mcp/servers/fauguste/boondmanager-mcp-server](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server) | live badge image served by Glama (`/badge`); listing auto-mirrors the MCP Registry | auto |
+| **Smithery badge** | [smithery.ai/server/@fauguste/boondmanager-mcp-server](https://smithery.ai/server/@fauguste/boondmanager-mcp-server) | live badge image served by Smithery (`/badge/@…`) | auto |
 
 ## One-time setup (manual)
 


### PR DESCRIPTION
Suite de #115 (déjà mergée). Élargit la couverture clients/LLM et corrige une note de sécurité périmée.

## Boutons d'installation (README)
- **LM Studio** — badge officiel + deeplink `lmstudio://add_mcp` (config base64).
- **Goose (Block)** — deeplink `goose://extension`.
- **VS Code Insiders** — variante du bouton VS Code (`quality=insiders`).
- Sections copier-coller pour LM Studio et Goose (les schémas natifs `lmstudio://`/`goose://` peuvent être non-cliquables depuis github.com → fallback config).

## Badges écosystème
- **Glama** (image `/badge` vérifiée → PNG 200) et **Smithery** (`/badge/@…`, convention répandue ; rendu à vérifier une fois en ligne car le WAF Smithery bloque la vérif automatique).

## Documentation portée non-Claude (#6)
- Tableau expliquant que le **transport HTTP/OAuth2 existant** est consommé tel quel par ChatGPT (connecteurs), OpenAI Agents SDK et Gemini — **aucun package par LLM requis**.

## Fix sécurité (#1)
- La note « protégez l'endpoint avec `MCP_HTTP_BEARER_TOKEN` » décrivait une variable **inexistante dans le code**. Remplacée par la vraie reco OAuth2 protected resource (TLS, forward `Authorization`, `MCP_HTTP_PUBLIC_URL`, `MCP_HTTP_ALLOWED_HOSTS`).

## Traçabilité
- `docs/distribution.md` : nouvelles lignes pour les boutons et les badges Glama/Smithery.

## Notes
- Aucun changement de surface MCP → `npm run docs:tools` non requis.
- Encodages des deeplinks générés programmatiquement (base64 / url-encode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)