### PR TITLE
docs: dictionary cache TTL, structured outputs, fix Node matrix (P5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ Behavior notes:
 
 ## CI/CD
 
-- **CI** (`.github/workflows/ci.yml`): Runs on push/PR to main. Matrix: Node 20 + 22. Steps: install, lint, typecheck, test:coverage, build, **MCPB validate** (Node 22 only), **TOOLS.md drift check** (Node 22 only), **version consistency** between `package.json` / `manifest.json` / `server.json`, coverage upload.
+- **CI** (`.github/workflows/ci.yml`): Runs on push/PR to main. Matrix: Node 20 + 22 + 24. Steps: install, lint, typecheck, test:coverage, build, **MCPB validate** (Node 22 only), **TOOLS.md drift check** (Node 22 only), **version consistency** between `package.json` / `manifest.json` / `server.json`, coverage upload.
 - **Release** (`.github/workflows/release.yml`): Triggered on `v*` tags. Publishes to:
   - **npm** with `--provenance --access public`
   - **GitHub Releases** with `.mcpb` bundle attached; release body extracted from the matching `## [X.Y.Z]` section of `CHANGELOG.md`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Serveur MCP (Model Context Protocol) pour l'API BoondManager, permettant a Claud
 
 **175 outils** couvrant **38 domaines** de l'API BoondManager. Voir [TOOLS.md](./TOOLS.md) pour le catalogue auto-généré (outils + prompts + ressources).
 
+> **Sorties structurées.** En plus du texte lisible, les outils `search`, `create`, `update` et `delete` renvoient un `structuredContent` conforme à un `outputSchema` MCP : `search` → `{ total?, count, items[] }` (résumés compacts, pas les ressources JSON:API complètes), `create`/`update` → `{ id?, type? }`, `delete` → `{ id, deleted, reason? }`. Les clients MCP qui exploitent les sorties structurées obtiennent une référence d'entité fiable pour chaîner les appels. Les outils `get` restent en texte seul (leur texte est déjà du JSON exploitable).
+
 ## Domaines couverts
 
 ### CRM & Commercial
@@ -513,6 +515,14 @@ Pour eviter qu'une boucle d'outils emballee n'inonde l'API (et n'enchaine les `4
 |----------|--------|-------------|
 | `BOOND_HTTP_RATE_LIMIT_RPS` | `10` | Debit soutenu (requetes/seconde). `0` desactive completement. |
 | `BOOND_HTTP_RATE_LIMIT_BURST` | `20` | Capacite du bucket = taille maximale de rafale immediate. |
+
+### Cache du dictionnaire
+
+L'API BoondManager n'expose qu'un seul endpoint `/application/dictionary` qui renvoie l'intégralité des libellés (états, types, pays…). Le serveur le met en cache en mémoire pour éviter de le re-télécharger à chaque résolution état/type → libellé.
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `BOOND_DICTIONARY_TTL_MS` | `3600000` (1 h) | Durée de vie du cache du dictionnaire, en millisecondes. Une valeur non numérique ou ≤ 0 retombe sur le défaut. |
 
 ### Restriction d'accès (domaines / lecture seule)
 


### PR DESCRIPTION
## Priorité 5 — Documentation

Cinquième et dernier lot issu de l'analyse. Documentation uniquement.

- **README** : ajout de **`BOOND_DICTIONARY_TTL_MS`** à la configuration (défaut `3600000` ms / 1 h) — la variable était respectée dans le code (`services/dictionary.ts`) mais jamais exposée aux opérateurs.
- **README** : documentation du contrat de **sorties structurées** (`search`/`create`/`update`/`delete` renvoient un `structuredContent` conforme à un `outputSchema` MCP ; `get` reste en texte seul), juste sous l'intro du catalogue d'outils.
- **CLAUDE.md** : correction de la description de la matrice CI (Node 20 + 22 → **20 + 22 + 24**) pour coller à `.github/workflows/ci.yml`.

> `LOG_LEVEL`/`LOG_FORMAT` étaient **déjà** documentés dans le README (l'item correspondant de l'analyse était un faux positif) — aucun changement.

> Note : pas de bump de version ni d'entrée CHANGELOG (volontaire — 5 PRs parallèles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)