### PR TITLE
refactor(schemas): centralise tools filter + validate action ISO dates (P4)

### DIFF
--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -14,6 +14,10 @@ import {
   CompanyUpdateSchema,
   OpportunityCreateSchema,
   OpportunityUpdateSchema,
+  ResourceSearchSchema,
+  CandidateSearchSchema,
+  ContactSearchSchema,
+  OpportunitySearchSchema,
   ActionSearchSchema,
   ActionCreateSchema,
   ResourceTimesheetSchema,
@@ -47,6 +51,45 @@ import {
   ReportingSynthesisSchema,
   ReportingProductionPlansSchema,
 } from "./index.js";
+
+describe("shared tools filter", () => {
+  const schemas = {
+    ResourceSearchSchema,
+    CandidateSearchSchema,
+    ContactSearchSchema,
+    OpportunitySearchSchema,
+  };
+
+  for (const [name, schema] of Object.entries(schemas)) {
+    it(`${name} accepts the #AND# tools syntax`, () => {
+      expect(schema.safeParse({ tools: ["#AND#", "12", "34"] }).success).toBe(true);
+      expect(schema.safeParse({ tools: ["12"] }).success).toBe(true);
+    });
+  }
+
+  it("exposes the same tools description on every entity (centralised field)", () => {
+    const descriptions = Object.values(schemas).map(
+      (schema) => (schema as unknown as { shape: Record<string, { description?: string }> }).shape.tools?.description
+    );
+    expect(new Set(descriptions).size).toBe(1);
+    expect(descriptions[0]).toContain("#AND#");
+  });
+});
+
+describe("ActionCreateSchema date validation", () => {
+  it("accepts ISO 8601 datetimes with a timezone offset", () => {
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, startDate: "2026-06-05T10:00:00+0200" }).success).toBe(true);
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, startDate: "2026-06-05T10:00:00+02:00" }).success).toBe(true);
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, endDate: "2026-06-05T10:00:00Z" }).success).toBe(true);
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, startDate: "2026-06-05T10:00:00" }).success).toBe(true);
+  });
+
+  it("rejects a date-only or malformed value", () => {
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, startDate: "2026-06-05" }).success).toBe(false);
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, startDate: "not-a-date" }).success).toBe(false);
+    expect(ActionCreateSchema.safeParse({ typeOf: 1, endDate: "05/06/2026" }).success).toBe(false);
+  });
+});
 
 describe("SearchSchema", () => {
   it("should accept valid input with all fields", () => {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -54,6 +54,23 @@ const fieldsField = z
   );
 const strArray = (doc: string) => z.array(z.string()).optional().describe(doc);
 
+// Shared `tools` (technologies/skills) filter. Centralised so every entity
+// search exposes the same `#AND#` semantics to the model — previously the
+// description ranged from the full explanation (resources) to a bare
+// "IDs d'outils." (opportunities), so the model only learned about `#AND#`
+// on some endpoints.
+const toolsFilterField = strArray(
+  "IDs d'outils/technos (dictionnaire setting.tool). Logique OU par défaut. " +
+    "Pour ET, ajouter '#AND#' en 1er élément: tools=['#AND#','12','34']."
+);
+
+// Action timestamps: ISO 8601 with timezone, e.g. 2026-06-05T10:00:00+0200.
+// Accepts the colon-less (+0200) and colon (+02:00) offset styles, an optional
+// fractional-seconds part, and a trailing Z. The timezone is optional so the
+// API can apply the account default. Surfaces a malformed value at the schema
+// boundary instead of as an opaque 422.
+const actionDateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)?$/;
+
 // Shared "perimeter" filters available on every entity search (from RAML trait `searchable`).
 // These are the CORRECT filters for "my team / my agency / my N-1" — NOT the old `mainManagers`.
 const perimeterManagersField = intArray(
@@ -135,10 +152,7 @@ export const ResourceSearchSchema = z
     excludeResourceTypes: intArray("IDs de types de ressource à EXCLURE."),
     activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
     expertiseAreas: strArray("IDs de domaines d'expertise (dictionnaire setting.expertiseArea)."),
-    tools: strArray(
-      "IDs d'outils/technos (dictionnaire setting.tool). Logique OU par défaut. " +
-        "Pour ET, ajouter '#AND#' en 1er élément: tools=['#AND#','12','34']."
-    ),
+    tools: toolsFilterField,
     experiences: intArray("IDs de niveaux d'expérience (dictionnaire setting.experience)."),
     trainings: strArray("IDs de formations (dictionnaire setting.training)."),
     mobilityAreas: strArray("IDs de zones de mobilité (dictionnaire setting.mobilityArea)."),
@@ -232,7 +246,7 @@ export const CandidateSearchSchema = z
     availabilityTypes: intArray("IDs de types de disponibilité (dictionnaire setting.availability)."),
     activityAreas: strArray("IDs de secteurs d'activité (dictionnaire setting.activityArea)."),
     expertiseAreas: strArray("IDs de domaines d'expertise."),
-    tools: strArray("IDs d'outils/technos. Logique OU par défaut. Pour ET, ajouter '#AND#' en 1er élément."),
+    tools: toolsFilterField,
     experiences: intArray("IDs de niveaux d'expérience."),
     trainings: strArray("IDs de formations."),
     mobilityAreas: strArray("IDs de zones de mobilité."),
@@ -308,7 +322,7 @@ export const ContactSearchSchema = z
     origins: strArray("IDs d'origines (dictionnaire setting.origin)."),
     activityAreas: strArray("IDs de secteurs d'activité de la société."),
     expertiseAreas: strArray("IDs de domaines d'expertise de la société."),
-    tools: strArray("IDs d'outils. Logique OU par défaut, '#AND#' en 1er pour ET."),
+    tools: toolsFilterField,
     influencers: intArray("IDs de contacts influenceurs."),
     flags: intArray("IDs de tags."),
     period: z
@@ -407,7 +421,7 @@ export const OpportunitySearchSchema = z
     positioningStates: strArray("IDs d'états de positionnement, ou 'none' pour les opportunités sans positionnement."),
     expertiseAreas: strArray("IDs de domaines d'expertise."),
     activityAreas: strArray("IDs de secteurs d'activité."),
-    tools: strArray("IDs d'outils."),
+    tools: toolsFilterField,
     places: strArray("IDs de zones (dictionnaire setting.mobilityArea)."),
     durations: intArray("IDs de durées (dictionnaire setting.duration)."),
     origins: strArray("IDs d'origines."),
@@ -837,9 +851,10 @@ export const ActionCreateSchema = z
     text: z.string().optional().describe("Contenu / notes de l'action"),
     startDate: z
       .string()
+      .regex(actionDateTimeRegex)
       .optional()
-      .describe("Date de début au format ISO avec timezone (ex: 2026-06-05T10:00:00+0200)"),
-    endDate: z.string().optional().describe("Date de fin (même format que startDate)"),
+      .describe("Date de début au format ISO 8601 avec timezone (ex: 2026-06-05T10:00:00+0200)"),
+    endDate: z.string().regex(actionDateTimeRegex).optional().describe("Date de fin (même format que startDate)"),
     candidateId: z.string().optional().describe("ID du candidat auquel rattacher l'action (dependsOn)"),
     resourceId: z.string().optional().describe("ID de la ressource à laquelle rattacher l'action (dependsOn)"),
     contactId: z.string().optional().describe("ID du contact auquel rattacher l'action (dependsOn)"),


### PR DESCRIPTION
## Priorité 4 — Schémas Zod

Quatrième des 5 lots issus de l'analyse.

### Filtre `tools` centralisé
Le filtre `tools` (technos) était décrit de **4 façons différentes** selon l'entité — de l'explication complète de la syntaxe `#AND#` (ressources) au simple « IDs d'outils. » (opportunités). Le modèle n'apprenait donc la logique ET que sur certains endpoints. Extraction d'un champ partagé unique **`toolsFilterField`**, réutilisé sur resources / candidates / contacts / opportunities (même pattern que les champs `perimeter*` déjà partagés).

### Dates d'action validées (ISO 8601)
`ActionCreateSchema.startDate`/`endDate` valident désormais un datetime ISO 8601 **avec timezone** via regex (offsets `+0200` et `+02:00`, fraction de secondes optionnelle, `Z` final, tz optionnelle). Une valeur date-seule ou malformée est rejetée **au niveau du schéma** plutôt que de remonter en 422 opaque côté BoondManager.

> L'item « description de `typeOf` oublie `BOOND_DICTIONARY_OVERRIDES` » de l'analyse était déjà couvert dans le code — aucun changement nécessaire.

### Vérifications
- +7 tests (chaque entité expose la description `tools` identique et accepte `#AND#` ; les dates d'action acceptent les variantes ISO valides et rejettent date-seule/malformé). Suite **664** verts ; `lint`/`typecheck`/`build` OK ; **TOOLS.md inchangé** (les descriptions de champs n'affectent pas le catalogue).

> Note : pas de bump de version ni d'entrée CHANGELOG (volontaire — 5 PRs parallèles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)