### PR TITLE
fix(search): respect BoondManager per-route maxResults cap via transparent chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Respect du plafond `maxResults` de BoondManager sur la route `/actions`** : l'équipe technique de BoondManager a signalé que des appels à `/api/actions` avec `maxResults > 100` provoquent des dépassements mémoire de leur côté (alertes internes, puis repli silencieux sur 30). Les outils de recherche ne passent plus directement par `apiRequest` mais par une nouvelle couche `apiSearch` qui applique un plafond `maxResults` par route (`ROUTE_MAX_RESULTS` dans `src/constants.ts`, `/actions` → 100). Quand la taille de page demandée dépasse le plafond de la route, la requête est **découpée de façon transparente** en tranches ≤ plafond, puis les pages sont fusionnées : l'appelant reçoit sa page complète (jusqu'à 500) « d'un coup », mais BoondManager ne reçoit jamais `maxResults` au-delà du plafond. Aucune régression sur les autres routes (chemin rapide à appel unique, plafond par défaut = `MAX_PAGE_SIZE`). Pour plafonner une future route, il suffit d'ajouter une entrée à `ROUTE_MAX_RESULTS`.
+
 ## [2.8.0] - 2026-06-29
 
 Extension des capacités d'écriture (4 nouveaux outils `*_create`) et nouveau mode d'authentification statique pour le transport HTTP. Catalogue : **180 outils** (176 → 180), 11 prompts, 22 ressources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,15 @@ All search tools enforce a **maximum page number of 100** (configurable via `MAX
 
 **Enforcement:** Zod schemas reject `page > MAX_SEARCH_PAGE` at input validation (before the API call). The model sees a clear schema error mentioning the limit, not a silent clamp or a cryptic API 400.
 
+### Per-route `maxResults` ceiling (transparent chunking)
+
+Some BoondManager routes cannot safely return large pages. `/actions` in particular overflows BoondManager's memory when `maxResults > 100` (their tech team reported internal alerts + a silent fallback to 30). To respect this **without** degrading usability, search tools do not go through `apiRequest` directly — they call `apiSearch(path, query)` (`src/services/boond-client.ts`).
+
+- `ROUTE_MAX_RESULTS` in `src/constants.ts` maps an API path to its safe ceiling (`/actions` → 100). Routes absent from the map use `DEFAULT_MAX_RESULTS` (= `MAX_PAGE_SIZE`, 500).
+- **Fast path:** when the requested `pageSize` is ≤ the route ceiling (every non-capped route, and small `/actions` requests), `apiSearch` makes a single `apiRequest` — byte-for-byte identical to before.
+- **Chunked path:** when `pageSize` exceeds the ceiling (e.g. 500 on `/actions`), `apiSearch` fetches the requested window in chunks of `cap` records (each API call sends `maxResults = cap`, never more), merges the pages into one `JsonApiResponse`, and returns it. The caller still receives its full page "at once"; BoondManager never sees `maxResults` above the cap. Chunk count is bounded by `ceil((offset + requested) / cap)` and the loop stops early on a short page.
+- To cap a future route, add one entry to `ROUTE_MAX_RESULTS`; no other code changes needed. Search-tool `pageSize` stays uniformly capped at `MAX_PAGE_SIZE`.
+
 ## Tool Naming Convention
 
 All tool names follow: `boond_{domain}_{operation}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,19 @@ export const CHARACTER_LIMIT = 50000;
 export const DEFAULT_PAGE_SIZE = 30;
 export const MAX_PAGE_SIZE = 500;
 
+// Per-route safe ceiling for the BoondManager `maxResults` query parameter.
+// Some routes return very heavy objects: on /actions, maxResults > 100 triggers
+// memory overflows on BoondManager's side (internal alerts, then a silent
+// fallback to 30) — reported by their tech team. When a search requests more
+// than a route's ceiling, the apiSearch layer fetches it in chunks of that size
+// and merges the pages, so the caller still gets the full page while we never
+// send maxResults above the cap. A route absent from this map uses
+// DEFAULT_MAX_RESULTS. Keys are the API paths as passed to apiRequest/apiSearch.
+export const ROUTE_MAX_RESULTS: Record<string, number> = {
+  "/actions": 100,
+};
+export const DEFAULT_MAX_RESULTS = MAX_PAGE_SIZE;
+
 // Cap the page number on search tools (openWorldHint) to prevent runaway
 // iterations. At 500 results/page, page 100 = 50k records — well beyond
 // typical interactive exploration. The model can refine filters instead.

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -8,6 +8,7 @@ import {
   initClient,
   buildJwt,
   apiRequest,
+  apiSearch,
   parseBoondErrorBody,
   formatApiError,
   resolveTimeoutMs,
@@ -602,6 +603,123 @@ describe("apiRequest", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkErr));
 
     await expect(apiRequest("/candidates")).rejects.toThrow("ECONNREFUSED");
+  });
+});
+
+describe("apiSearch (per-route maxResults chunking)", () => {
+  // Mock fetch as a paginated backend: page N with maxResults M returns rows
+  // [(N-1)*M, N*M) as resources whose id === their absolute 0-based row index,
+  // capped at `totalRows`. This lets us assert both the chunk boundaries sent
+  // to the API and the absolute window returned to the caller.
+  function pagedFetch(totalRows: number) {
+    return vi.fn().mockImplementation((url: string) => {
+      const u = new URL(url);
+      const max = Number(u.searchParams.get("maxResults") ?? "30");
+      const page = Number(u.searchParams.get("page") ?? "1");
+      const start = (page - 1) * max;
+      const items = [];
+      for (let i = start; i < Math.min(start + max, totalRows); i++) {
+        items.push({ id: String(i), type: "action", attributes: {} });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-length": "100" }),
+        json: () => Promise.resolve({ data: items, meta: { totals: { rows: totalRows } } }),
+      });
+    });
+  }
+
+  const maxResultsOf = (call: unknown[]) => Number(new URL(call[0] as string).searchParams.get("maxResults"));
+  const pageOf = (call: unknown[]) => Number(new URL(call[0] as string).searchParams.get("page"));
+
+  beforeEach(() => {
+    process.env.BOOND_API_TOKEN = "test-token";
+    process.env.BOOND_HTTP_MAX_RETRIES = "0";
+    process.env.BOOND_HTTP_RATE_LIMIT_RPS = "0";
+    resetRateLimiterForTests();
+    initClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BOOND_API_TOKEN;
+    delete process.env.BOOND_HTTP_MAX_RETRIES;
+    delete process.env.BOOND_HTTP_RATE_LIMIT_RPS;
+    resetRateLimiterForTests();
+  });
+
+  it("takes the fast path (single call) for non-capped routes even at pageSize 500", async () => {
+    vi.stubGlobal("fetch", pagedFetch(2000));
+
+    const res = await apiSearch("/candidates", { maxResults: 500, page: 1 });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(maxResultsOf(vi.mocked(fetch).mock.calls[0])).toBe(500);
+    expect(Array.isArray(res.data) ? res.data.length : 0).toBe(500);
+  });
+
+  it("takes the fast path when the /actions request is within the cap", async () => {
+    vi.stubGlobal("fetch", pagedFetch(2000));
+
+    await apiSearch("/actions", { maxResults: 100, page: 1 });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(maxResultsOf(vi.mocked(fetch).mock.calls[0])).toBe(100);
+  });
+
+  it("chunks a large /actions request into calls that never exceed maxResults 100", async () => {
+    vi.stubGlobal("fetch", pagedFetch(2000));
+
+    const res = await apiSearch("/actions", { maxResults: 500, page: 1 });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls).toHaveLength(5);
+    for (const call of calls) expect(maxResultsOf(call)).toBeLessThanOrEqual(100);
+    expect(calls.map(pageOf)).toEqual([1, 2, 3, 4, 5]);
+
+    const data = res.data as { id: string }[];
+    expect(data).toHaveLength(500);
+    expect(data[0].id).toBe("0");
+    expect(data[499].id).toBe("499");
+    // Grand total from the server survives the merge.
+    expect(res.meta?.totals?.rows).toBe(2000);
+  });
+
+  it("stops early when the server returns a short page", async () => {
+    vi.stubGlobal("fetch", pagedFetch(250));
+
+    const res = await apiSearch("/actions", { maxResults: 500, page: 1 });
+
+    // 100 + 100 + 50 → third page is short, so we stop after 3 calls.
+    expect(vi.mocked(fetch).mock.calls).toHaveLength(3);
+    expect((res.data as unknown[]).length).toBe(250);
+  });
+
+  it("honours page > 1 with the correct absolute offset", async () => {
+    vi.stubGlobal("fetch", pagedFetch(2000));
+
+    const res = await apiSearch("/actions", { maxResults: 500, page: 2 });
+
+    // Rows 500..999 → Boond pages 6..10 at 100/page.
+    expect(vi.mocked(fetch).mock.calls.map(pageOf)).toEqual([6, 7, 8, 9, 10]);
+    const data = res.data as { id: string }[];
+    expect(data).toHaveLength(500);
+    expect(data[0].id).toBe("500");
+    expect(data[499].id).toBe("999");
+  });
+
+  it("slices a non-zero offset inside the first chunk", async () => {
+    vi.stubGlobal("fetch", pagedFetch(2000));
+
+    // page 2 × 150 → startRow 150 → first Boond page 2, offset 50 within it.
+    const res = await apiSearch("/actions", { maxResults: 150, page: 2 });
+
+    expect(vi.mocked(fetch).mock.calls.map(pageOf)).toEqual([2, 3]);
+    const data = res.data as { id: string }[];
+    expect(data).toHaveLength(150);
+    expect(data[0].id).toBe("150");
+    expect(data[149].id).toBe("299");
   });
 });
 

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -2,6 +2,9 @@ import { createHmac } from "crypto";
 import {
   DEFAULT_BASE_URL,
   CHARACTER_LIMIT,
+  DEFAULT_PAGE_SIZE,
+  ROUTE_MAX_RESULTS,
+  DEFAULT_MAX_RESULTS,
   DEFAULT_HTTP_TIMEOUT_MS,
   DEFAULT_HTTP_MAX_RETRIES,
   DEFAULT_HTTP_RETRY_BASE_MS,
@@ -9,7 +12,7 @@ import {
   DEFAULT_HTTP_RATE_LIMIT_RPS,
   DEFAULT_HTTP_RATE_LIMIT_BURST,
 } from "../constants.js";
-import type { BoondAuthProvider, BoondConfig, JsonApiResponse, SearchParams } from "../types.js";
+import type { BoondAuthProvider, BoondConfig, JsonApiResource, JsonApiResponse, SearchParams } from "../types.js";
 import { TokenBucket } from "./rate-limiter.js";
 import { oauthContext } from "./oauth.js";
 
@@ -789,6 +792,54 @@ export function buildSearchQuery(params: SearchParams): Record<string, QueryValu
   }
 
   return query;
