### PR TITLE
feat: add static HTTP auth and extend Boond write tools

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -3,7 +3,7 @@
 > Auto-generated from the server registrations. Do not edit by hand.
 > Regenerate with `npm run docs:tools` (CI fails if this file is stale).
 
-**176 tools** across **38 domains** · **11 prompts** · **22 resources**.
+**180 tools** across **38 domains** · **11 prompts** · **22 resources**.
 
 Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destructiveHint), `idempotent` (idempotentHint), `open-world` (openWorldHint, e.g. paginated keyword search).
 
@@ -13,10 +13,10 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 
 | Tool | Title | Hints |
 |---|---|---|
-| `boond_absences_create` | Créer une absence | write |
+| `boond_absences_create` | Creer une demande d'absence | write |
 | `boond_absences_delete` | Supprimer une absence | delete |
-| `boond_absences_get` | Détails d'une absence | read · idempotent |
-| `boond_absences_search` | Rechercher des absences | read · idempotent · open-world |
+| `boond_absences_get` | Details d'une absence | read · idempotent |
+| `boond_absences_search` | Rechercher des demandes d'absence | read · idempotent · open-world |
 | `boond_absences_update` | Modifier une absence | write · idempotent |
 
 ### accounts (2)
@@ -128,11 +128,12 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_contracts_create` | Créer un contrat | write |
 | `boond_contracts_get` | Détails d'un contrat | read · idempotent |
 
-### deliveries (2)
+### deliveries (3)
 
 | Tool | Title | Hints |
 |---|---|---|
-| `boond_deliveries_get` | Détails d'une livraison / CRA | read · idempotent |
+| `boond_deliveries_create` | Creer une prestation/livraison | write |
+| `boond_deliveries_get` | Details d'une livraison / CRA | read · idempotent |
 | `boond_deliveries_search` | Rechercher des livraisons / CRA | read · idempotent · open-world |
 
 ### documents (3)
@@ -209,11 +210,12 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_orders_search` | Rechercher des bons de commande | read · idempotent · open-world |
 | `boond_orders_update` | Modifier un(e) bon de commande | write · idempotent |
 
-### payments (2)
+### payments (3)
 
 | Tool | Title | Hints |
 |---|---|---|
-| `boond_payments_get` | Détails d'un paiement | read · idempotent |
+| `boond_payments_create` | Creer un paiement | write |
+| `boond_payments_get` | Details d'un paiement | read · idempotent |
 | `boond_payments_search` | Rechercher des paiements | read · idempotent · open-world |
 
 ### planning_absences (1)
@@ -266,11 +268,12 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_projects_simulation` | Simulation financière d'un projet | read · idempotent |
 | `boond_projects_update` | Modifier un(e) projet | write · idempotent |
 
-### provider_invoices (2)
+### provider_invoices (3)
 
 | Tool | Title | Hints |
 |---|---|---|
-| `boond_provider_invoices_get` | Détails d'une facture fournisseur | read · idempotent |
+| `boond_provider_invoices_create` | Creer une facture fournisseur | write |
+| `boond_provider_invoices_get` | Details d'une facture fournisseur | read · idempotent |
 | `boond_provider_invoices_search` | Rechercher des factures fournisseur | read · idempotent · open-world |
 
 ### purchases (4)
@@ -331,10 +334,11 @@ Hint legend: `read` (readOnlyHint), `write` (creates/updates), `delete` (destruc
 | `boond_threads_get` | Détails d'un(e) fil de discussion | read · idempotent |
 | `boond_threads_search` | Rechercher des fils de discussion | read · idempotent · open-world |
 
-### timesheets (2)
+### timesheets (3)
 
 | Tool | Title | Hints |
 |---|---|---|
+| `boond_timesheets_create` | Créer une feuille de temps | write |
 | `boond_timesheets_get` | Détails d'une feuille de temps | read · idempotent |
 | `boond_timesheets_search` | Rechercher des feuilles de temps | read · idempotent · open-world |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { initClient, initClientWithAuth, oauthContextAuth } from "./services/boond-client.js";
+import { initClient, initClientWithAuth, oauthContextAuth, hasEnvCredentials } from "./services/boond-client.js";
 import { createMcpServer, REGISTERED_DOMAINS } from "./server.js";
 import { runUpdateNotification } from "./services/update-checker.js";
 import { resolveHttpOptions, startHttpTransport } from "./transports/http.js";
@@ -34,22 +34,50 @@ function scheduleUpdateCheck(): void {
   void runUpdateNotification({ currentVersion: meta.version, packageName: meta.name });
 }
 
+function resolveStaticAuth(): boolean {
+  const v = process.env["BOOND_HTTP_STATIC_AUTH"];
+  if (!v || v.startsWith("${")) return false;
+  return v.toLowerCase() === "true" || v === "1" || v.toLowerCase() === "yes";
+}
+
 async function main(): Promise<void> {
   const kind = resolveTransport();
 
   if (kind === "http") {
-    // HTTP transport: OAuth2 only. The MCP server is a *protected resource*
-    // — it does not hold any OAuth client secrets and does not store tokens.
-    // Each MCP request carries its own `Authorization: Bearer <token>`,
-    // which the transport pushes into an AsyncLocalStorage context that the
-    // boond-client reads to call BoondManager on behalf of the user.
-    initClientWithAuth(oauthContextAuth);
+    const useStaticAuth = resolveStaticAuth();
+
+    if (useStaticAuth) {
+      // Static-auth mode: operator provides env credentials; no per-request
+      // OAuth token needed from MCP clients (e.g. Hermes, CI pipelines,
+      // single-tenant self-hosted deployments).
+      if (!hasEnvCredentials()) {
+        console.error(
+          "⚠️  BOOND_HTTP_STATIC_AUTH is set but no credentials found. " +
+            "Set BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY (or BOOND_API_TOKEN)."
+        );
+        process.exit(1);
+      }
+      try {
+        initClient();
+      } catch (error) {
+        console.error("⚠️  Failed to initialise env-based credentials:", (error as Error).message);
+        process.exit(1);
+      }
+    } else {
+      // OAuth2 protected resource: each MCP request must carry its own Bearer.
+      initClientWithAuth(oauthContextAuth);
+    }
+
     const options = resolveHttpOptions();
     const handle = await startHttpTransport(createMcpServer, options);
     console.error("🚀 BoondManager MCP Server running (streamable HTTP transport)");
     console.error(`📡 Endpoint: http://${handle.address.host}:${handle.address.port}${handle.address.path}`);
     console.error(`🔑 Mode: ${options.stateless ? "stateless" : "stateful"}`);
-    console.error("🔐 Boond auth: OAuth2 (per-request Bearer from MCP client)");
+    if (useStaticAuth) {
+      console.error("🔐 Boond auth: JWT statique (credentials env, pas de Bearer requis par le client)");
+    } else {
+      console.error("🔐 Boond auth: OAuth2 (per-request Bearer from MCP client)");
+    }
     console.error(`📦 Domains: ${REGISTERED_DOMAINS.join(", ")}`);
 
     const shutdown = async (signal: string): Promise<void> => {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -985,6 +985,7 @@ export const ProjectCreateSchema = z
     companyId: z.string().optional().describe("ID de la société cliente"),
     contactId: z.string().optional().describe("ID du contact associé"),
     opportunityId: z.string().optional().describe("ID de l'opportunité liée"),
+    typeOf: z.number().int().optional().describe("Type de projet (ID du dictionnaire setting.typeOf.project)"),
     state: stateField("project", "État du projet (0=en cours, 1=terminé, 2=archivé...)"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
@@ -996,6 +997,7 @@ export const ProjectUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID du projet à modifier"),
     name: z.string().optional().describe("Nom du projet"),
+    typeOf: z.number().int().optional().describe("Type de projet (ID du dictionnaire setting.typeOf.project)"),
     state: stateField("project", "État du projet"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
@@ -1008,13 +1010,14 @@ export const ProjectUpdateSchema = z
 export const InvoiceCreateSchema = z
   .object({
     reference: z.string().optional().describe("Référence de la facture"),
-    companyId: z.string().optional().describe("ID de la société facturée"),
-    projectId: z.string().optional().describe("ID du projet associé"),
+    orderId: z.string().optional().describe("ID du bon de commande associé"),
     state: z.number().int().optional().describe("État de la facture"),
     invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
-    dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
+    expectedPaymentDate: z.string().optional().describe("Date d'échéance/paiement attendu (YYYY-MM-DD)"),
     amountExcludingTax: z.number().optional().describe("Montant HT"),
     taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    invoiceRecords: z.array(z.record(z.string(), z.unknown())).optional().describe("Lignes de facture Boond"),
+    invoicePayments: z.array(z.record(z.string(), z.unknown())).optional().describe("Paiements client de la facture"),
     note: z.string().optional().describe("Notes / commentaires"),
   })
   .strict();
@@ -1025,9 +1028,11 @@ export const InvoiceUpdateSchema = z
     reference: z.string().optional().describe("Référence de la facture"),
     state: z.number().int().optional().describe("État de la facture"),
     invoiceDate: z.string().optional().describe("Date de facturation (YYYY-MM-DD)"),
-    dueDate: z.string().optional().describe("Date d'échéance (YYYY-MM-DD)"),
+    expectedPaymentDate: z.string().optional().describe("Date d'échéance/paiement attendu (YYYY-MM-DD)"),
     amountExcludingTax: z.number().optional().describe("Montant HT"),
     taxRate: z.number().optional().describe("Taux de TVA (%)"),
+    invoiceRecords: z.array(z.record(z.string(), z.unknown())).optional().describe("Lignes de facture Boond"),
+    invoicePayments: z.array(z.record(z.string(), z.unknown())).optional().describe("Paiements client de la facture"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -1057,7 +1062,11 @@ export const OrderCreateSchema = z
     projectId: z.string().optional().describe("ID du projet associé"),
     state: z.number().int().optional().describe("État du bon de commande"),
     orderDate: z.string().optional().describe("Date du bon de commande (YYYY-MM-DD)"),
+    startDate: z.string().optional().describe("Date de début couverte (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin couverte (YYYY-MM-DD)"),
     amountExcludingTax: z.number().optional().describe("Montant HT"),
+    customerAgreement: z.boolean().optional().describe("Accord client reçu"),
+    schedules: z.array(z.record(z.string(), z.unknown())).optional().describe("Lignes/échéances de commande"),
     note: z.string().optional().describe("Notes / commentaires"),
   })
   .strict();
@@ -1068,7 +1077,11 @@ export const OrderUpdateSchema = z
     reference: z.string().optional().describe("Référence"),
     state: z.number().int().optional().describe("État"),
     orderDate: z.string().optional().describe("Date (YYYY-MM-DD)"),
+    startDate: z.string().optional().describe("Date de début couverte (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin couverte (YYYY-MM-DD)"),
     amountExcludingTax: z.number().optional().describe("Montant HT"),
+    customerAgreement: z.boolean().optional().describe("Accord client reçu"),
+    schedules: z.array(z.record(z.string(), z.unknown())).optional().describe("Lignes/échéances de commande"),
     note: z.string().optional().describe("Notes"),
   })
   .strict();
