### PR TITLE
test: behavioural coverage for read-only domains + CI thresholds (P1)

### DIFF
--- a/src/tools/accounts.test.ts
+++ b/src/tools/accounts.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerAccountTools } from "./accounts.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerAccountTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 account tools", () => {
-    registerAccountTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerAccountTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_accounts_search");
-    expect(names).toContain("boond_accounts_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerAccountTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerAccountTools", {
+  registrar: registerAccountTools,
+  namePrefix: "boond_accounts",
+  searchPath: "/accounts",
 });

--- a/src/tools/advantages.test.ts
+++ b/src/tools/advantages.test.ts
@@ -1,38 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerAdvantageTools } from "./advantages.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerAdvantageTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 advantage tools", () => {
-    registerAdvantageTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerAdvantageTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_advantages_search");
-    expect(names).toContain("boond_advantages_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerAdvantageTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      const [, metadata] = call;
-      expect(metadata.annotations?.readOnlyHint).toBe(true);
-      expect(metadata.annotations?.destructiveHint).toBe(false);
-    }
-  });
+describeSearchGetTools("registerAdvantageTools", {
+  registrar: registerAdvantageTools,
+  namePrefix: "boond_advantages",
+  searchPath: "/advantages",
 });

--- a/src/tools/agencies.test.ts
+++ b/src/tools/agencies.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerAgencyTools } from "./agencies.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerAgencyTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 agency tools", () => {
-    registerAgencyTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerAgencyTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_agencies_search");
-    expect(names).toContain("boond_agencies_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerAgencyTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerAgencyTools", {
+  registrar: registerAgencyTools,
+  namePrefix: "boond_agencies",
+  searchPath: "/agencies",
 });

--- a/src/tools/business-units.test.ts
+++ b/src/tools/business-units.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerBusinessUnitTools } from "./business-units.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerBusinessUnitTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 business unit tools", () => {
-    registerBusinessUnitTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerBusinessUnitTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_business_units_search");
-    expect(names).toContain("boond_business_units_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerBusinessUnitTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerBusinessUnitTools", {
+  registrar: registerBusinessUnitTools,
+  namePrefix: "boond_business_units",
+  searchPath: "/business-units",
 });

--- a/src/tools/calendars.test.ts
+++ b/src/tools/calendars.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerCalendarTools } from "./calendars.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerCalendarTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 calendar tools", () => {
-    registerCalendarTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerCalendarTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_calendars_search");
-    expect(names).toContain("boond_calendars_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerCalendarTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerCalendarTools", {
+  registrar: registerCalendarTools,
+  namePrefix: "boond_calendars",
+  searchPath: "/calendars",
 });

--- a/src/tools/deliveries.test.ts
+++ b/src/tools/deliveries.test.ts
@@ -1,38 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerDeliveryTools } from "./deliveries.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerDeliveryTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 delivery tools", () => {
-    registerDeliveryTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerDeliveryTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_deliveries_search");
-    expect(names).toContain("boond_deliveries_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerDeliveryTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      const [, metadata] = call;
-      expect(metadata.annotations?.readOnlyHint).toBe(true);
-      expect(metadata.annotations?.destructiveHint).toBe(false);
-    }
-  });
+describeSearchGetTools("registerDeliveryTools", {
+  registrar: registerDeliveryTools,
+  namePrefix: "boond_deliveries",
+  searchPath: "/deliveries-groupments",
+  getPath: (id) => `/deliveries/${id}`,
 });

--- a/src/tools/flags.test.ts
+++ b/src/tools/flags.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerFlagTools } from "./flags.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerFlagTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 flag tools", () => {
-    registerFlagTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerFlagTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_flags_search");
-    expect(names).toContain("boond_flags_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerFlagTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerFlagTools", {
+  registrar: registerFlagTools,
+  namePrefix: "boond_flags",
+  searchPath: "/flags",
 });

--- a/src/tools/logs.test.ts
+++ b/src/tools/logs.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerLogTools } from "./logs.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerLogTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 log tools", () => {
-    registerLogTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerLogTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_logs_search");
-    expect(names).toContain("boond_logs_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerLogTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerLogTools", {
+  registrar: registerLogTools,
+  namePrefix: "boond_logs",
+  searchPath: "/logs",
 });

--- a/src/tools/notifications.test.ts
+++ b/src/tools/notifications.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerNotificationTools } from "./notifications.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerNotificationTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 notification tools", () => {
-    registerNotificationTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerNotificationTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_notifications_search");
-    expect(names).toContain("boond_notifications_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerNotificationTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerNotificationTools", {
+  registrar: registerNotificationTools,
+  namePrefix: "boond_notifications",
+  searchPath: "/notifications",
 });

--- a/src/tools/payments.test.ts
+++ b/src/tools/payments.test.ts
@@ -1,38 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerPaymentTools } from "./payments.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerPaymentTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 payment tools", () => {
-    registerPaymentTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerPaymentTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_payments_search");
-    expect(names).toContain("boond_payments_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerPaymentTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      const [, metadata] = call;
-      expect(metadata.annotations?.readOnlyHint).toBe(true);
-      expect(metadata.annotations?.destructiveHint).toBe(false);
-    }
-  });
+describeSearchGetTools("registerPaymentTools", {
+  registrar: registerPaymentTools,
+  namePrefix: "boond_payments",
+  searchPath: "/payments",
 });

