### PR TITLE
fix(opportunities): expose missing create/update fields + fix update 405 (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.6.3] - 2026-06-19
+
+Suite de la correction d'`boond_opportunities_create`/`update` : exposition des champs métier manquants et correction du `405` à la mise à jour ([#124](https://github.com/fauguste/boondmanager-mcp-server/issues/124)). Aucun changement de catalogue — toujours **175 outils, 11 prompts, 22 ressources**.
+
+### Fixed
+
+- **`boond_opportunities_update` renvoyait systématiquement `405 Method Not Allowed` (PATCH /opportunities/{id})** ([#124](https://github.com/fauguste/boondmanager-mcp-server/issues/124)) : l'API BoondManager n'accepte pas `PATCH` sur la ressource de base. La mise à jour cible désormais `PUT /opportunities/{id}/information` (endpoint documenté dans la RAML). Le corps reste partiel — seuls les champs fournis sont envoyés. Le `crud-factory` gagne une option `pathSuffix` pour router une mise à jour vers une sous-ressource.
+- **`note` ne renseignait pas la description de l'opportunité** ([#124](https://github.com/fauguste/boondmanager-mcp-server/issues/124)) : l'API n'a pas d'attribut `note` ; le paramètre était silencieusement ignoré et `description` restait vide. `note` est désormais mappé sur `/data/attributes/description`.
+
+### Added
+
+- **`boond_opportunities_create` / `boond_opportunities_update` exposent les champs métier principaux** ([#124](https://github.com/fauguste/boondmanager-mcp-server/issues/124)), mappés sur les attributs/relations exacts de la RAML :
+  - Attributs : `typeOf` (type d'opportunité, dictionnaire `setting.typeOf.project`), `criteria` (critères / compétences recherchées — alimente le matching de `boond_workflow_candidats_pour_opportunite`), `expertiseArea` (dictionnaire `setting.expertiseArea`), `turnoverEstimatedExcludingTax` (CA estimé HT).
+  - Relations : `poleId` (pole), `hrManagerId` (resource), `mainManagerId` (resource), `agencyId` (agency) — en complément de `companyId`/`contactId`.
+
 ## [2.6.2] - 2026-06-18
 
 Correctif de l'outil `boond_opportunities_create` (et `boond_opportunities_update`) qui échouait systématiquement. Aucun changement de catalogue — toujours **175 outils, 11 prompts, 22 ressources**.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Serveur MCP pour l'API BoondManager (ERP/CRM ESN) - 175 outils, 11 prompts, 22 ressources.",
   "mcpServers": {
     "boondmanager": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 175 tools, 11 prompts, 22 resources (ERP/CRM)",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.6.2/boondmanager-mcp-server-v2.6.2.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.6.3/boondmanager-mcp-server-v2.6.3.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -798,15 +798,59 @@ export const CompanyUpdateSchema = z
 
 // ---- Opportunity schemas ----
 
+// Writable fields shared by create and update. The attribute/relationship
+// names mirror the official RAML (schemas/opportunities/information.json):
+//  - `note` → /data/attributes/description (the API has no `note` attribute,
+//    so the old direct pass-through was silently dropped — see issue #124)
+//  - `typeOf`, `criteria`, `expertiseArea`, `turnoverEstimatedExcludingTax`
+//    are plain attributes
+//  - `companyId`/`contactId`/`poleId`/`hrManagerId`/`mainManagerId`/`agencyId`
+//    become JSON:API relationships (resource types: company, contact, pole,
+//    resource, resource, agency)
+const opportunityWritableShape = {
+  typeOf: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      "Type d'opportunité : ID numérique du dictionnaire setting.typeOf.project (ex: 1, 3), via boond_application_dictionary"
+    ),
+  companyId: z.string().optional().describe("ID de la société cliente (relation company)"),
+  contactId: z.string().optional().describe("ID du contact associé (relation contact)"),
+  state: stateField("opportunity", "État de l'opportunité"),
+  startDate: z.string().optional().describe("Date de début prévue (YYYY-MM-DD ou 'immediate')"),
+  endDate: z.string().optional().describe("Date de fin prévue (YYYY-MM-DD)"),
+  note: z
+    .string()
+    .max(65000)
+    .optional()
+    .describe("Description de l'opportunité (mappée sur /data/attributes/description)"),
+  criteria: z
+    .string()
+    .max(5000)
+    .optional()
+    .describe(
+      "Critères / compétences recherchées (texte libre). Alimente le matching de boond_workflow_candidats_pour_opportunite."
+    ),
+  expertiseArea: z
+    .string()
+    .optional()
+    .describe("Domaine d'expertise : ID du dictionnaire setting.expertiseArea (via boond_application_dictionary)"),
+  turnoverEstimatedExcludingTax: z.coerce.number().optional().describe("Chiffre d'affaires estimé HT (montant)"),
+  poleId: z.string().optional().describe("ID du pôle (relation pole)"),
+  hrManagerId: z.string().optional().describe("ID de la ressource responsable RH (relation hrManager)"),
+  mainManagerId: z
+    .string()
+    .optional()
+    .describe("ID de la ressource responsable principal / commercial (relation mainManager)"),
+  agencyId: z.string().optional().describe("ID de l'agence (relation agency)"),
+} as const;
+
 export const OpportunityCreateSchema = z
   .object({
     name: z.string().min(1).describe("Nom / titre de l'opportunité"),
-    companyId: z.string().optional().describe("ID de la société cliente"),
-    contactId: z.string().optional().describe("ID du contact associé"),
-    state: stateField("opportunity", "État de l'opportunité"),
-    startDate: z.string().optional().describe("Date de début prévue (YYYY-MM-DD)"),
-    endDate: z.string().optional().describe("Date de fin prévue (YYYY-MM-DD)"),
-    note: z.string().optional().describe("Notes / description"),
+    ...opportunityWritableShape,
   })
   .strict();
 
@@ -814,10 +858,7 @@ export const OpportunityUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID de l'opportunité à modifier"),
     name: z.string().optional().describe("Nom / titre"),
-    state: stateField("opportunity", "État"),
-    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
-    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
-    note: z.string().optional().describe("Notes"),
+    ...opportunityWritableShape,
   })
   .strict();
 

--- a/src/tools/crud-factory.test.ts
+++ b/src/tools/crud-factory.test.ts
@@ -398,4 +398,17 @@ describe("registerCreateTool / registerUpdateTool handlers", () => {
     const result = await registeredHandler(server)({ id: "99" });
     expect(result.structuredContent).toEqual({ id: "99", type: "test" });
   });
+
+  it("update honours method + pathSuffix overrides (PUT /{id}/information)", async () => {
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "99", type: "test", attributes: {} } });
+    const server = createMockServer();
+    registerUpdateTool(server, OPTS, z.object({ id: z.string() }), (p) => buildJsonApiBody("test", p), {
+      method: "PUT",
+      pathSuffix: "information",
+    });
+    await registeredHandler(server)({ id: "99" });
+    const [path, method] = vi.mocked(apiRequest).mock.calls[0];
+    expect(path).toBe("/tests/99/information");
+    expect(method).toBe("PUT");
+  });
 });