+}
+
+/**
+ * Search wrapper around `apiRequest` that enforces BoondManager's per-route
+ * `maxResults` ceiling (see `ROUTE_MAX_RESULTS`). When the caller requests more
+ * results than the route allows, the request is transparently split into
+ * chunks of `cap` records and the pages are merged into a single JSON:API
+ * response — the caller still receives the full page, but BoondManager never
+ * sees `maxResults` above the cap (which overflows memory on `/actions`).
+ *
+ * Routes whose ceiling already covers the requested page size take the fast
+ * path: a single `apiRequest`, byte-for-byte identical to calling it directly.
+ * The chunk count is bounded by `ceil((offset + requested) / cap)`, so there is
+ * no unbounded loop; the loop also stops early once a page comes back short
+ * (end of the result set on the server).
+ */
+export async function apiSearch(path: string, query: Record<string, QueryValue>): Promise<JsonApiResponse> {
+  const cap = ROUTE_MAX_RESULTS[path] ?? DEFAULT_MAX_RESULTS;
+  const requested = typeof query["maxResults"] === "number" ? query["maxResults"] : DEFAULT_PAGE_SIZE;
+  const page = typeof query["page"] === "number" ? query["page"] : 1;
+
+  // Fast path: one call, maxResults left exactly as the caller built it.
+  if (requested <= cap) {
+    return apiRequest(path, "GET", undefined, query);
+  }
+
+  // Chunked path: fetch `requested` records starting at the absolute offset
+  // implied by (page, requested), in BoondManager pages of `cap` records.
+  const startRow = (page - 1) * requested;
+  const firstBoondPage = Math.floor(startRow / cap) + 1;
+  const offsetInFirstChunk = startRow % cap;
+  const needed = offsetInFirstChunk + requested;
+
+  const collected: JsonApiResource[] = [];
+  let meta: JsonApiResponse["meta"];
+
+  for (let i = 0; collected.length < needed; i++) {
+    const chunkQuery: Record<string, QueryValue> = { ...query, page: firstBoondPage + i, maxResults: cap };
+    const response = await apiRequest(path, "GET", undefined, chunkQuery);
+    if (meta === undefined) meta = response.meta;
+    const chunk = Array.isArray(response.data) ? response.data : response.data ? [response.data] : [];
+    collected.push(...chunk);
+    // A short page means there is no more data on the server — stop early.
+    if (chunk.length < cap) break;
+  }
+
+  const data = collected.slice(offsetInFirstChunk, offsetInFirstChunk + requested);
+  return meta !== undefined ? { data, meta } : { data };
 }
 
 export function formatEntitySummary(entity: unknown): string {

--- a/src/tools/accounts.test.ts
+++ b/src/tools/accounts.test.ts
@@ -4,7 +4,7 @@ import { registerAccountTools } from "./accounts.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerAccountTools", {

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerActionTools } from "./actions.js";
-import { apiRequest } from "../services/boond-client.js";
+import { apiRequest, apiSearch, buildSearchQuery } from "../services/boond-client.js";
 import { resetDictionaryOverridesForTests } from "../config/dictionary-overrides.js";
 
 vi.mock("../services/boond-client.js", () => ({
   apiRequest: vi.fn().mockResolvedValue({ data: { id: "123", type: "action" } }),
+  apiSearch: vi.fn().mockResolvedValue({ data: [] }),
   buildSearchQuery: vi.fn().mockReturnValue({}),
   formatListResponse: vi.fn().mockReturnValue(""),
   formatDetailResponse: vi.fn().mockReturnValue(""),
@@ -63,6 +64,31 @@ describe("registerActionTools", () => {
     registerActionTools(server);
     const deleteCall = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_actions_delete");
     expect(deleteCall?.[1].annotations?.destructiveHint).toBe(true);
+  });
+
+  describe("boond_actions_search handler", () => {
+    function getSearchHandler() {
+      registerActionTools(server);
+      const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_actions_search");
+      return call?.[2] as (params: Record<string, unknown>) => Promise<{
+        content: Array<{ type: string; text: string }>;
+      }>;
+    }
+
+    beforeEach(() => {
+      vi.mocked(apiSearch).mockClear();
+      vi.mocked(buildSearchQuery).mockClear();
+    });
+
+    it("routes /actions search through apiSearch (per-route chunking), not a raw apiRequest", async () => {
+      const handler = getSearchHandler();
+      vi.mocked(buildSearchQuery).mockReturnValueOnce({ maxResults: 500, page: 1 });
+
+      await handler({ pageSize: 500 });
+
+      expect(apiSearch).toHaveBeenCalledWith("/actions", { maxResults: 500, page: 1 });
+      expect(apiRequest).not.toHaveBeenCalledWith("/actions", "GET", undefined, expect.anything());
+    });
   });
 
   describe("boond_actions_create handler", () => {

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ActionSearchSchema, ActionCreateSchema, ActionUpdateSchema, IdSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 import { buildJsonApiBody, registerDeleteTool, MutationOutputSchema } from "./crud-factory.js";
 import { availableLabels, formatOverridesSummary, resolveLabel } from "../config/dictionary-overrides.js";
 
@@ -52,7 +58,9 @@ Returns: Liste des actions correspondantes.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/actions", "GET", undefined, query);
+      // apiSearch chunks the request to respect BoondManager's 100-result cap
+      // on /actions (heavy objects → memory overflow above 100).
+      const response = await apiSearch("/actions", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "action") }],
       };

--- a/src/tools/advantages.test.ts
+++ b/src/tools/advantages.test.ts
@@ -4,7 +4,7 @@ import { registerAdvantageTools } from "./advantages.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerAdvantageTools", {

--- a/src/tools/advantages.ts
+++ b/src/tools/advantages.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AdvantageSearchSchema, IdSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 
 export function registerAdvantageTools(server: McpServer): void {
   // Search advantages
@@ -26,7 +32,7 @@ Returns: Liste des avantages correspondants.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/advantages", "GET", undefined, query);
+      const response = await apiSearch("/advantages", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "avantage") }],
       };

--- a/src/tools/agencies.test.ts
+++ b/src/tools/agencies.test.ts
@@ -4,7 +4,7 @@ import { registerAgencyTools } from "./agencies.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerAgencyTools", {

--- a/src/tools/business-units.test.ts
+++ b/src/tools/business-units.test.ts
@@ -4,7 +4,7 @@ import { registerBusinessUnitTools } from "./business-units.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerBusinessUnitTools", {

--- a/src/tools/calendars.test.ts
+++ b/src/tools/calendars.test.ts
@@ -4,7 +4,7 @@ import { registerCalendarTools } from "./calendars.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerCalendarTools", {

--- a/src/tools/crud-factory.test.ts
+++ b/src/tools/crud-factory.test.ts
@@ -9,12 +9,12 @@ import {
   registerUpdateTool,
   registerDeleteTool,
 } from "./crud-factory.js";
-import { apiRequest } from "../services/boond-client.js";
+import { apiRequest, apiSearch } from "../services/boond-client.js";
 import { z } from "zod";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 function createMockServer() {
@@ -263,7 +263,7 @@ describe("registerSearchTool handler", () => {
   };
 
   it("returns text summary plus compact structuredContent", async () => {
-    vi.mocked(apiRequest).mockResolvedValue(RESPONSE);
+    vi.mocked(apiSearch).mockResolvedValue(RESPONSE);
     const server = createMockServer();
     registerSearchTool(server, OPTS);
     const result = await registeredHandler(server)({ keywords: "dupont" });
@@ -281,7 +281,7 @@ describe("registerSearchTool handler", () => {
   });
 
   it("projects `fields` into both text and structuredContent, and keeps it out of the API query", async () => {
-    vi.mocked(apiRequest).mockResolvedValue(RESPONSE);
+    vi.mocked(apiSearch).mockResolvedValue(RESPONSE);
     const server = createMockServer();
     registerSearchTool(server, OPTS);
     const result = await registeredHandler(server)({ keywords: "dupont", fields: ["title", "unknownField"] });
@@ -292,8 +292,8 @@ describe("registerSearchTool handler", () => {
     const structured = result.structuredContent as { items: Array<Record<string, unknown>> };
     expect(structured.items[0].attributes).toEqual({ title: "Dev" });
     expect(structured.items[0].summary).toBeUndefined();
-    // API query: `fields` is client-side only
-    const [, , , query] = vi.mocked(apiRequest).mock.calls[0];
+    // API query: `fields` is client-side only. Search goes through apiSearch(path, query).
+    const [, query] = vi.mocked(apiSearch).mock.calls[0];
     expect(query).not.toHaveProperty("fields");
     expect(query).not.toHaveProperty("fields[]");
   });

--- a/src/tools/crud-factory.ts
+++ b/src/tools/crud-factory.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   apiRequest,
+  apiSearch,
   buildSearchQuery,
   formatListResponse,
   formatDetailResponse,
@@ -186,7 +187,9 @@ Returns: Liste des ${opts.entityNamePlural} correspondants avec leur ID, nom et 
     async (params: unknown) => {
       const p = params as SearchInput & { fields?: string[] };
       const query = buildSearchQuery(p);
-      const response = await apiRequest(opts.apiPath, "GET", undefined, query);
+      // apiSearch respects BoondManager's per-route maxResults ceiling,
+      // chunking large requests transparently (see ROUTE_MAX_RESULTS).
+      const response = await apiSearch(opts.apiPath, query);
       const text = formatListResponse(response, opts.entityName, p.fields);
       return {
         content: [{ type: "text" as const, text }],

--- a/src/tools/deliveries.test.ts
+++ b/src/tools/deliveries.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMockServer, registeredToolNames, toolCallback } from "./test-helpers.js";
 import { registerDeliveryTools } from "./deliveries.js";
-import { apiRequest } from "../services/boond-client.js";
+import { apiRequest, apiSearch } from "../services/boond-client.js";
 
 vi.mock("../services/boond-client.js", () => ({
   apiRequest: vi.fn().mockResolvedValue({ data: { id: "21", type: "delivery", attributes: {} } }),
+  apiSearch: vi.fn().mockResolvedValue({ data: [] }),
   buildSearchQuery: vi.fn((params: Record<string, unknown>) => params),
   formatListResponse: vi.fn().mockReturnValue(""),
   formatDetailResponse: vi.fn().mockReturnValue(""),
@@ -44,8 +45,8 @@ describe("registerDeliveryTools", () => {
   it("search should call the BoondManager API on the deliveries groupments path", async () => {
     registerDeliveryTools(server);
     await toolCallback(server, "boond_deliveries_search")({ page: 2, pageSize: 10 });
-    expect(vi.mocked(apiRequest).mock.calls[0][0]).toBe("/deliveries-groupments");
-    expect(vi.mocked(apiRequest).mock.calls[0][1]).toBe("GET");
+    // Search goes through apiSearch (per-route maxResults chunking).
+    expect(vi.mocked(apiSearch).mock.calls[0][0]).toBe("/deliveries-groupments");
   });
 
   it("get should call the BoondManager API on the detail path", async () => {

--- a/src/tools/deliveries.ts
+++ b/src/tools/deliveries.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { DeliverySearchSchema, IdSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 import { buildJsonApiBody } from "./crud-factory.js";
 import { z } from "zod";
 
@@ -85,7 +91,7 @@ Returns: Liste des livraisons correspondantes.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/deliveries-groupments", "GET", undefined, query);
+      const response = await apiSearch("/deliveries-groupments", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "livraison") }],
       };

--- a/src/tools/flags.test.ts
+++ b/src/tools/flags.test.ts
@@ -4,7 +4,7 @@ import { registerFlagTools } from "./flags.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerFlagTools", {

--- a/src/tools/logs.test.ts
+++ b/src/tools/logs.test.ts
@@ -4,7 +4,7 @@ import { registerLogTools } from "./logs.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerLogTools", {

--- a/src/tools/notifications.test.ts
+++ b/src/tools/notifications.test.ts
@@ -4,7 +4,7 @@ import { registerNotificationTools } from "./notifications.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerNotificationTools", {

--- a/src/tools/notifications.ts
+++ b/src/tools/notifications.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IdSchema, NotificationSearchSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 
 export function registerNotificationTools(server: McpServer): void {
   server.registerTool(
@@ -27,7 +33,7 @@ Returns: Liste des notifications correspondantes.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/notifications", "GET", undefined, query);
+      const response = await apiSearch("/notifications", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "notification") }],
       };

--- a/src/tools/planning-absences.ts
+++ b/src/tools/planning-absences.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SearchSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse } from "../services/boond-client.js";
+import { apiSearch, buildSearchQuery, formatListResponse } from "../services/boond-client.js";
 
 export function registerPlanningAbsenceTools(server: McpServer): void {
   server.registerTool(
@@ -20,7 +20,7 @@ Returns: Planning des absences.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/planning-absences", "GET", undefined, query);
+      const response = await apiSearch("/planning-absences", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "planning absence") }],
       };

--- a/src/tools/poles.test.ts
+++ b/src/tools/poles.test.ts
@@ -4,7 +4,7 @@ import { registerPoleTools } from "./poles.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerPoleTools", {

--- a/src/tools/purchases.ts
+++ b/src/tools/purchases.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IdSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 import { buildJsonApiBody, registerDeleteTool } from "./crud-factory.js";
 import { z } from "zod";
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_SEARCH_PAGE } from "../constants.js";
@@ -50,7 +56,7 @@ Returns: Liste des achats correspondants.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/purchases", "GET", undefined, query);
+      const response = await apiSearch("/purchases", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "achat") }],
       };

--- a/src/tools/roles.test.ts
+++ b/src/tools/roles.test.ts
@@ -4,7 +4,7 @@ import { registerRoleTools } from "./roles.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerRoleTools", {

--- a/src/tools/test-helpers.ts
+++ b/src/tools/test-helpers.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { apiRequest } from "../services/boond-client.js";
+import { apiRequest, apiSearch } from "../services/boond-client.js";
 
 /**
  * Shared test utilities for tool-registration suites.
@@ -10,12 +10,13 @@ import { apiRequest } from "../services/boond-client.js";
  *
  *   vi.mock("../services/boond-client.js", async (importOriginal) => {
  *     const actual = await importOriginal<typeof import("../services/boond-client.js")>();
- *     return { ...actual, apiRequest: vi.fn() };
+ *     return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
  *   });
  *
- * That way `apiRequest` is a spy (so we can assert on the path/method it is
- * called with) while `buildSearchQuery` / `formatListResponse` run for real,
- * exercising the domain tool's callback end-to-end.
+ * `apiRequest` (used by the get tool) and `apiSearch` (used by the search tool,
+ * which chunks per-route — see ROUTE_MAX_RESULTS) are spies so we can assert on
+ * the path they are called with, while `buildSearchQuery` / `formatListResponse`
+ * run for real, exercising the domain tool's callback end-to-end.
  */
 export function createMockServer(): McpServer {
   return {
@@ -66,6 +67,7 @@ export function describeSearchGetTools(label: string, contract: SearchGetContrac
     beforeEach(() => {
       server = createMockServer();
       vi.mocked(apiRequest).mockReset();
+      vi.mocked(apiSearch).mockReset();
     });
 
     it("should register 2 tools", () => {
@@ -89,12 +91,13 @@ export function describeSearchGetTools(label: string, contract: SearchGetContrac
     });
 
     it("search should call the BoondManager API on the search path", async () => {
-      vi.mocked(apiRequest).mockResolvedValue({ data: [] });
+      vi.mocked(apiSearch).mockResolvedValue({ data: [] });
       contract.registrar(server);
       await toolCallback(server, searchTool)({ page: 2, pageSize: 10 });
-      const call = vi.mocked(apiRequest).mock.calls[0];
+      // Search goes through apiSearch (per-route maxResults chunking), not a raw
+      // apiRequest, so the route cap is always applied.
+      const call = vi.mocked(apiSearch).mock.calls[0];
       expect(call[0]).toBe(contract.searchPath);
-      expect(call[1]).toBe("GET");
     });
 
     it("get should call the BoondManager API on the detail path", async () => {

--- a/src/tools/threads.test.ts
+++ b/src/tools/threads.test.ts
@@ -4,7 +4,7 @@ import { registerThreadTools } from "./threads.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerThreadTools", {

--- a/src/tools/timesheets.ts
+++ b/src/tools/timesheets.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ResourceTimesheetSchema, TimesheetSearchSchema, TimesheetGetSchema } from "../schemas/index.js";
 import type { ResourceTimesheetInput, TimesheetSearchInput, TimesheetGetInput } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatDetailResponse } from "../services/boond-client.js";
+import { apiRequest, apiSearch, buildSearchQuery, formatDetailResponse } from "../services/boond-client.js";
 import { buildJsonApiBody } from "./crud-factory.js";
 import { CHARACTER_LIMIT } from "../constants.js";
 import type { JsonApiResponse } from "../types.js";
@@ -153,7 +153,7 @@ Returns: Liste des feuilles de temps correspondantes.`,
     },
     async (params: TimesheetSearchInput) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/times-reports", "GET", undefined, query);
+      const response = await apiSearch("/times-reports", query);
       const text = formatTimesheetSummary(response);
       return {
         content: [{ type: "text" as const, text }],

--- a/src/tools/todolists.test.ts
+++ b/src/tools/todolists.test.ts
@@ -4,7 +4,7 @@ import { registerTodolistTools } from "./todolists.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerTodolistTools", {

--- a/src/tools/validations.test.ts
+++ b/src/tools/validations.test.ts
@@ -4,7 +4,7 @@ import { registerValidationTools } from "./validations.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerValidationTools", {

--- a/src/tools/validations.ts
+++ b/src/tools/validations.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IdSchema, ValidationSearchSchema } from "../schemas/index.js";
-import { apiRequest, buildSearchQuery, formatListResponse, formatDetailResponse } from "../services/boond-client.js";
+import {
+  apiRequest,
+  apiSearch,
+  buildSearchQuery,
+  formatListResponse,
+  formatDetailResponse,
+} from "../services/boond-client.js";
 
 export function registerValidationTools(server: McpServer): void {
   server.registerTool(
@@ -30,7 +36,7 @@ Returns: Liste des validations correspondantes.`,
     },
     async (params) => {
       const query = buildSearchQuery(params);
-      const response = await apiRequest("/validations", "GET", undefined, query);
+      const response = await apiSearch("/validations", query);
       return {
         content: [{ type: "text" as const, text: formatListResponse(response, "validation") }],
       };

--- a/src/tools/webhooks.test.ts
+++ b/src/tools/webhooks.test.ts
@@ -4,7 +4,7 @@ import { registerWebhookTools } from "./webhooks.js";
 
 vi.mock("../services/boond-client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/boond-client.js")>();
-  return { ...actual, apiRequest: vi.fn() };
+  return { ...actual, apiRequest: vi.fn(), apiSearch: vi.fn() };
 });
 
 describeSearchGetTools("registerWebhookTools", {


### PR DESCRIPTION
## Contexte

L'équipe technique de BoondManager nous a contactés (mail) au sujet d'appels à la route `/api/actions` avec `maxResults > 100` : cette route peut ramener des objets très lourds et provoque des **dépassements mémoire côté BoondManager** (alertes internes, puis retour en erreur sur les appels). BoondManager prévoit de **plafonner `maxResults` à 100 uniquement pour `/api/actions`** (repli silencieux sur 30 au-delà).

Dans le MCP, `maxResults` est exposé sous le nom `pageSize` (mappé par `buildSearchQuery`) et va jusqu'à `MAX_PAGE_SIZE = 500`. Un simple bridage à 100 casserait l'usage « récupérer une page complète d'un coup ». Cette PR met donc en place un **découpage transparent**.

## Changement

- Nouvelle table `ROUTE_MAX_RESULTS` (`src/constants.ts`) : plafond `maxResults` par route (`/actions` → 100 ; défaut `DEFAULT_MAX_RESULTS = MAX_PAGE_SIZE`).
- Nouvelle couche `apiSearch(path, query)` (`src/services/boond-client.ts`) par laquelle passent désormais **tous les outils de recherche** :
  - **Chemin rapide** : si la page demandée ≤ plafond de la route → un seul appel, comportement identique à avant (routes non plafonnées incluses).
  - **Chemin découpé** : si la demande dépasse le plafond → la fenêtre demandée est récupérée en tranches de ≤ plafond (chaque appel envoie `maxResults = cap`, jamais plus), puis les pages sont fusionnées en une seule réponse JSON:API. L'appelant reçoit sa page complète (jusqu'à 500) « d'un coup », mais BoondManager ne voit **jamais** `maxResults > 100` sur `/actions`.
  - Nombre de tranches borné (`ceil((offset + requested) / cap)`), arrêt anticipé sur page courte.
- Câblage : `crud-factory.ts` (6 domaines principaux + domaines simples) et les handlers de recherche standard (`actions`, `advantages`, `deliveries`, `notifications`, `planning-absences`, `purchases`, `timesheets`, `validations`) appellent `apiSearch`.

Pour plafonner une future route, il suffit d'ajouter une entrée à `ROUTE_MAX_RESULTS`.

## Tests

- Nouvelle suite `apiSearch` (`boond-client.test.ts`) : chemin rapide (routes non plafonnées, appel unique), découpage `/actions` à 500 → 5 appels de `maxResults: 100` (jamais > 100), fusion de 500 items, arrêt anticipé sur page courte, offset correct avec `page > 1`.
- Test du handler `boond_actions_search` + adaptation des suites de recherche (assertions sur `apiSearch`).
- `npm test` (739 tests), `lint`, `typecheck`, `build`, `docs:tools:check` : verts.

## Compatibilité

Aucune régression sur les routes non plafonnées (chemin rapide à appel unique). `pageSize` reste plafonné à `MAX_PAGE_SIZE` de façon uniforme. Aucun changement du catalogue d'outils (`TOOLS.md` inchangé).
