### PR TITLE
chore(ci): bump codeql-action to 4.36.3 and group Dependabot actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,13 @@ updates:
       - "fauguste"
     labels:
       - "ci"
+    groups:
+      # Single PR for all action bumps — sub-actions sharing a repo
+      # (github/codeql-action/init|autobuild|analyze) must move together,
+      # otherwise CodeQL fails on a version mismatch.
+      github-actions:
+        patterns:
+          - "*"
 
   # Docker base image
   - package-ecosystem: "docker"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
## Summary
- Bumps all three `github/codeql-action` sub-actions (init/autobuild/analyze) to the same v4.36.3 SHA. Dependabot bumped `init` (#142) and `autobuild` (#141) in separate PRs, each failing CodeQL with `Loaded a configuration file for version '4.36.3', but running version '4.36.2'`.
- Adds a Dependabot `groups` config for the `github-actions` ecosystem so all action bumps land in a single weekly PR — sub-actions from the same repo move together.

Supersedes #141 and #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)