@@ -1102,9 +1115,12 @@ export const DeliverySearchSchema = z
 export const AbsenceCreateSchema = z
   .object({
     resourceId: z.string().min(1).describe("ID de la ressource en absence"),
-    typeOf: z.string().min(1).describe("Type d'absence (congé payé, RTT, maladie, sans solde...)"),
+    typeOf: z.string().min(1).describe("Libellé de l'absence (congé payé, RTT, maladie, sans solde...)"),
     startDate: z.string().min(1).describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().min(1).describe("Date de fin (YYYY-MM-DD)"),
+    duration: z.number().optional().describe("Durée en jours ; calculée automatiquement si absente"),
+    workUnitTypeReference: z.number().int().min(1).optional().describe("Référence du type d'unité d'absence, défaut 1"),
+    absencesPeriods: z.array(z.record(z.string(), z.unknown())).optional().describe("Périodes d'absence Boond brutes"),
     state: z.number().int().optional().describe("État de la demande (0=en attente, 1=validé, 2=refusé...)"),
     note: z.string().optional().describe("Commentaire / motif"),
   })
@@ -1124,8 +1140,8 @@ export const AbsenceSearchSchema = z
   .object({
     keywords: z.string().optional().describe("Mots-clés de recherche"),
     resourceId: z.string().optional().describe("Filtrer par ID ressource"),
-    startDate: z.string().optional().describe("Date de début de période (YYYY-MM-DD)"),
-    endDate: z.string().optional().describe("Date de fin de période (YYYY-MM-DD)"),
+    startMonth: z.string().optional().describe("Mois de début de période (YYYY-MM)"),
+    endMonth: z.string().optional().describe("Mois de fin de période (YYYY-MM)"),
     page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
     pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
   })
@@ -1138,9 +1154,11 @@ export const ExpenseCreateSchema = z
     resourceId: z.string().min(1).describe("ID de la ressource"),
     projectId: z.string().optional().describe("ID du projet associé"),
     typeOf: z.string().optional().describe("Type de frais (transport, repas, hébergement...)"),
+    term: z.string().optional().describe("Période de la note de frais (YYYY-MM)"),
     expenseDate: z.string().min(1).describe("Date du frais (YYYY-MM-DD)"),
     amount: z.number().describe("Montant du frais"),
     currency: z.string().optional().describe("Devise (EUR, USD...)"),
+    exchangeRateAgency: z.number().optional().describe("Taux de change agence"),
     state: z.number().int().optional().describe("État de la note de frais"),
     note: z.string().optional().describe("Description / justification"),
   })
@@ -1149,7 +1167,9 @@ export const ExpenseCreateSchema = z
 export const ExpenseUpdateSchema = z
   .object({
     id: z.string().min(1).describe("ID de la note de frais à modifier"),
+    term: z.string().optional().describe("Période de la note de frais (YYYY-MM)"),
     amount: z.number().optional().describe("Montant"),
+    exchangeRateAgency: z.number().optional().describe("Taux de change agence"),
     state: z.number().int().optional().describe("État"),
     note: z.string().optional().describe("Description"),
   })
