### PR TITLE
fix: remove Smithery badge, shrink Glama badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 [![Install in VS Code](https://img.shields.io/badge/Install-VS%20Code-0098FF?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/Install-VS%20Code%20Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=boondmanager&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22boondmanager-mcp-server%22%5D%7D&quality=insiders)
 
-[![Smithery](https://img.shields.io/badge/Smithery-listing-ea580c)](https://smithery.ai/server/@fauguste/boondmanager-mcp-server)
-[![Glama](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server/badge)](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server)
+<a href="https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server"><img src="https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server/badge" alt="Glama" width="180" /></a>
 
 > **LM Studio**, **Goose** et **Gemini CLI** s'installent via leur procédure dédiée (deeplink natif ou commande) — voir la section [Installation](#installation). GitHub ne rend pas cliquables les liens à schéma non-HTTP (`lmstudio://`, `goose://`), c'est pourquoi ils n'ont pas de bouton 1-clic ici.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -18,7 +18,7 @@ the reference for what gets pushed where on each release.
 | **Gemini CLI extension** | `gemini extensions install https://github.com/fauguste/boondmanager-mcp-server` | reads `gemini-extension.json` from repo root | on install (reads the default branch) |
 | **One-click badges (Cursor, VS Code, VS Code Insiders)** | deeplinks in `README.md` (no package) | hosted HTTPS redirects (`cursor.com/install-mcp`, `insiders.vscode.dev/redirect/mcp/install`) with base64/url-encoded `npx` config — clickable on github.com | manual (only if the `npx` invocation changes) |
 | **LM Studio / Goose** | install sections in `README.md` (no package) | native `lmstudio://` / `goose://` deeplinks are stripped by GitHub, so these are documented as copy-paste config instead of badges | manual |
-| **Glama / Smithery listing badges** | [Glama](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server) · [Smithery](https://smithery.ai/server/@fauguste/boondmanager-mcp-server) | Glama serves a live `/badge` image; Smithery uses a static shields.io badge (their own badge endpoint is WAF-gated) | auto |
+| **Glama listing badge** | [Glama](https://glama.ai/mcp/servers/fauguste/boondmanager-mcp-server) | live `/badge` PNG, embedded via `<img width>` to keep it compact. Smithery has no usable README badge (their badge endpoint is WAF-gated), so only the listing channel row above is kept | auto |
 
 ## One-time setup (manual)
 


### PR DESCRIPTION
## Pourquoi
- **Smithery** : aucun badge README exploitable (leur endpoint de badge est bloqué par WAF ; le badge shields.io statique de repli n'apportait rien). On le retire. La **ligne de canal Smithery** dans `docs/distribution.md` (listing via `smithery.yaml`) reste inchangée.
- **Glama** : le badge PNG était trop grand dans l'en-tête → embarqué via `<img width="180">` pour le réduire.

## Changements
- `README.md` : suppression du badge Smithery, badge Glama en `<img>` compact (largeur 180px, ajustable).
- `docs/distribution.md` : ligne badges mise à jour (Glama seul).

Aucun changement de surface MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)