--- a/src/tools/poles.test.ts
+++ b/src/tools/poles.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerPoleTools } from "./poles.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerPoleTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 pole tools", () => {
-    registerPoleTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerPoleTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_poles_search");
-    expect(names).toContain("boond_poles_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerPoleTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerPoleTools", {
+  registrar: registerPoleTools,
+  namePrefix: "boond_poles",
+  searchPath: "/poles",
 });

--- a/src/tools/roles.test.ts
+++ b/src/tools/roles.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerRoleTools } from "./roles.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerRoleTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 role tools", () => {
-    registerRoleTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerRoleTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_roles_search");
-    expect(names).toContain("boond_roles_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerRoleTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerRoleTools", {
+  registrar: registerRoleTools,
+  namePrefix: "boond_roles",
+  searchPath: "/roles",
 });

--- a/src/tools/test-helpers.ts
+++ b/src/tools/test-helpers.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { apiRequest } from "../services/boond-client.js";
+
+/**
+ * Shared test utilities for tool-registration suites.
+ *
+ * Behavioural helpers assume the calling test file has mocked the boond-client
+ * module while keeping the real query/formatting helpers, e.g.:
+ *
+ *   vi.mock("../services/boond-client.js", async (importOriginal) => {
+ *     const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+ *     return { ...actual, apiRequest: vi.fn() };
+ *   });
+ *
+ * That way `apiRequest` is a spy (so we can assert on the path/method it is
+ * called with) while `buildSearchQuery` / `formatListResponse` run for real,
+ * exercising the domain tool's callback end-to-end.
+ */
+export function createMockServer(): McpServer {
+  return {
+    registerTool: vi.fn(),
+    registerPrompt: vi.fn(),
+    registerResource: vi.fn(),
+  } as unknown as McpServer;
+}
+
+type ToolCallback = (args: Record<string, unknown>) => Promise<{ content: unknown[] }>;
+
+/** Names registered on a mock server, in call order. */
+export function registeredToolNames(server: McpServer): string[] {
+  return vi.mocked(server.registerTool).mock.calls.map((c) => c[0] as string);
+}
+
+/** Pulls the callback (3rd registerTool arg) for a given tool name. */
+export function toolCallback(server: McpServer, name: string): ToolCallback {
+  const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === name);
+  if (!call) throw new Error(`Tool "${name}" was not registered`);
+  return call[2] as unknown as ToolCallback;
+}
+
+interface SearchGetContract {
+  /** The register*Tools function under test. */
+  registrar: (server: McpServer) => void;
+  /** Tool-name prefix, e.g. "boond_agencies". */
+  namePrefix: string;
+  /** API path hit by the search tool, e.g. "/agencies". */
+  searchPath: string;
+  /** API path hit by the get tool. Defaults to `${searchPath}/${id}`. */
+  getPath?: (id: string) => string;
+}
+
+/**
+ * Generates the standard suite for a read-only search + get domain:
+ * registration count, names, readOnly annotations, plus behavioural checks
+ * that the callbacks call the BoondManager API on the expected path.
+ */
+export function describeSearchGetTools(label: string, contract: SearchGetContract): void {
+  const searchTool = `${contract.namePrefix}_search`;
+  const getTool = `${contract.namePrefix}_get`;
+  const getPath = contract.getPath ?? ((id: string) => `${contract.searchPath}/${id}`);
+
+  describe(label, () => {
+    let server: McpServer;
+
+    beforeEach(() => {
+      server = createMockServer();
+      vi.mocked(apiRequest).mockReset();
+    });
+
+    it("should register 2 tools", () => {
+      contract.registrar(server);
+      expect(server.registerTool).toHaveBeenCalledTimes(2);
+    });
+
+    it("should register the expected tool names", () => {
+      contract.registrar(server);
+      const names = registeredToolNames(server);
+      expect(names).toContain(searchTool);
+      expect(names).toContain(getTool);
+    });
+
+    it("should register all tools as readOnly", () => {
+      contract.registrar(server);
+      for (const call of vi.mocked(server.registerTool).mock.calls) {
+        expect(call[1].annotations?.readOnlyHint).toBe(true);
+        expect(call[1].annotations?.destructiveHint).toBe(false);
+      }
+    });
+
+    it("search should call the BoondManager API on the search path", async () => {
+      vi.mocked(apiRequest).mockResolvedValue({ data: [] });
+      contract.registrar(server);
+      await toolCallback(server, searchTool)({ page: 2, pageSize: 10 });
+      const call = vi.mocked(apiRequest).mock.calls[0];
+      expect(call[0]).toBe(contract.searchPath);
+      expect(call[1]).toBe("GET");
+    });
+
+    it("get should call the BoondManager API on the detail path", async () => {
+      vi.mocked(apiRequest).mockResolvedValue({ data: { id: "42", type: "x", attributes: {} } });
+      contract.registrar(server);
+      await toolCallback(server, getTool)({ id: "42" });
+      expect(vi.mocked(apiRequest).mock.calls[0][0]).toBe(getPath("42"));
+    });
+  });
+}