--- a/src/tools/crud-factory.ts
+++ b/src/tools/crud-factory.ts
@@ -290,6 +290,11 @@ interface UpdateToolOverrides {
   /** HTTP verb for the update call. A few BoondManager endpoints expect PUT
    * (e.g. /expenses-reports) rather than the JSON:API-conventional PATCH. */
   method?: "PATCH" | "PUT";
+  /** Sub-resource segment appended to `${apiPath}/${id}` for the update call
+   * (e.g. "information" → PUT /opportunities/{id}/information). Some entities
+   * only accept updates on their `/information` sub-resource and return 405 on
+   * PATCH/PUT against the base resource (see issue #124). */
+  pathSuffix?: string;
 }
 
 export function registerUpdateTool(
@@ -300,6 +305,7 @@ export function registerUpdateTool(
   overrides: UpdateToolOverrides = {}
 ): void {
   const method = overrides.method ?? "PATCH";
+  const pathSuffix = overrides.pathSuffix ? `/${overrides.pathSuffix}` : "";
   server.registerTool(
     `${opts.prefix}_update`,
     {
@@ -320,7 +326,7 @@ Returns: Données mises à jour du/de la ${opts.entityName}.`,
       const p = params as Record<string, unknown>;
       const id = p.id as string;
       const body = buildBody(p);
-      const response = await apiRequest(`${opts.apiPath}/${id}`, method, body);
+      const response = await apiRequest(`${opts.apiPath}/${id}${pathSuffix}`, method, body);
       return {
         content: [
           {

--- a/src/tools/opportunities.test.ts
+++ b/src/tools/opportunities.test.ts
@@ -105,7 +105,7 @@ describe("registerOpportunityTools", () => {
       expect(data.relationships.contact).toEqual({ data: { id: "34", type: "contact" } });
     });
 
-    it("maps `name` to `title` on update", async () => {
+    it("maps `name` to `title` on update via PUT /opportunities/{id}/information (issue #124)", async () => {
       registerOpportunityTools(server);
       const apiSpy = vi
         .spyOn(boondClient, "apiRequest")
@@ -115,8 +115,10 @@ describe("registerOpportunityTools", () => {
       await handler({ id: "7", name: "Renamed" });
 
       const [path, method, body] = apiSpy.mock.calls[0];
-      expect(path).toBe("/opportunities/7");
-      expect(method).toBe("PATCH");
+      // The base resource returns 405 on PATCH; updates target the
+      // /information sub-resource with PUT.
+      expect(path).toBe("/opportunities/7/information");
+      expect(method).toBe("PUT");
       const attrs = (body as { data: { attributes: Record<string, unknown> } }).data.attributes;
       expect(attrs.title).toBe("Renamed");
       expect(attrs.name).toBeUndefined();
@@ -134,7 +136,88 @@ describe("registerOpportunityTools", () => {
       const [, , body] = apiSpy.mock.calls[0];
       const attrs = (body as { data: { attributes: Record<string, unknown> } }).data.attributes;
       expect(attrs).not.toHaveProperty("title");
-      expect(attrs.note).toBe("just a note");
+    });
+  });
+
+  // Regression for issue #124: create/update must expose the main opportunity
+  // fields and map them to the correct API attributes / relationships.
+  describe("extended fields (issue #124)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function bodyOf(call: unknown[]): {
+      attributes: Record<string, unknown>;
+      relationships: Record<string, unknown>;
+    } {
+      return (call[2] as { data: { attributes: Record<string, unknown>; relationships: Record<string, unknown> } })
+        .data;
+    }
+
+    it("maps typeOf/criteria/expertiseArea/turnover attributes and note→description on create", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "9", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_create");
+      await handler({
+        name: "Full opp",
+        typeOf: 3,
+        note: "Mission description",
+        criteria: "React, 5 ans",
+        expertiseArea: "developpementweb",
+        turnoverEstimatedExcludingTax: 120000,
+      });
+
+      const { attributes } = bodyOf(apiSpy.mock.calls[0]);
+      expect(attributes.title).toBe("Full opp");
+      expect(attributes.typeOf).toBe(3);
+      expect(attributes.description).toBe("Mission description");
+      expect(attributes.note).toBeUndefined();
+      expect(attributes.criteria).toBe("React, 5 ans");
+      expect(attributes.expertiseArea).toBe("developpementweb");
+      expect(attributes.turnoverEstimatedExcludingTax).toBe(120000);
+    });
+
+    it("maps pole/hrManager/mainManager/agency ids to relationships on create", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "9", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_create");
+      await handler({
+        name: "Rel opp",
+        poleId: "5",
+        hrManagerId: "11",
+        mainManagerId: "12",
+        agencyId: "2",
+      });
+
+      const { relationships } = bodyOf(apiSpy.mock.calls[0]);
+      expect(relationships.pole).toEqual({ data: { id: "5", type: "pole" } });
+      expect(relationships.hrManager).toEqual({ data: { id: "11", type: "resource" } });
+      expect(relationships.mainManager).toEqual({ data: { id: "12", type: "resource" } });
+      expect(relationships.agency).toEqual({ data: { id: "2", type: "agency" } });
+    });
+
+    it("forwards extended fields on update (PUT /information)", async () => {
+      registerOpportunityTools(server);
+      const apiSpy = vi
+        .spyOn(boondClient, "apiRequest")
+        .mockResolvedValue({ data: { id: "7", type: "opportunity", attributes: {} } } as never);
+
+      const handler = getHandler(server, "boond_opportunities_update");
+      await handler({ id: "7", typeOf: 2, criteria: "Java", poleId: "8" });
+
+      const [path, method] = apiSpy.mock.calls[0];
+      expect(path).toBe("/opportunities/7/information");
+      expect(method).toBe("PUT");
+      const { attributes, relationships } = bodyOf(apiSpy.mock.calls[0]);
+      expect(attributes.typeOf).toBe(2);
+      expect(attributes.criteria).toBe("Java");
+      expect(relationships.pole).toEqual({ data: { id: "8", type: "pole" } });
     });
   });
 });

--- a/src/tools/opportunities.ts
+++ b/src/tools/opportunities.ts
@@ -112,6 +112,40 @@ Pagination : \`page\`, \`pageSize\` (max 500). Tri : \`sort: "creationDate"|"tit
 
 Returns : liste paginée des opportunités. Utiliser \`boond_opportunities_get\` ou les outils d'onglets pour le détail.`;
 
+/**
+ * Builds the JSON:API body for create (no id) and update (with id) of an
+ * opportunity. Maps the friendly schema field names to the API's attribute /
+ * relationship names (see issues #113 and #124):
+ *   - `name` → /data/attributes/title
+ *   - `note` → /data/attributes/description (the API has no `note` attribute)
+ *   - `{company,contact,pole,hrManager,mainManager,agency}Id` → relationships
+ * `buildJsonApiBody` strips undefined attributes and relationships, so partial
+ * updates only touch the supplied fields.
+ */
+function buildOpportunityBody(params: Record<string, unknown>): unknown {
+  const { id, name, note, companyId, contactId, poleId, hrManagerId, mainManagerId, agencyId, ...attributes } =
+    params as {
+      id?: string;
+      name?: string;
+      note?: string;
+      companyId?: string;
+      contactId?: string;
+      poleId?: string;
+      hrManagerId?: string;
+      mainManagerId?: string;
+      agencyId?: string;
+    } & Record<string, unknown>;
+
+  return buildJsonApiBody("opportunity", { ...attributes, title: name, description: note }, id, {
+    company: companyId ? { id: companyId, type: "company" } : undefined,
+    contact: contactId ? { id: contactId, type: "contact" } : undefined,
+    pole: poleId ? { id: poleId, type: "pole" } : undefined,
+    hrManager: hrManagerId ? { id: hrManagerId, type: "resource" } : undefined,
+    mainManager: mainManagerId ? { id: mainManagerId, type: "resource" } : undefined,
+    agency: agencyId ? { id: agencyId, type: "agency" } : undefined,
+  });
+}
+
 export function registerOpportunityTools(server: McpServer): void {
   registerSearchTool(server, OPTS, {
     schema: OpportunitySearchSchema,
@@ -119,25 +153,14 @@ export function registerOpportunityTools(server: McpServer): void {
   });
   registerGetTool(server, OPTS);
 
-  registerCreateTool(server, OPTS, OpportunityCreateSchema, (params) => {
-    // The Boond API expects the opportunity name under `/data/attributes/title`,
-    // so the schema's `name` field must be mapped to `title` (see issue #113).
-    const { companyId, contactId, name, ...rest } = params;
-    const body = buildJsonApiBody("opportunity", { title: name, ...rest });
-    const relationships: Record<string, unknown> = {};
-    if (companyId) relationships.company = { data: { id: companyId, type: "company" } };
-    if (contactId) relationships.contact = { data: { id: contactId, type: "contact" } };
-    if (Object.keys(relationships).length > 0) {
-      (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
-    }
-    return body;
-  });
+  registerCreateTool(server, OPTS, OpportunityCreateSchema, buildOpportunityBody);
 
-  registerUpdateTool(server, OPTS, OpportunityUpdateSchema, (params) => {
-    // Same `name` → `title` mapping as create (issue #113). `title` stays
-    // undefined when `name` is omitted, so buildJsonApiBody drops it.
-    const { id, name, ...rest } = params;
-    return buildJsonApiBody("opportunity", { title: name, ...rest }, id as string);
+  // Updates go through PUT /opportunities/{id}/information — the base resource
+  // returns 405 on PATCH (issue #124). buildJsonApiBody drops undefined values,
+  // so PUT still only touches the fields the caller supplied.
+  registerUpdateTool(server, OPTS, OpportunityUpdateSchema, buildOpportunityBody, {
+    method: "PUT",
+    pathSuffix: "information",
   });
 
   registerDeleteTool(server, OPTS);


### PR DESCRIPTION
Closes #124.

Follow-up to the v2.6.2 `name → title` fix. Two issues reported against `boond_opportunities_create` / `boond_opportunities_update`, both addressed here.

## 1. Update returned `405 Method Not Allowed`

`boond_opportunities_update` issued `PATCH /opportunities/{id}`, which the BoondManager API rejects. The documented endpoint (per the RAML, `resources/opportunities/information.raml` exposes `put`) is **`PUT /opportunities/{id}/information`**. Updates now route there.

- `crud-factory.registerUpdateTool` gains an optional `pathSuffix` override (alongside the existing `method`), so an update can target a sub-resource. Opportunities pass `{ method: "PUT", pathSuffix: "information" }`.
- The body stays partial (`buildJsonApiBody` drops `undefined`), so PUT only touches supplied fields — existing values aren't wiped.

> Note: all major entities (candidates, resources, companies, contacts, projects) expose the same `PUT /{entity}/{id}/information` and currently update via `PATCH /{id}` through the factory default. They may share this latent 405. Left out of scope here (this issue only reports opportunities, and I couldn't validate the others against a live tenant), but the `pathSuffix` hook is now in place to fix them the same way if confirmed.

## 2. Missing create/update fields

Create/update only exposed `name`, `companyId`, `contactId`, `state`, `startDate`, `endDate`, `note`. Now exposed, mapped to the exact RAML attribute/relationship names (`schemas/opportunities/information.json`):

| Param | Maps to |
|-------|---------|
| `typeOf` | `/data/attributes/typeOf` (dict `setting.typeOf.project`) |
| `criteria` | `/data/attributes/criteria` (feeds `boond_workflow_candidats_pour_opportunite` matching) |
| `expertiseArea` | `/data/attributes/expertiseArea` (dict `setting.expertiseArea`) |
| `turnoverEstimatedExcludingTax` | `/data/attributes/turnoverEstimatedExcludingTax` |
| `poleId` | relationship `pole` (type `pole`) |
| `hrManagerId` | relationship `hrManager` (type `resource`) |
| `mainManagerId` | relationship `mainManager` (type `resource`) |
| `agencyId` | relationship `agency` (type `agency`) |

Plus a bug fix: **`note` had no matching API attribute** (the attributes object is `additionalProperties: false`), so it was silently dropped and `description` stayed empty. `note` now maps to `/data/attributes/description`.

Create and update share one `opportunityWritableShape` (schema) and one `buildOpportunityBody` (handler), keeping the two in lockstep.

## Tests / validation

- New tests in `opportunities.test.ts` (attribute mapping, relationship mapping, `note → description`, PUT `/information` path) and `crud-factory.test.ts` (`pathSuffix` + `method` override).
- `npm test` → 705 passing · lint · typecheck · build · `docs:tools:check` (catalogue unchanged — still 175 tools / 11 prompts / 22 resources).
- Versions bumped to 2.6.3 across `package.json` / `manifest.json` / `server.json` / `gemini-extension.json` + lockfile; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)