@@ -1250,7 +1270,10 @@ export const PaymentSearchSchema = z
   .object({
     keywords: z.string().optional().describe("Mots-clés de recherche"),
     invoiceId: z.string().optional().describe("Filtrer par ID facture"),
+    purchaseId: z.string().optional().describe("Filtrer par ID achat"),
     companyId: z.string().optional().describe("Filtrer par ID société"),
+    projectId: z.string().optional().describe("Filtrer par ID projet"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
     endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
     page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -145,6 +145,21 @@ export function initClient(): void {
 }
 
 /**
+ * True when env-based credentials (JWT components, API token, or BasicAuth) are
+ * configured. Used by the HTTP transport to decide whether static-auth mode is
+ * possible without attempting a full `initClient()` call.
+ */
+export function hasEnvCredentials(): boolean {
+  return !!(
+    (envOrUndefined("BOOND_USER_TOKEN") &&
+      envOrUndefined("BOOND_CLIENT_TOKEN") &&
+      envOrUndefined("BOOND_CLIENT_KEY")) ||
+    envOrUndefined("BOOND_API_TOKEN") ||
+    (envOrUndefined("BOOND_USER") && envOrUndefined("BOOND_PASSWORD"))
+  );
+}
+
+/**
  * Install a custom auth provider — used by the HTTP transport bootstrap to
  * wire in an OAuth2 token source (where the access token is refreshed
  * transparently per request rather than baked in at startup).

--- a/src/tools/absences.test.ts
+++ b/src/tools/absences.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerAbsenceTools } from "./absences.js";
+import { apiRequest } from "../services/boond-client.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "31", type: "absencesreport", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -13,6 +21,8 @@ describe("registerAbsenceTools", () => {
 
   beforeEach(() => {
     server = createMockServer();
+    vi.mocked(apiRequest).mockClear();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "31", type: "absencesreport", attributes: {} } } as never);
   });
 
   it("should register 5 absence tools", () => {
@@ -32,9 +42,11 @@ describe("registerAbsenceTools", () => {
 
   it("should register search and get as readOnly", () => {
     registerAbsenceTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_absences_search", "boond_absences_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) => typeof c[0] === "string" && ["boond_absences_search", "boond_absences_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -42,9 +54,82 @@ describe("registerAbsenceTools", () => {
 
   it("should register delete as destructive", () => {
     registerAbsenceTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_absences_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_absences_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  it("creates absences-reports with absencesPeriods", async () => {
+    registerAbsenceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_absences_create");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({
+      resourceId: "5",
+      typeOf: "CP",
+      startDate: "2026-07-14",
+      endDate: "2026-07-15",
+      workUnitTypeReference: 1,
+      note: "note",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/absences-reports", "POST", {
+      data: {
+        type: "absencesreport",
+        attributes: {
+          informationComments: "note",
+          absencesPeriods: [
+            {
+              startDate: "2026-07-14",
+              endDate: "2026-07-15",
+              duration: 2,
+              title: "CP",
+              workUnitType: { reference: 1 },
+            },
+          ],
+        },
+        relationships: {
+          resource: { data: { id: "5", type: "resource" } },
+        },
+      },
+    });
+  });
+
+  it("maps absence state when provided", async () => {
+    registerAbsenceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_absences_create");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({
+      resourceId: "5",
+      typeOf: "CP",
+      startDate: "2026-07-14",
+      endDate: "2026-07-14",
+      state: 1,
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "/absences-reports",
+      "POST",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          attributes: expect.objectContaining({ state: 1 }),
+        }),
+      })
+    );
+  });
+
+  it("searches absences reports with resource keyword reference", async () => {
+    registerAbsenceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_absences_search");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({ resourceId: "5", startMonth: "2026-07", endMonth: "2026-09", page: 1, pageSize: 20 });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "/absences-reports",
+      "GET",
+      undefined,
+      expect.objectContaining({ keywords: "COMP5", startMonth: "2026-07", endMonth: "2026-09" })
+    );
   });
 });

--- a/src/tools/absences.ts
+++ b/src/tools/absences.ts
@@ -3,21 +3,26 @@ import { AbsenceSearchSchema, AbsenceCreateSchema, AbsenceUpdateSchema, IdSchema
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
 import { buildJsonApiBody, registerDeleteTool } from "./crud-factory.js";
 
+function inclusiveDays(startDate: string, endDate: string): number {
+  const start = new Date(`${startDate}T00:00:00Z`);
+  const end = new Date(`${endDate}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end < start) return 1;
+  return Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1;
+}
+
 export function registerAbsenceTools(server: McpServer): void {
-  // Search absences
   server.registerTool(
     "boond_absences_search",
     {
-      title: "Rechercher des absences",
-      description: `Recherche des absences (congés, RTT, maladie...) dans BoondManager avec filtres par ressource et période.
+      title: "Rechercher des demandes d'absence",
+      description: `Recherche des demandes d'absence dans BoondManager.
 
 Args:
-  - keywords (string, optional): Termes de recherche
-  - resourceId (string, optional): Filtrer par ID ressource
-  - startDate, endDate (string, optional): Période (YYYY-MM-DD)
+  - keywords (string, optional): Termes de recherche. resourceId est converti en COMP<id>.
+  - startMonth, endMonth (string, optional): Periode au format YYYY-MM.
   - page, pageSize: Pagination
 
-Returns: Liste des absences correspondantes.`,
+Returns: Liste des demandes d'absence correspondantes.`,
       inputSchema: AbsenceSearchSchema,
       annotations: {
         readOnlyHint: true,
@@ -27,20 +32,23 @@ Returns: Liste des absences correspondantes.`,
       },
     },
     async (params) => {
-      const query = buildSearchQuery(params);
-      const response = await apiRequest("/absences", "GET", undefined, query);
+      const { resourceId, keywords, ...rest } = params;
+      const tokens: string[] = [];
+      if (keywords) tokens.push(keywords);
+      if (resourceId) tokens.push(`COMP${resourceId}`);
+      const query = buildSearchQuery(tokens.length > 0 ? { ...rest, keywords: tokens.join(" ") } : rest);
+      const response = await apiRequest("/absences-reports", "GET", undefined, query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "absence") }],
       };
     }
   );
 
-  // Get absence details
   server.registerTool(
     "boond_absences_get",
     {
-      title: "Détails d'une absence",
-      description: `Récupère les informations détaillées d'une absence par son ID.`,
+      title: "Details d'une absence",
+      description: "Recupere les informations detaillees d'une demande d'absence par son ID.",
       inputSchema: IdSchema,
       annotations: {
         readOnlyHint: true,
@@ -57,12 +65,11 @@ Returns: Liste des absences correspondantes.`,
     }
   );
 
-  // Create absence
   server.registerTool(
     "boond_absences_create",
     {
-      title: "Créer une absence",
-      description: `Crée une nouvelle demande d'absence dans BoondManager, liée à une ressource.`,
+      title: "Creer une demande d'absence",
+      description: "Cree une demande d'absence Boond avec absencesPeriods.",
       inputSchema: AbsenceCreateSchema,
       annotations: {
         readOnlyHint: false,
@@ -72,32 +79,43 @@ Returns: Liste des absences correspondantes.`,
       },
     },
     async (params) => {
-      const { resourceId, ...attrs } = params;
-      const body = buildJsonApiBody("absence", attrs);
-      if (resourceId) {
-        (body as Record<string, Record<string, unknown>>).data.relationships = {
-          resource: { data: { id: resourceId, type: "resource" } },
-        };
-      }
+      const { resourceId, typeOf, startDate, endDate, duration, workUnitTypeReference, absencesPeriods, state, note } =
+        params;
+      const periods = absencesPeriods ?? [
+        {
+          startDate,
+          endDate,
+          duration: duration ?? inclusiveDays(startDate, endDate),
+          title: typeOf,
+          workUnitType: { reference: workUnitTypeReference ?? 2 },
+        },
+      ];
+      const body = buildJsonApiBody("absencesreport", {
+        ...(note ? { informationComments: note } : {}),
+        ...(state !== undefined ? { state } : {}),
+        absencesPeriods: periods,
+      });
+      (body as Record<string, Record<string, unknown>>).data.relationships = {
+        resource: { data: { id: resourceId, type: "resource" } },
+      };
       const response = await apiRequest("/absences-reports", "POST", body);
       const entity = Array.isArray(response.data) ? response.data[0] : response.data;
       return {
         content: [
           {
             type: "text" as const,
-            text: `✅ Absence créée avec succès.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+            text: `Absence creee avec succes.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
           },
         ],
       };
     }
   );
 
-  // Update absence
   server.registerTool(
     "boond_absences_update",
     {
       title: "Modifier une absence",
-      description: `Met à jour une absence existante. Seuls les champs fournis sont modifiés.`,
+      description: "Met a jour une demande d'absence existante. Seuls les champs fournis sont modifies.",
       inputSchema: AbsenceUpdateSchema,
       annotations: {
         readOnlyHint: false,
@@ -108,26 +126,25 @@ Returns: Liste des absences correspondantes.`,
     },
     async (params) => {
       const { id, ...attrs } = params;
-      const body = buildJsonApiBody("absence", attrs, id);
+      const body = buildJsonApiBody("absencesreport", attrs, id);
       const response = await apiRequest(`/absences-reports/${id}`, "PUT", body);
       return {
         content: [
           {
             type: "text" as const,
-            text: `✅ Absence #${id} mise à jour.\n\n${formatDetailResponse(response)}`,
+            text: `Absence #${id} mise a jour.\n\n${formatDetailResponse(response)}`,
           },
         ],
       };
     }
   );
 
-  // Delete absence — via la factory pour l'élicitation de confirmation + structuredContent
   registerDeleteTool(
     server,
     { entityName: "absence", entityNamePlural: "absences", apiPath: "/absences-reports", prefix: "boond_absences" },
     {
       title: "Supprimer une absence",
-      description: `Supprime une absence de BoondManager. ⚠️ Action irréversible. Si le client MCP supporte l'élicitation, une confirmation est demandée avant la suppression.`,
+      description: "Supprime une absence de BoondManager. Action irreversible.",
     }
   );
 }

--- a/src/tools/deliveries.test.ts
+++ b/src/tools/deliveries.test.ts
@@ -1,15 +1,93 @@
-import { vi } from "vitest";
-import { describeSearchGetTools } from "./test-helpers.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createMockServer, registeredToolNames, toolCallback } from "./test-helpers.js";
 import { registerDeliveryTools } from "./deliveries.js";
+import { apiRequest } from "../services/boond-client.js";
 
-vi.mock("../services/boond-client.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
-});
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "21", type: "delivery", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
-describeSearchGetTools("registerDeliveryTools", {
-  registrar: registerDeliveryTools,
-  namePrefix: "boond_deliveries",
-  searchPath: "/deliveries-groupments",
-  getPath: (id) => `/deliveries/${id}`,
+describe("registerDeliveryTools", () => {
+  let server: McpServer;
+
+  beforeEach(() => {
+    server = createMockServer();
+    vi.mocked(apiRequest).mockReset();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "21", type: "delivery", attributes: {} } } as never);
+  });
+
+  it("should register 3 delivery tools", () => {
+    registerDeliveryTools(server);
+    expect(server.registerTool).toHaveBeenCalledTimes(3);
+  });
+
+  it("should register all expected tool names", () => {
+    registerDeliveryTools(server);
+    const names = registeredToolNames(server);
+    expect(names).toContain("boond_deliveries_create");
+    expect(names).toContain("boond_deliveries_search");
+    expect(names).toContain("boond_deliveries_get");
+  });
+
+  it("should register search/get as readOnly and create as write", () => {
+    registerDeliveryTools(server);
+    const calls = vi.mocked(server.registerTool).mock.calls;
+    expect(calls.find((c) => c[0] === "boond_deliveries_create")?.[1].annotations?.readOnlyHint).toBe(false);
+    expect(calls.find((c) => c[0] === "boond_deliveries_search")?.[1].annotations?.readOnlyHint).toBe(true);
+    expect(calls.find((c) => c[0] === "boond_deliveries_get")?.[1].annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("search should call the BoondManager API on the deliveries groupments path", async () => {
+    registerDeliveryTools(server);
+    await toolCallback(server, "boond_deliveries_search")({ page: 2, pageSize: 10 });
+    expect(vi.mocked(apiRequest).mock.calls[0][0]).toBe("/deliveries-groupments");
+    expect(vi.mocked(apiRequest).mock.calls[0][1]).toBe("GET");
+  });
+
+  it("get should call the BoondManager API on the detail path", async () => {
+    registerDeliveryTools(server);
+    await toolCallback(server, "boond_deliveries_get")({ id: "42" });
+    expect(vi.mocked(apiRequest).mock.calls[0][0]).toBe("/deliveries/42");
+  });
+
+  it("creates deliveries through /deliveries with project and dependsOn resource", async () => {
+    registerDeliveryTools(server);
+
+    await toolCallback(
+      server,
+      "boond_deliveries_create"
+    )({
+      projectId: "2",
+      resourceId: "4",
+      title: "Prestation",
+      startDate: "2026-08-01",
+      endDate: "2026-08-31",
+      quantity: 15,
+      unitPrice: 850,
+      note: "note",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/deliveries", "POST", {
+      data: {
+        type: "delivery",
+        attributes: {
+          title: "Prestation",
+          startDate: "2026-08-01",
+          endDate: "2026-08-31",
+          numberOfDaysInvoicedOrQuantity: 15,
+          averageDailyPriceExcludingTax: 850,
+          forceAverageDailyPriceExcludingTax: true,
+          informationComments: "note",
+        },
+        relationships: {
+          project: { data: { id: "2", type: "project" } },
+          dependsOn: { data: { id: "4", type: "resource" } },
+        },
+      },
+    });
+  });
 });

--- a/src/tools/deliveries.ts
+++ b/src/tools/deliveries.ts
@@ -1,19 +1,77 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { DeliverySearchSchema, IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import { buildJsonApiBody } from "./crud-factory.js";
+import { z } from "zod";
+
+const DeliveryCreateSchema = z
+  .object({
+    projectId: z.string().min(1).describe("ID du projet"),
+    resourceId: z.string().min(1).describe("ID de la ressource portee par la prestation"),
+    title: z.string().optional().describe("Titre de la prestation/livraison"),
+    typeOf: z.number().int().optional().describe("Type de prestation"),
+    state: z.number().int().optional().describe("Etat"),
+    startDate: z.string().optional().describe("Date de debut (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    quantity: z.number().optional().describe("Nombre de jours / quantite"),
+    unitPrice: z.number().optional().describe("Prix journalier HT"),
+    averageDailyCost: z.number().optional().describe("Cout journalier moyen"),
+    forceAverageDailyPriceExcludingTax: z.boolean().optional().describe("Forcer le prix journalier HT"),
+    note: z.string().optional().describe("Notes, mappees vers informationComments"),
+  })
+  .strict();
 
 export function registerDeliveryTools(server: McpServer): void {
-  // Search deliveries
+  server.registerTool(
+    "boond_deliveries_create",
+    {
+      title: "Creer une prestation/livraison",
+      description: "Cree une prestation Boond via POST /deliveries, liee a un projet et une ressource.",
+      inputSchema: DeliveryCreateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params) => {
+      const { projectId, resourceId, quantity, unitPrice, note, ...attrs } = params;
+      const apiAttrs = {
+        ...attrs,
+        ...(quantity !== undefined ? { numberOfDaysInvoicedOrQuantity: quantity } : {}),
+        ...(unitPrice !== undefined ? { averageDailyPriceExcludingTax: unitPrice } : {}),
+        ...(unitPrice !== undefined ? { forceAverageDailyPriceExcludingTax: true } : {}),
+        ...(note ? { informationComments: note } : {}),
+      };
+      const body = buildJsonApiBody("delivery", apiAttrs);
+      (body as Record<string, Record<string, unknown>>).data.relationships = {
+        project: { data: { id: projectId, type: "project" } },
+        dependsOn: { data: { id: resourceId, type: "resource" } },
+      };
+      const response = await apiRequest("/deliveries", "POST", body);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Prestation/livraison creee avec succes.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
   server.registerTool(
     "boond_deliveries_search",
     {
       title: "Rechercher des livraisons / CRA",
-      description: `Recherche des livraisons (comptes rendus d'activité) dans BoondManager avec filtres par projet, société et période.
+      description: `Recherche des livraisons (comptes rendus d'activite) dans BoondManager avec filtres par projet, societe et periode.
 
 Args:
   - keywords (string, optional): Termes de recherche
-  - projectId, companyId (string, optional): Filtrer par entité liée
-  - startDate, endDate (string, optional): Période (YYYY-MM-DD)
+  - projectId, companyId (string, optional): Filtrer par entite liee
+  - startDate, endDate (string, optional): Periode (YYYY-MM-DD)
   - page, pageSize: Pagination
 
 Returns: Liste des livraisons correspondantes.`,
@@ -34,12 +92,11 @@ Returns: Liste des livraisons correspondantes.`,
     }
   );
 
-  // Get delivery details
   server.registerTool(
     "boond_deliveries_get",
     {
-      title: "Détails d'une livraison / CRA",
-      description: `Récupère les informations détaillées d'une livraison (CRA) par son ID.`,
+      title: "Details d'une livraison / CRA",
+      description: "Recupere les informations detaillees d'une livraison (CRA) par son ID.",
       inputSchema: IdSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/invoices.test.ts
+++ b/src/tools/invoices.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerInvoiceTools } from "./invoices.js";
+import { apiRequest } from "../services/boond-client.js";
+import { InvoiceCreateSchema, InvoiceUpdateSchema } from "../schemas/index.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "1", type: "invoice", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -13,6 +22,8 @@ describe("registerInvoiceTools", () => {
 
   beforeEach(() => {
     server = createMockServer();
+    vi.mocked(apiRequest).mockClear();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "1", type: "invoice", attributes: {} } } as never);
   });
 
   it("should register 5 invoice tools", () => {
@@ -32,9 +43,11 @@ describe("registerInvoiceTools", () => {
 
   it("should register search and get as readOnly", () => {
     registerInvoiceTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_invoices_search", "boond_invoices_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) => typeof c[0] === "string" && ["boond_invoices_search", "boond_invoices_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -42,9 +55,89 @@ describe("registerInvoiceTools", () => {
 
   it("should register delete as destructive", () => {
     registerInvoiceTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_invoices_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_invoices_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  it("keeps invoice create contract centered on orderId", () => {
+    expect(InvoiceCreateSchema.safeParse({ orderId: "7", reference: "FAC-1" }).success).toBe(true);
+    expect(InvoiceCreateSchema.safeParse({ companyId: "1", projectId: "2", reference: "FAC-1" }).success).toBe(false);
+  });
+
+  it("rejects invoice update fields that are not mapped by the information endpoint", () => {
+    expect(InvoiceUpdateSchema.safeParse({ id: "1", orderId: "7" }).success).toBe(false);
+    expect(InvoiceUpdateSchema.safeParse({ id: "1", dueDate: "2026-08-24" }).success).toBe(false);
+    expect(InvoiceUpdateSchema.safeParse({ id: "1", amountIncludingTax: 12600 }).success).toBe(false);
+  });
+
+  it("creates invoices with an order relationship", async () => {
+    registerInvoiceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_invoices_create");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({ orderId: "7", reference: "FAC-1", amountExcludingTax: 12000, taxRate: 5 });
+
+    expect(apiRequest).toHaveBeenCalledWith("/invoices", "POST", {
+      data: {
+        type: "invoice",
+        attributes: {
+          reference: "FAC-1",
+          invoiceRecords: [
+            {
+              invoiceRecordType: null,
+              description: "Prestation",
+              amountExcludingTax: 12000,
+              quantity: 1,
+              taxRates: [5],
+              taxes: [5],
+            },
+          ],
+        },
+        relationships: {
+          order: { data: { id: "7", type: "order" } },
+        },
+      },
+    });
+  });
+
+  it("updates invoice information with records and customer payments", async () => {
+    registerInvoiceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_invoices_update");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({
+      id: "1",
+      reference: "FAC-1",
+      invoiceDate: "2026-07-25",
+      expectedPaymentDate: "2026-08-24",
+      amountExcludingTax: 12000,
+      taxRate: 5,
+      invoicePayments: [{ createdAt: "2026-08-10T10:00:00+0000", amountIncludingTax: 12600, comment: "paye" }],
+      note: "Audit",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/invoices/1/information", "PUT", {
+      data: {
+        type: "invoice",
+        attributes: {
+          reference: "FAC-1",
+          expectedPaymentDate: "2026-08-24",
+          invoicePayments: [{ createdAt: "2026-08-10T10:00:00+0000", amountIncludingTax: 12600, comment: "paye" }],
+          date: "2026-07-25",
+          invoiceRecords: [
+            {
+              invoiceRecordType: null,
+              description: "Audit",
+              amountExcludingTax: 12000,
+              quantity: 1,
+              taxRates: [5],
+              taxes: [5],
+            },
+          ],
+          informationComments: "Audit",
+        },
+        id: "1",
+      },
+    });
   });
 });

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -18,13 +18,45 @@ const OPTS = {
   prefix: "boond_invoices",
 };
 
-/** Maps the companyId/projectId convenience inputs to JSON:API relationships. */
+/** Maps convenience inputs and simple amount fields to the Boond JSON:API body. */
 function buildInvoiceBody(params: Record<string, unknown>): unknown {
-  const { id, companyId, projectId, ...attrs } = params;
-  return buildJsonApiBody("invoice", attrs, id as string | undefined, {
+  const { id, orderId, companyId, projectId, ...rest } = params;
+  return buildJsonApiBody("invoice", invoiceAttributes(rest), id as string | undefined, {
+    order: orderId ? { id: String(orderId), type: "order" } : undefined,
     company: companyId ? { id: String(companyId), type: "company" } : undefined,
     project: projectId ? { id: String(projectId), type: "project" } : undefined,
   });
+}
+
+function invoiceRecordFromAmount(amount: number, taxRate?: number, note?: string): Record<string, unknown> {
+  return {
+    invoiceRecordType: null,
+    description: note ?? "Prestation",
+    amountExcludingTax: amount,
+    quantity: 1,
+    taxRates: [taxRate ?? 0],
+    taxes: [taxRate ?? 0],
+  };
+}
+
+function invoiceAttributes(params: Record<string, unknown>): Record<string, unknown> {
+  const { invoiceDate, amountExcludingTax, taxRate, note, ...attrs } = params;
+  return {
+    ...attrs,
+    ...(invoiceDate ? { date: invoiceDate } : {}),
+    ...(amountExcludingTax !== undefined && !Array.isArray(attrs.invoiceRecords)
+      ? {
+          invoiceRecords: [
+            invoiceRecordFromAmount(
+              Number(amountExcludingTax),
+              typeof taxRate === "number" ? taxRate : undefined,
+              note as string | undefined
+            ),
+          ],
+        }
+      : {}),
+    ...(note ? { informationComments: note } : {}),
+  };
 }
 
 export function registerInvoiceTools(server: McpServer): void {
@@ -35,15 +67,7 @@ export function registerInvoiceTools(server: McpServer): void {
     "boond_invoices_search",
     {
       title: "Rechercher des factures",
-      description: `Recherche des factures dans BoondManager avec filtres par société, projet et période.
-
-Args:
-  - keywords (string, optional): Termes de recherche (référence, société...)
-  - companyId, projectId (string, optional): Filtrer par entité liée
-  - startDate, endDate (string, optional): Période (YYYY-MM-DD)
-  - page, pageSize: Pagination
-
-Returns: Liste des factures correspondantes.`,
+      description: "Recherche des factures dans BoondManager avec filtres par societe, projet et periode.",
       inputSchema: InvoiceSearchSchema,
       outputSchema: SearchOutputSchema,
       annotations: {
@@ -68,7 +92,10 @@ Returns: Liste des factures correspondantes.`,
 
   registerGetTool(server, OPTS, { withTab: false });
   registerCreateTool(server, OPTS, InvoiceCreateSchema, buildInvoiceBody);
-  registerUpdateTool(server, OPTS, InvoiceUpdateSchema, buildInvoiceBody);
+  registerUpdateTool(server, OPTS, InvoiceUpdateSchema, buildInvoiceBody, {
+    method: "PUT",
+    pathSuffix: "information",
+  });
   registerDeleteTool(server, OPTS, {
     title: "Supprimer une facture",
     description: `Supprime une facture de BoondManager. ⚠️ Action irréversible. Si le client MCP supporte l'élicitation, une confirmation est demandée avant la suppression.`,

--- a/src/tools/orders.test.ts
+++ b/src/tools/orders.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerOrderTools } from "./orders.js";
+import { apiRequest } from "../services/boond-client.js";
+import { OrderCreateSchema, OrderUpdateSchema } from "../schemas/index.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "1", type: "order", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -13,6 +22,8 @@ describe("registerOrderTools", () => {
 
   beforeEach(() => {
     server = createMockServer();
+    vi.mocked(apiRequest).mockClear();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "1", type: "order", attributes: {} } } as never);
   });
 
   it("should register 5 order tools", () => {
@@ -32,9 +43,11 @@ describe("registerOrderTools", () => {
 
   it("should register search and get as readOnly", () => {
     registerOrderTools(server);
-    const readOnlyCalls = vi.mocked(server.registerTool).mock.calls.filter(
-      (c) => typeof c[0] === "string" && ["boond_orders_search", "boond_orders_get"].includes(c[0] as string)
-    );
+    const readOnlyCalls = vi
+      .mocked(server.registerTool)
+      .mock.calls.filter(
+        (c) => typeof c[0] === "string" && ["boond_orders_search", "boond_orders_get"].includes(c[0] as string)
+      );
     for (const call of readOnlyCalls) {
       expect(call[1].annotations?.readOnlyHint).toBe(true);
     }
@@ -42,9 +55,47 @@ describe("registerOrderTools", () => {
 
   it("should register delete as destructive", () => {
     registerOrderTools(server);
-    const deleteCall = vi.mocked(server.registerTool).mock.calls.find(
-      (c) => c[0] === "boond_orders_delete"
-    );
+    const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_orders_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  it("rejects order amount fields that are not mapped", () => {
+    expect(OrderCreateSchema.safeParse({ amountIncludingTax: 12600 }).success).toBe(false);
+    expect(OrderUpdateSchema.safeParse({ id: "1", amountIncludingTax: 12600 }).success).toBe(false);
+  });
+
+  it("updates order information with Boond schedule fields", async () => {
+    registerOrderTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_orders_update");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({
+      id: "1",
+      reference: "BC-1",
+      amountExcludingTax: 12000,
+      customerAgreement: true,
+      schedules: [{ title: "Echeance", date: "2026-07-31", amountExcludingTax: 12000 }],
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/orders/1/information", "PUT", {
+      data: {
+        type: "order",
+        attributes: {
+          number: "BC-1",
+          turnoverOrderedExcludingTax: 12000,
+          customerAgreement: true,
+          schedules: [
+            {
+              date: "2026-07-31",
+              title: "Echeance",
+              turnoverQuotaExcludingTax: 12000,
+              turnoverTermOfPaymentExcludingTax: 12000,
+              forceTermOfPaymentExcludingTax: true,
+            },
+          ],
+        },
+        id: "1",
+      },
+    });
   });
 });

--- a/src/tools/orders.ts
+++ b/src/tools/orders.ts
@@ -16,13 +16,44 @@ const OPTS = {
   prefix: "boond_orders",
 };
 
-/** Maps the companyId/projectId convenience inputs to JSON:API relationships. */
+/** Maps convenience inputs and schedule shortcuts to the Boond JSON:API body. */
 function buildOrderBody(params: Record<string, unknown>): unknown {
-  const { id, companyId, projectId, ...attrs } = params;
-  return buildJsonApiBody("order", attrs, id as string | undefined, {
+  const { id, companyId, projectId, ...rest } = params;
+  return buildJsonApiBody("order", orderAttributes(rest), id as string | undefined, {
     company: companyId ? { id: String(companyId), type: "company" } : undefined,
     project: projectId ? { id: String(projectId), type: "project" } : undefined,
   });
+}
+
+function normalizeSchedules(schedules?: Array<Record<string, unknown>>): Array<Record<string, unknown>> | undefined {
+  return schedules?.map((schedule) => {
+    const amount =
+      typeof schedule.amountExcludingTax === "number"
+        ? schedule.amountExcludingTax
+        : typeof schedule.turnoverTermOfPaymentExcludingTax === "number"
+          ? schedule.turnoverTermOfPaymentExcludingTax
+          : undefined;
+    return {
+      ...(typeof schedule.id === "string" ? { id: schedule.id } : {}),
+      date: schedule.date ?? schedule.endDate ?? schedule.startDate,
+      title: schedule.title ?? "Echeance",
+      turnoverQuotaExcludingTax: schedule.turnoverQuotaExcludingTax ?? amount ?? 0,
+      turnoverTermOfPaymentExcludingTax: schedule.turnoverTermOfPaymentExcludingTax ?? amount ?? 0,
+      forceTermOfPaymentExcludingTax: schedule.forceTermOfPaymentExcludingTax ?? true,
+    };
+  });
+}
+
+function orderAttributes(params: Record<string, unknown>): Record<string, unknown> {
+  const { reference, orderDate, amountExcludingTax, schedules, note, ...attrs } = params;
+  return {
+    ...attrs,
+    ...(reference ? { number: reference } : {}),
+    ...(orderDate ? { date: orderDate } : {}),
+    ...(amountExcludingTax !== undefined ? { turnoverOrderedExcludingTax: amountExcludingTax } : {}),
+    ...(Array.isArray(schedules) ? { schedules: normalizeSchedules(schedules as Array<Record<string, unknown>>) } : {}),
+    ...(note ? { informationComments: note } : {}),
+  };
 }
 
 export function registerOrderTools(server: McpServer): void {
@@ -39,7 +70,10 @@ Returns: Liste des bons de commande correspondants.`,
   });
   registerGetTool(server, OPTS, { withTab: false });
   registerCreateTool(server, OPTS, OrderCreateSchema, buildOrderBody);
-  registerUpdateTool(server, OPTS, OrderUpdateSchema, buildOrderBody);
+  registerUpdateTool(server, OPTS, OrderUpdateSchema, buildOrderBody, {
+    method: "PUT",
+    pathSuffix: "information",
+  });
   registerDeleteTool(server, OPTS, {
     title: "Supprimer un bon de commande",
     description: `Supprime un bon de commande de BoondManager. ⚠️ Action irréversible. Si le client MCP supporte l'élicitation, une confirmation est demandée avant la suppression.`,

--- a/src/tools/payments.test.ts
+++ b/src/tools/payments.test.ts
@@ -1,14 +1,95 @@
-import { vi } from "vitest";
-import { describeSearchGetTools } from "./test-helpers.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createMockServer, registeredToolNames, toolCallback } from "./test-helpers.js";
 import { registerPaymentTools } from "./payments.js";
+import { apiRequest } from "../services/boond-client.js";
 
-vi.mock("../services/boond-client.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
-});
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "9", type: "payment", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
-describeSearchGetTools("registerPaymentTools", {
-  registrar: registerPaymentTools,
-  namePrefix: "boond_payments",
-  searchPath: "/payments",
+describe("registerPaymentTools", () => {
+  let server: McpServer;
+
+  beforeEach(() => {
+    server = createMockServer();
+    vi.mocked(apiRequest).mockReset();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "9", type: "payment", attributes: {} } } as never);
+  });
+
+  it("should register 3 payment tools", () => {
+    registerPaymentTools(server);
+    expect(server.registerTool).toHaveBeenCalledTimes(3);
+  });
+
+  it("should register all expected tool names", () => {
+    registerPaymentTools(server);
+    const names = registeredToolNames(server);
+    expect(names).toContain("boond_payments_create");
+    expect(names).toContain("boond_payments_search");
+    expect(names).toContain("boond_payments_get");
+  });
+
+  it("should register search/get as readOnly and create as write", () => {
+    registerPaymentTools(server);
+    const calls = vi.mocked(server.registerTool).mock.calls;
+    expect(calls.find((c) => c[0] === "boond_payments_create")?.[1].annotations?.readOnlyHint).toBe(false);
+    expect(calls.find((c) => c[0] === "boond_payments_search")?.[1].annotations?.readOnlyHint).toBe(true);
+    expect(calls.find((c) => c[0] === "boond_payments_get")?.[1].annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("maps create input to Boond purchase payment body", async () => {
+    registerPaymentTools(server);
+
+    await toolCallback(
+      server,
+      "boond_payments_create"
+    )({
+      purchaseId: "3",
+      paymentDate: "2026-08-10",
+      amount: 3200,
+      reference: "PAY-1",
+      note: "note",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/payments", "POST", {
+      data: {
+        type: "payment",
+        attributes: {
+          date: "2026-08-10",
+          amountExcludingTax: 3200,
+          number: "PAY-1",
+          informationComments: "note",
+        },
+        relationships: {
+          purchase: { data: { id: "3", type: "purchase" } },
+        },
+      },
+    });
+  });
+
+  it("converts payment search filters into keyword references", async () => {
+    registerPaymentTools(server);
+
+    await toolCallback(
+      server,
+      "boond_payments_search"
+    )({
+      purchaseId: "1",
+      companyId: "2",
+      projectId: "3",
+      resourceId: "4",
+      page: 1,
+      pageSize: 20,
+    });
+
+    const query = vi.mocked(apiRequest).mock.calls[0][3] as Record<string, unknown>;
+    expect(query.keywords).toContain("ACH1");
+    expect(query.keywords).toContain("CSOC2");
+    expect(query.keywords).toContain("PRJ3");
+    expect(query.keywords).toContain("COMP4");
+  });
 });

--- a/src/tools/payments.ts
+++ b/src/tools/payments.ts
@@ -1,19 +1,77 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PaymentSearchSchema, IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import { buildJsonApiBody } from "./crud-factory.js";
+import { z } from "zod";
+
+const PaymentCreateSchema = z
+  .object({
+    purchaseId: z.string().min(1).describe("ID de l'achat regle"),
+    paymentDate: z.string().optional().describe("Date du paiement (YYYY-MM-DD), mappee vers date"),
+    performedDate: z.string().optional().describe("Date de paiement effectif (YYYY-MM-DD)"),
+    expectedDate: z.string().optional().describe("Date de paiement attendu (YYYY-MM-DD)"),
+    startDate: z.string().optional().describe("Date de debut couverte (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin couverte (YYYY-MM-DD)"),
+    amount: z.number().optional().describe("Montant HT du paiement, mappe vers amountExcludingTax"),
+    amountExcludingTax: z.number().optional().describe("Montant HT du paiement"),
+    state: z.number().int().optional().describe("Etat du paiement / achat"),
+    paymentMethod: z.number().int().optional().describe("Methode de paiement"),
+    taxRates: z.array(z.number()).optional().describe("Taux de taxes Boond"),
+    reference: z.string().optional().describe("Reference bancaire ou reglement"),
+    note: z.string().optional().describe("Note interne, mappee vers informationComments"),
+  })
+  .strict();
 
 export function registerPaymentTools(server: McpServer): void {
-  // Search payments
+  server.registerTool(
+    "boond_payments_create",
+    {
+      title: "Creer un paiement",
+      description: "Cree un paiement fournisseur lie a un achat. L'API Boond /payments requiert une relation purchase.",
+      inputSchema: PaymentCreateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params) => {
+      const { purchaseId, paymentDate, amount, reference, note, ...attrs } = params;
+      const apiAttrs = {
+        ...attrs,
+        ...(paymentDate ? { date: paymentDate } : {}),
+        ...(amount !== undefined && attrs.amountExcludingTax === undefined ? { amountExcludingTax: amount } : {}),
+        ...(reference ? { number: reference } : {}),
+        ...(note ? { informationComments: note } : {}),
+      };
+      const body = buildJsonApiBody("payment", apiAttrs);
+      (body as Record<string, Record<string, unknown>>).data.relationships = {
+        purchase: { data: { id: purchaseId, type: "purchase" } },
+      };
+      const response = await apiRequest("/payments", "POST", body);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Paiement cree avec succes.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
   server.registerTool(
     "boond_payments_search",
     {
       title: "Rechercher des paiements",
-      description: `Recherche des paiements / règlements dans BoondManager avec filtres par facture, société et période.
+      description: `Recherche des paiements / reglements dans BoondManager.
 
 Args:
-  - keywords (string, optional): Termes de recherche
-  - invoiceId, companyId (string, optional): Filtrer par entité liée
-  - startDate, endDate (string, optional): Période (YYYY-MM-DD)
+  - keywords (string, optional): Termes de recherche. Utiliser ACH<id>, CSOC<id>, PRJ<id> selon la doc Boond pour filtrer par achat, societe ou projet.
+  - invoiceId, companyId (string, optional): Conserves pour compatibilite, transmis comme query params si fournis.
+  - startDate, endDate (string, optional): Periode (YYYY-MM-DD)
   - page, pageSize: Pagination
 
 Returns: Liste des paiements correspondants.`,
@@ -26,7 +84,14 @@ Returns: Liste des paiements correspondants.`,
       },
     },
     async (params) => {
-      const query = buildSearchQuery(params);
+      const { purchaseId, companyId, projectId, resourceId, keywords, ...rest } = params;
+      const tokens: string[] = [];
+      if (keywords) tokens.push(keywords);
+      if (purchaseId) tokens.push(`ACH${purchaseId}`);
+      if (companyId) tokens.push(`CSOC${companyId}`);
+      if (projectId) tokens.push(`PRJ${projectId}`);
+      if (resourceId) tokens.push(`COMP${resourceId}`);
+      const query = buildSearchQuery(tokens.length > 0 ? { ...rest, keywords: tokens.join(" ") } : rest);
       const response = await apiRequest("/payments", "GET", undefined, query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "paiement") }],
@@ -34,12 +99,11 @@ Returns: Liste des paiements correspondants.`,
     }
   );
 
-  // Get payment details
   server.registerTool(
     "boond_payments_get",
     {
-      title: "Détails d'un paiement",
-      description: `Récupère les informations détaillées d'un paiement / règlement par son ID.`,
+      title: "Details d'un paiement",
+      description: "Recupere les informations detaillees d'un paiement / reglement par son ID.",
       inputSchema: IdSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/positionings.test.ts
+++ b/src/tools/positionings.test.ts
@@ -183,4 +183,36 @@ describe("registerPositioningTools", () => {
       expect(Object.keys(body.data.attributes).sort()).toEqual(["informationComments", "startDate"]);
     });
   });
+
+  describe("boond_positionings_create handler", () => {
+    function createHandler() {
+      registerPositioningTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_positionings_create");
+      return call?.[2] as (params: unknown) => Promise<{
+        content: Array<{ type: string; text: string }>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiRequest).mockClear();
+      vi.mocked(apiRequest).mockResolvedValue({
+        data: { id: "88", type: "positioning", attributes: { state: 3 } },
+      } as never);
+    });
+
+    it("uses dependsOn for candidate positioning creation", async () => {
+      const handler = createHandler();
+      await handler({ candidateId: "6", opportunityId: "4", state: 3, startDate: "2026-07-01" });
+      expect(apiRequest).toHaveBeenCalledWith("/positionings", "POST", {
+        data: {
+          type: "positioning",
+          attributes: { state: 3, startDate: "2026-07-01" },
+          relationships: {
+            dependsOn: { data: { id: "6", type: "candidate" } },
+            opportunity: { data: { id: "4", type: "opportunity" } },
+          },
+        },
+      });
+    });
+  });
 });

--- a/src/tools/positionings.ts
+++ b/src/tools/positionings.ts
@@ -93,8 +93,8 @@ Returns: Liste des positionnements correspondants.`,
       const { candidateId, resourceId, projectId, opportunityId, ...attrs } = params;
       const body = buildJsonApiBody("positioning", attrs);
       const relationships: Record<string, unknown> = {};
-      if (candidateId) relationships.candidate = { data: { id: candidateId, type: "candidate" } };
-      if (resourceId) relationships.resource = { data: { id: resourceId, type: "resource" } };
+      if (candidateId) relationships.dependsOn = { data: { id: candidateId, type: "candidate" } };
+      if (resourceId) relationships.dependsOn = { data: { id: resourceId, type: "resource" } };
       if (projectId) relationships.project = { data: { id: projectId, type: "project" } };
       if (opportunityId) relationships.opportunity = { data: { id: opportunityId, type: "opportunity" } };
       if (Object.keys(relationships).length > 0) {

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -137,8 +137,9 @@ export function registerProjectTools(server: McpServer): void {
   registerGetTool(server, OPTS);
 
   registerCreateTool(server, OPTS, ProjectCreateSchema, (params) => {
-    const { companyId, contactId, opportunityId, ...attrs } = params;
-    const body = buildJsonApiBody("project", attrs);
+    const { companyId, contactId, opportunityId, name, ...attrs } = params;
+    const apiAttrs = { ...attrs, ...(name ? { title: name } : {}) };
+    const body = buildJsonApiBody("project", apiAttrs);
     const relationships: Record<string, unknown> = {};
     if (companyId) relationships.company = { data: { id: companyId, type: "company" } };
     if (contactId) relationships.contact = { data: { id: contactId, type: "contact" } };
@@ -150,8 +151,9 @@ export function registerProjectTools(server: McpServer): void {
   });
 
   registerUpdateTool(server, OPTS, ProjectUpdateSchema, (params) => {
-    const { id, ...attrs } = params;
-    return buildJsonApiBody("project", attrs, id as string);
+    const { id, name, ...attrs } = params;
+    const apiAttrs = { ...attrs, ...(name ? { title: name } : {}) };
+    return buildJsonApiBody("project", apiAttrs, id as string);
   });
 
   registerDeleteTool(server, OPTS);

--- a/src/tools/provider-invoices.test.ts
+++ b/src/tools/provider-invoices.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerProviderInvoiceTools } from "./provider-invoices.js";
+import { apiRequest } from "../services/boond-client.js";
+
+vi.mock("../services/boond-client.js", () => ({
+  apiRequest: vi.fn().mockResolvedValue({ data: { id: "11", type: "providerinvoice", attributes: {} } }),
+  buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
+  formatListResponse: vi.fn().mockReturnValue(""),
+  formatDetailResponse: vi.fn().mockReturnValue(""),
+}));
 
 function createMockServer() {
   return {
@@ -13,24 +21,79 @@ describe("registerProviderInvoiceTools", () => {
 
   beforeEach(() => {
     server = createMockServer();
+    vi.mocked(apiRequest).mockClear();
+    vi.mocked(apiRequest).mockResolvedValue({ data: { id: "11", type: "providerinvoice", attributes: {} } } as never);
   });
 
-  it("should register 2 provider invoice tools", () => {
+  it("should register 3 provider invoice tools", () => {
     registerProviderInvoiceTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
+    expect(server.registerTool).toHaveBeenCalledTimes(3);
   });
 
   it("should register all expected tool names", () => {
     registerProviderInvoiceTools(server);
     const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
+    expect(names).toContain("boond_provider_invoices_create");
     expect(names).toContain("boond_provider_invoices_search");
     expect(names).toContain("boond_provider_invoices_get");
   });
 
-  it("should register all tools as readOnly", () => {
+  it("should register search/get as readOnly and create as write", () => {
     registerProviderInvoiceTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      expect(call[1].annotations?.readOnlyHint).toBe(true);
-    }
+    const calls = vi.mocked(server.registerTool).mock.calls;
+    expect(calls.find((c) => c[0] === "boond_provider_invoices_create")?.[1].annotations?.readOnlyHint).toBe(false);
+    expect(calls.find((c) => c[0] === "boond_provider_invoices_search")?.[1].annotations?.readOnlyHint).toBe(true);
+    expect(calls.find((c) => c[0] === "boond_provider_invoices_get")?.[1].annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("rejects provider invoice fields that are not mapped", () => {
+    registerProviderInvoiceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_provider_invoices_create");
+    const schema = call?.[1].inputSchema as { safeParse: (input: unknown) => { success: boolean } };
+
+    expect(
+      schema.safeParse({
+        reference: "FF-1",
+        resourceId: "4",
+        startDate: "2026-08-01",
+        endDate: "2026-08-31",
+        dueDate: "2026-09-30",
+      }).success
+    ).toBe(false);
+  });
+
+  it("maps create input to providerCompany/providerContact/resource relationships", async () => {
+    registerProviderInvoiceTools(server);
+    const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_provider_invoices_create");
+    const handler = call?.[2] as (params: unknown) => Promise<unknown>;
+
+    await handler({
+      reference: "FF-1",
+      resourceId: "4",
+      companyId: "1",
+      contactId: "2",
+      invoiceDate: "2026-08-18",
+      startDate: "2026-08-01",
+      endDate: "2026-08-31",
+      amountExcludingTax: 4700,
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/provider-invoices", "POST", {
+      data: {
+        type: "providerinvoice",
+        attributes: {
+          reference: "FF-1",
+          invoiceDate: "2026-08-18",
+          startDate: "2026-08-01",
+          endDate: "2026-08-31",
+          amountExcludingTax: 4700,
+        },
+        relationships: {
+          resource: { data: { id: "4", type: "resource" } },
+          providerCompany: { data: { id: "1", type: "company" } },
+          providerContact: { data: { id: "2", type: "contact" } },
+        },
+      },
+    });
   });
 });

--- a/src/tools/provider-invoices.ts
+++ b/src/tools/provider-invoices.ts
@@ -1,24 +1,80 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IdSchema } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import { buildJsonApiBody } from "./crud-factory.js";
 import { z } from "zod";
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
 
-const ProviderInvoiceSearchSchema = z.object({
-  keywords: z.string().optional().describe("Mots-clés de recherche"),
-  companyId: z.string().optional().describe("Filtrer par ID société fournisseur"),
-  page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numéro de page (max: ${MAX_SEARCH_PAGE})`),
-  pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Résultats par page"),
-}).strict();
+const ProviderInvoiceSearchSchema = z
+  .object({
+    keywords: z.string().optional().describe("Mots-cles de recherche"),
+    companyId: z.string().optional().describe("Filtrer par ID societe fournisseur"),
+    resourceId: z.string().optional().describe("Filtrer par ID ressource via mot-cle COMP<id>"),
+    page: z.number().int().min(1).max(MAX_SEARCH_PAGE).default(1).describe(`Numero de page (max: ${MAX_SEARCH_PAGE})`),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE).describe("Resultats par page"),
+  })
+  .strict();
+
+const ProviderInvoiceCreateSchema = z
+  .object({
+    reference: z.string().min(1).describe("Reference de la facture fournisseur"),
+    resourceId: z.string().min(1).describe("ID de la ressource portee par la facture fournisseur"),
+    companyId: z.string().optional().describe("ID de la societe fournisseur, mappe vers providerCompany"),
+    contactId: z.string().optional().describe("ID du contact fournisseur, mappe vers providerContact"),
+    invoiceDate: z.string().optional().describe("Date de facture (YYYY-MM-DD)"),
+    startDate: z.string().min(1).describe("Date de debut de periode (YYYY-MM-DD)"),
+    endDate: z.string().min(1).describe("Date de fin de periode (YYYY-MM-DD)"),
+    amountExcludingTax: z.number().optional().describe("Montant HT"),
+    amountIncludingTax: z.number().optional().describe("Montant TTC"),
+    currency: z.number().optional().describe("Devise Boond"),
+    exchangeRate: z.number().optional().describe("Taux de change"),
+    currencyAgency: z.number().optional().describe("Devise agence"),
+    exchangeRateAgency: z.number().optional().describe("Taux de change agence"),
+    state: z.number().int().optional().describe("Etat de la facture fournisseur"),
+  })
+  .strict();
 
 export function registerProviderInvoiceTools(server: McpServer): void {
+  server.registerTool(
+    "boond_provider_invoices_create",
+    {
+      title: "Creer une facture fournisseur",
+      description: "Cree une facture fournisseur Boond avec resource, providerCompany et providerContact.",
+      inputSchema: ProviderInvoiceCreateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params) => {
+      const { companyId, contactId, resourceId, ...attrs } = params;
+      const body = buildJsonApiBody("providerinvoice", attrs);
+      const relationships: Record<string, unknown> = {
+        resource: { data: { id: resourceId, type: "resource" } },
+      };
+      if (companyId) relationships.providerCompany = { data: { id: companyId, type: "company" } };
+      if (contactId) relationships.providerContact = { data: { id: contactId, type: "contact" } };
+      (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
+      const response = await apiRequest("/provider-invoices", "POST", body);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Facture fournisseur creee avec succes.\nID: ${entity?.id}\n\n${formatDetailResponse(response)}`,
+          },
+        ],
+      };
+    }
+  );
+
   server.registerTool(
     "boond_provider_invoices_search",
     {
       title: "Rechercher des factures fournisseur",
-      description: `Recherche des factures fournisseur dans BoondManager.
-
-Returns: Liste des factures fournisseur correspondantes.`,
+      description: "Recherche des factures fournisseur dans BoondManager.",
       inputSchema: ProviderInvoiceSearchSchema,
       annotations: {
         readOnlyHint: true,
@@ -28,7 +84,12 @@ Returns: Liste des factures fournisseur correspondantes.`,
       },
     },
     async (params) => {
-      const query = buildSearchQuery(params);
+      const { resourceId, companyId, keywords, ...rest } = params;
+      const tokens: string[] = [];
+      if (keywords) tokens.push(keywords);
+      if (resourceId) tokens.push(`COMP${resourceId}`);
+      if (companyId) tokens.push(`CSOC${companyId}`);
+      const query = buildSearchQuery(tokens.length > 0 ? { ...rest, keywords: tokens.join(" ") } : rest);
       const response = await apiRequest("/provider-invoices", "GET", undefined, query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "facture fournisseur") }],
@@ -39,8 +100,8 @@ Returns: Liste des factures fournisseur correspondantes.`,
   server.registerTool(
     "boond_provider_invoices_get",
     {
-      title: "Détails d'une facture fournisseur",
-      description: `Récupère les informations détaillées d'une facture fournisseur par son ID.`,
+      title: "Details d'une facture fournisseur",
+      description: "Recupere les informations detaillees d'une facture fournisseur par son ID.",
       inputSchema: IdSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/purchases.ts
+++ b/src/tools/purchases.ts
@@ -17,7 +17,9 @@ const PurchaseSearchSchema = z
 
 const PurchaseCreateSchema = z
   .object({
+    title: z.string().optional().describe("Titre de l'achat/sous-traitance"),
     companyId: z.string().optional().describe("ID de la société fournisseur"),
+    contactId: z.string().optional().describe("ID du contact fournisseur"),
     projectId: z.string().optional().describe("ID du projet associé"),
     state: z.number().int().optional().describe("État de l'achat"),
     startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
@@ -90,10 +92,11 @@ Returns: Liste des achats correspondants.`,
       },
     },
     async (params) => {
-      const { companyId, projectId, ...attrs } = params;
+      const { companyId, contactId, projectId, ...attrs } = params;
       const body = buildJsonApiBody("purchase", attrs);
       const relationships: Record<string, unknown> = {};
       if (companyId) relationships.company = { data: { id: companyId, type: "company" } };
+      if (contactId) relationships.contact = { data: { id: contactId, type: "contact" } };
       if (projectId) relationships.project = { data: { id: projectId, type: "project" } };
       if (Object.keys(relationships).length > 0) {
         (body as Record<string, Record<string, unknown>>).data.relationships = relationships;

--- a/src/tools/timesheets.test.ts
+++ b/src/tools/timesheets.test.ts
@@ -15,9 +15,9 @@ describe("registerTimesheetTools", () => {
     server = createMockServer();
   });
 
-  it("should register 3 timesheet tools", () => {
+  it("should register 4 timesheet tools", () => {
     registerTimesheetTools(server);
-    expect(server.registerTool).toHaveBeenCalledTimes(3);
+    expect(server.registerTool).toHaveBeenCalledTimes(4);
   });
 
   it("should register boond_resources_timesheets tool", () => {
@@ -32,18 +32,24 @@ describe("registerTimesheetTools", () => {
     expect(names).toContain("boond_timesheets_search");
   });
 
+  it("should register boond_timesheets_create tool", () => {
+    registerTimesheetTools(server);
+    const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
+    expect(names).toContain("boond_timesheets_create");
+  });
+
   it("should register boond_timesheets_get tool", () => {
     registerTimesheetTools(server);
     const names = vi.mocked(server.registerTool).mock.calls.map((c) => c[0]);
     expect(names).toContain("boond_timesheets_get");
   });
 
-  it("should register all tools as readOnly", () => {
+  it("should register read tools as readOnly and create as write", () => {
     registerTimesheetTools(server);
-    for (const call of vi.mocked(server.registerTool).mock.calls) {
-      const [, metadata] = call;
-      expect(metadata.annotations?.readOnlyHint).toBe(true);
-      expect(metadata.annotations?.destructiveHint).toBe(false);
-    }
+    const calls = vi.mocked(server.registerTool).mock.calls;
+    expect(calls.find((c) => c[0] === "boond_timesheets_create")?.[1].annotations?.readOnlyHint).toBe(false);
+    expect(calls.find((c) => c[0] === "boond_timesheets_search")?.[1].annotations?.readOnlyHint).toBe(true);
+    expect(calls.find((c) => c[0] === "boond_timesheets_get")?.[1].annotations?.readOnlyHint).toBe(true);
+    expect(calls.find((c) => c[0] === "boond_resources_timesheets")?.[1].annotations?.readOnlyHint).toBe(true);
   });
 });

--- a/src/tools/timesheets.ts
+++ b/src/tools/timesheets.ts
@@ -2,8 +2,27 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ResourceTimesheetSchema, TimesheetSearchSchema, TimesheetGetSchema } from "../schemas/index.js";
 import type { ResourceTimesheetInput, TimesheetSearchInput, TimesheetGetInput } from "../schemas/index.js";
 import { apiRequest, buildSearchQuery, formatDetailResponse } from "../services/boond-client.js";
+import { buildJsonApiBody } from "./crud-factory.js";
 import { CHARACTER_LIMIT } from "../constants.js";
 import type { JsonApiResponse } from "../types.js";
+import { z } from "zod";
+
+const TimesheetCreateSchema = z
+  .object({
+    resourceId: z.string().min(1).describe("ID de la ressource"),
+    projectId: z.string().optional().describe("ID du projet"),
+    term: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Mois au format YYYY-MM"),
+    startDate: z.string().optional().describe("Date de début (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Date de fin (YYYY-MM-DD)"),
+    totalDays: z.number().optional().describe("Total jours"),
+    totalHours: z.number().optional().describe("Total heures"),
+    state: z.string().optional().describe("État de la feuille de temps"),
+    note: z.string().optional().describe("Notes"),
+  })
+  .strict();
 
 function formatTimesheetSummary(response: JsonApiResponse): string {
   const data = Array.isArray(response.data) ? response.data : [response.data];
@@ -40,6 +59,39 @@ function formatTimesheetSummary(response: JsonApiResponse): string {
 }
 
 export function registerTimesheetTools(server: McpServer): void {
+  server.registerTool(
+    "boond_timesheets_create",
+    {
+      title: "Créer une feuille de temps",
+      description: "Crée une feuille de temps mensuelle liée à une ressource.",
+      inputSchema: TimesheetCreateSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (params) => {
+      const { resourceId, projectId, ...attrs } = params;
+      const body = buildJsonApiBody("timesreport", attrs);
+      const relationships: Record<string, unknown> = {};
+      if (resourceId) relationships.resource = { data: { id: resourceId, type: "resource" } };
+      if (projectId) relationships.project = { data: { id: projectId, type: "project" } };
+      if (Object.keys(relationships).length > 0) {
+        (body as Record<string, Record<string, unknown>>).data.relationships = relationships;
+      }
+      const response = await apiRequest("/times-reports", "POST", body);
+      const text = formatDetailResponse(response);
+      const entity = Array.isArray(response.data) ? response.data[0] : response.data;
+      return {
+        content: [
+          { type: "text" as const, text: `✅ Feuille de temps créée avec succès.\nID: ${entity?.id}\n\n${text}` },
+        ],
+      };
+    }
+  );
+
   // Get timesheets for a specific resource
   server.registerTool(
     "boond_resources_timesheets",

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -56,6 +56,7 @@ const ENV_KEYS = [
   "MCP_HTTP_PUBLIC_URL",
   "BOOND_OAUTH_AUTHORIZATION_SERVER",
   "BOOND_OAUTH_SCOPES",
+  "BOOND_HTTP_STATIC_AUTH",
 ];
 
 /** Shorthand for an authenticated MCP request body (OAuth Bearer required). */
@@ -134,6 +135,19 @@ describe("resolveHttpOptions", () => {
   it("leaves allowedHosts undefined when MCP_HTTP_ALLOWED_HOSTS is unset", () => {
     const opts = resolveHttpOptions();
     expect(opts.allowedHosts).toBeUndefined();
+  });
+
+  it("reads BOOND_HTTP_STATIC_AUTH correctly", () => {
+    process.env["BOOND_HTTP_STATIC_AUTH"] = "true";
+    expect(resolveHttpOptions().staticAuth).toBe(true);
+    process.env["BOOND_HTTP_STATIC_AUTH"] = "1";
+    expect(resolveHttpOptions().staticAuth).toBe(true);
+    process.env["BOOND_HTTP_STATIC_AUTH"] = "yes";
+    expect(resolveHttpOptions().staticAuth).toBe(true);
+    process.env["BOOND_HTTP_STATIC_AUTH"] = "false";
+    expect(resolveHttpOptions().staticAuth).toBe(false);
+    delete process.env["BOOND_HTTP_STATIC_AUTH"];
+    expect(resolveHttpOptions().staticAuth).toBe(false);
   });
 });
 
@@ -478,6 +492,54 @@ describe("startHttpTransport (integration)", () => {
       result?: { serverInfo?: { name?: string } };
     };
     expect(json.result?.serverInfo?.name).toBe("boondmanager-mcp-server");
+  });
+
+  it("accepts MCP initialize without Bearer token in staticAuth mode", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34591,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+      staticAuth: true,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        // No Authorization header
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "vitest", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+    expect(json.result?.serverInfo?.name).toBe("boondmanager-mcp-server");
+  });
+
+  it("still rejects without Bearer when staticAuth is false (default)", async () => {
+    handle = await startHttpTransport(createMcpServer, {
+      host: "127.0.0.1",
+      port: 34592,
+      path: "/mcp",
+      stateless: true,
+      enableJsonResponse: true,
+      staticAuth: false,
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.address.port}/mcp`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
   });
 
   it("rejects an oversized body with 413 (Content-Length precheck)", async () => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -40,6 +40,14 @@ export interface HttpTransportOptions {
    * reverse proxy, set `MCP_HTTP_PUBLIC_URL` explicitly.
    */
   publicUrl?: string;
+  /**
+   * Skip the OAuth2 Bearer check and use the env-based credentials configured
+   * via `initClient()` (BOOND_USER_TOKEN + BOOND_CLIENT_TOKEN + BOOND_CLIENT_KEY,
+   * or BOOND_API_TOKEN, or BasicAuth). Intended for single-tenant / self-hosted
+   * deployments where the operator owns both the server and the credentials.
+   * Set `BOOND_HTTP_STATIC_AUTH=true` to enable via `resolveHttpOptions()`.
+   */
+  staticAuth?: boolean;
 }
 
 export interface HttpServerHandle {
@@ -140,6 +148,9 @@ export function resolveHttpOptions(): HttpTransportOptions {
   const stateless = (readEnv("MCP_HTTP_STATEFUL") ?? "false").toLowerCase() !== "true";
   const enableJsonResponse = (readEnv("MCP_HTTP_JSON_RESPONSE") ?? "false").toLowerCase() === "true";
 
+  const staticAuthRaw = (readEnv("BOOND_HTTP_STATIC_AUTH") ?? "").toLowerCase();
+  const staticAuth = staticAuthRaw === "true" || staticAuthRaw === "1" || staticAuthRaw === "yes";
+
   return {
     host: readEnv("MCP_HTTP_HOST") ?? "127.0.0.1",
     port,
@@ -151,6 +162,7 @@ export function resolveHttpOptions(): HttpTransportOptions {
     maxSessions: readPositiveInt("MCP_HTTP_MAX_SESSIONS", DEFAULT_MAX_SESSIONS),
     allowedHosts: readAllowedHosts(),
     publicUrl: readEnv("MCP_HTTP_PUBLIC_URL"),
+    staticAuth,
   };
 }
 
@@ -354,11 +366,11 @@ export async function startHttpTransport(
 
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
-      // Public OAuth2 discovery endpoint (RFC 9728). Must be reachable
-      // without authentication — clients fetch it to learn where to send
-      // the user for authorization. Served at both the canonical root path
-      // and the path-suffixed variant per RFC 9728 §3.2.
+      // Public OAuth2 discovery endpoint (RFC 9728). Not served in static-auth
+      // mode — exposing it would cause OAuth-aware clients (mcp-remote, etc.)
+      // to attempt a full OAuth dance that will never complete.
       if (
+        !options.staticAuth &&
         req.method === "GET" &&
         (url.pathname === "/.well-known/oauth-protected-resource" ||
           url.pathname === `/.well-known/oauth-protected-resource${options.path}`)
@@ -373,22 +385,8 @@ export async function startHttpTransport(
         return;
       }
 
-      // OAuth2 Bearer is mandatory on the MCP endpoint. The token is opaque
-      // to us — we forward it to BoondManager, which is authoritative.
-      const accessToken = extractBearerToken(req.headers["authorization"]);
-      if (!accessToken) {
-        writeOAuthChallenge(
-          res,
-          401,
-          "Missing Bearer token. Authenticate against BoondManager and include `Authorization: Bearer <access_token>`."
-        );
-        return;
-      }
-
-      // Wrap the rest of the request lifecycle in the AsyncLocalStorage
-      // context so boond-client's `oauthContextAuth` can pull the token
-      // out when issuing API calls.
-      await oauthContext.run({ accessToken }, async () => {
+      // Core MCP dispatch — shared between OAuth and static-auth paths.
+      const dispatchMcpRequest = async (): Promise<void> => {
         if (options.stateless) {
           if (req.method !== "POST") {
             writeJsonRpcError(res, 405, "Only POST is supported in stateless mode");
@@ -477,7 +475,28 @@ export async function startHttpTransport(
         const server = createServerFactory();
         await server.connect(transport);
         await transport.handleRequest(req, res, body);
-      });
+      };
+
+      if (options.staticAuth) {
+        // Static-auth mode: env-based JWT credentials configured at startup via
+        // initClient(). No Bearer token required from the MCP client.
+        await dispatchMcpRequest();
+      } else {
+        // OAuth2 Bearer is mandatory on the MCP endpoint. The token is opaque
+        // to us — we forward it to BoondManager, which is authoritative.
+        const accessToken = extractBearerToken(req.headers["authorization"]);
+        if (!accessToken) {
+          writeOAuthChallenge(
+            res,
+            401,
+            "Missing Bearer token. Authenticate against BoondManager and include `Authorization: Bearer <access_token>`."
+          );
+          return;
+        }
+        // Wrap in AsyncLocalStorage so boond-client's oauthContextAuth can pull
+        // the token out when issuing API calls.
+        await oauthContext.run({ accessToken }, dispatchMcpRequest);
+      }
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
         if (!res.headersSent) {


### PR DESCRIPTION
## Summary

This PR adds a static-auth mode for the HTTP transport and expands write coverage for several BoondManager domains.

## Changes

- Add `BOOND_HTTP_STATIC_AUTH` support for HTTP deployments using env-based Boond credentials instead of per-request OAuth Bearer tokens
- Hide OAuth protected-resource discovery when static auth is enabled
- Add or improve create/update mappings for absences, deliveries, invoices, orders, payments, provider invoices, purchases, projects, positionings, and timesheets
- Align Boond JSON:API payloads with expected relationship/attribute names such as `dependsOn`, `providerCompany`, `providerContact`, `order`, `purchase`, `title`, and `/information` PUT updates
- Extend schemas to expose newly supported input fields and reject unsupported ones where needed
- Add behavioral tests for the new mappings, static-auth transport mode, and updated tool contracts

## Validation

- `npm.cmd run typecheck`
- `npm.cmd test -- src/tools/deliveries.test.ts src/tools/payments.test.ts src/tools/opportunities.test.ts src/tools/invoices.test.ts src/tools/orders.test.ts`
- `npm.cmd test`
- `npm.cmd run lint`

Full test suite result: 54 test files passed, 726 tests passed.