--- a/src/tools/threads.test.ts
+++ b/src/tools/threads.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerThreadTools } from "./threads.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerThreadTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 thread tools", () => {
-    registerThreadTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerThreadTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_threads_search");
-    expect(names).toContain("boond_threads_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerThreadTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerThreadTools", {
+  registrar: registerThreadTools,
+  namePrefix: "boond_threads",
+  searchPath: "/threads",
 });

--- a/src/tools/todolists.test.ts
+++ b/src/tools/todolists.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerTodolistTools } from "./todolists.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerTodolistTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 todolist tools", () => {
-    registerTodolistTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerTodolistTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_todolists_search");
-    expect(names).toContain("boond_todolists_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerTodolistTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerTodolistTools", {
+  registrar: registerTodolistTools,
+  namePrefix: "boond_todolists",
+  searchPath: "/todolists",
 });

--- a/src/tools/validations.test.ts
+++ b/src/tools/validations.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerValidationTools } from "./validations.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerValidationTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 validation tools", () => {
-    registerValidationTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerValidationTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_validations_search");
-    expect(names).toContain("boond_validations_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerValidationTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerValidationTools", {
+  registrar: registerValidationTools,
+  namePrefix: "boond_validations",
+  searchPath: "/validations",
 });

--- a/src/tools/webhooks.test.ts
+++ b/src/tools/webhooks.test.ts
@@ -1,36 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { vi } from "vitest";
+import { describeSearchGetTools } from "./test-helpers.js";
 import { registerWebhookTools } from "./webhooks.js";
 
-function createMockServer() {
-  return {
-    registerTool: vi.fn(),
-  } as unknown as McpServer;
-}
+vi.mock("../services/boond-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
+  return { ...actual, apiRequest: vi.fn() };
+});
 
-describe("registerWebhookTools", () => {
-  let server: McpServer;
-
-  beforeEach(() => {
-    server = createMockServer();
-  });
-
-  it("should register 2 webhook tools", () => {
-    registerWebhookTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
-  });
-
-  it("should register all expected tool names", () => {
-    registerWebhookTools(server);
-    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
-    expect(names).toContain("boond_webhooks_search");
-    expect(names).toContain("boond_webhooks_get");
-  });
-
-  it("should register all tools as readOnly", () => {
-    registerWebhookTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
-  });
+describeSearchGetTools("registerWebhookTools", {
+  registrar: registerWebhookTools,
+  namePrefix: "boond_webhooks",
+  searchPath: "/webhooks",
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "vitest.config.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/tools/test-helpers.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/index.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts", "src/tools/test-helpers.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 75,
+        branches: 75,
+        statements: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Priorité 1 — Couverture de tests comportementale

Premier des 5 lots d'amélioration issus de l'analyse du dépôt.

### Problème
`src/tools` n'était couvert qu'à **~59 %** : les 16 domaines simples *search+get* étaient testés uniquement pour leur **enregistrement** (nombre d'outils, noms, annotations). Les callbacks — donc la logique d'appel API et de formatage — n'étaient jamais exécutés.

### Changements
- **`src/tools/test-helpers.ts`** (nouveau) : `createMockServer()` + `describeSearchGetTools()` qui factorise les assertions d'enregistrement **et** exécute chaque callback (`apiRequest` espionné, `buildSearchQuery`/`format*` réels) pour vérifier le path/méthode réellement appelés sur l'API BoondManager.
- **16 fichiers de test convertis** (agencies, accounts, logs, poles, roles, flags, calendars, advantages, deliveries, notifications, payments, todolists, threads, validations, webhooks, business-units) : suppression de la duplication, ajout de la vérification comportementale.
- **Seuils de couverture en CI** (`vitest.config.ts`) : lines/statements 80 %, functions/branches 75 % — empêche toute régression silencieuse.
- `test-helpers.ts` exclu du build `tsc` (il importe `vitest`, une devDep) et de la comptabilité de couverture.

### Résultat
- Tests : 657 → **689**
- `src/tools` : 59 % → **~70 %** · global : 79,5 % → **~84 %**
- `npm test`, `lint`, `typecheck`, `build`, `docs:tools:check` : tous verts. Aucun changement de catalogue d'outils.

> Note : pas de bump de version ni d'entrée CHANGELOG (volontaire — ces 5 PRs sont parallèles ; le versionnement/CHANGELOG sera consolidé par le mainteneur au moment de la release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)