### PR TITLE
fix(documents): accept suffixed document ids, stop returning the app shell (#186)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "boondmanager-mcp",
       "source": "./plugins/boondmanager-mcp",
       "description": "BoondManager ERP/CRM — 180 outils, 11 prompts, 22 resources",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "category": "productivity",
       "tags": ["erp", "crm", "boondmanager", "esn", "recrutement", "facturation"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.1] - 2026-08-13
+
+### Fixed
+
+- **`boond_documents_get` : les identifiants de documents suffixés sont acceptés, et l'échec n'est plus masqué** ([#186](https://github.com/fauguste/boondmanager-mcp-server/issues/186)). Les relations d'entités exposent des IDs de documents **suffixés** (`"resumes": [{ "id": "123_resume" }]`), que `IdSchema` (numérique strict) rejetait : l'appelant en déduisait qu'il fallait retirer le suffixe — et c'est là que le bug devenait invisible. `/documents/123` n'existe pas, mais l'API ne répond `404` que si l'on demande explicitement du JSON ; avec l'en-tête `Accept: */*` qu'envoie `apiDownload`, c'est la **coquille HTML de l'application** qui arrive, en HTTP 200. `isTextMime("text/html")` étant vrai, cette page était retournée comme contenu texte du document : vu de l'appelant, un CV illisible plutôt qu'un ID tronqué. Deux correctifs, chacun verrouillé par des tests. (1) Nouveau `DocumentIdSchema` (`/^\d+(_[A-Za-z]+)?$/`), utilisé **par `boond_documents_get` uniquement** — les autres outils gardent `IdSchema`. L'alphabet du suffixe reste alphabétique pur, donc le garde-fou contre l'injection de segments de chemin (`/`, `..`, `?`, `#`) est intact ; les deux casses sont admises parce que Boond dérive le suffixe de types parents en camelCase (`administrativeFile`). (2) Garde dans `apiDownload` : une réponse `text/html` **sans nom de fichier en `Content-Disposition`** est la coquille de l'app, pas un document — elle lève désormais une erreur explicite qui nomme la cause probable (ID tronqué) plutôt que d'être transmise. Un vrai document HTML, qui lui porte un `Content-Disposition: attachment`, reste téléchargeable. La description de l'outil dit maintenant de reprendre l'ID **tel quel, suffixe compris**.
+
 ## [2.12.0] - 2026-08-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,25 @@ the file server-side; the MCP server never reads local files), with
 `parsing: true` to trigger Boond's AI resume parsing on `candidateResume`.
 Delete goes through the factory (elicitation + structuredContent).
 
+Document ids are the **one exception** to the numeric-id rule, and the two
+halves of that exception have to stay together (issue #186):
+
+- Relations expose them **suffixed** — `{"resumes":{"data":[{"id":"123_resume"}]}}`
+  — so `boond_documents_get` validates with `DocumentIdSchema`
+  (`/^\d+(_[A-Za-z]+)?$/`), not `IdSchema`. Every other tool keeps `IdSchema`.
+  The suffix alphabet stays letters-only so the id still can't smuggle a path
+  segment / `..` / `?` / `#` into the API path; both cases are allowed because
+  Boond derives the suffix from camelCase parent types (`administrativeFile`).
+- BoondManager answers an **unknown** `/documents/<id>` with its app shell —
+  HTTP 200, `text/html`, ~9 KB — instead of a 404, because `apiDownload` sends
+  `Accept: */*` (it only 404s when JSON is explicitly requested). `isTextMime`
+  accepts `text/html`, so that page used to be returned *as the document's
+  text*: a truncated id looked like a corrupted CV, not a wrong id. `apiDownload`
+  therefore refuses `text/html` **without** a `Content-Disposition` filename —
+  a real file download carries one, the shell doesn't, so genuine HTML documents
+  still work. Rejecting the suffixed id without this guard is what made the
+  failure silent, hence: don't remove one without the other.
+
 **List summaries** (`src/services/boond-client.ts::formatEntitySummary`): one
 line per search result. Rows are normally identified by name / `value` /
 `title`. Rows that have none of those — `/invoices`, `/orders`, `/actions`,

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Serveur MCP pour l'API BoondManager (ERP/CRM ESN) - 180 outils, 11 prompts, 22 ressources.",
   "mcpServers": {
     "boondmanager": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/boondmanager-mcp/.claude-plugin/plugin.json
+++ b/plugins/boondmanager-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "boondmanager-mcp",
   "displayName": "BoondManager MCP Server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/plugins/boondmanager-mcp/.mcp.json
+++ b/plugins/boondmanager-mcp/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "boondmanager-mcp-server@2.12.0"
+        "boondmanager-mcp-server@2.12.1"
       ],
       "env": {
         "BOOND_BASE_URL": "${user_config.base_url}",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.12.0/boondmanager-mcp-server-v2.12.0.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.12.1/boondmanager-mcp-server-v2.12.1.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/schemas/index.test.ts
+++ b/src/schemas/index.test.ts
@@ -4,6 +4,7 @@ import {
   SearchSchema,
   IdSchema,
   IdTabSchema,
+  DocumentIdSchema,
   CandidateCreateSchema,
   CandidateUpdateSchema,
   ResourceCreateSchema,
@@ -143,6 +144,45 @@ describe("IdSchema", () => {
     for (const id of ["../invoices/5", "1?maxResults=99999", "1/financial", "abc", "%2e%2e"]) {
       expect(IdSchema.safeParse({ id }).success, id).toBe(false);
     }
+  });
+});
+
+describe("DocumentIdSchema", () => {
+  it("should accept the suffixed ids exposed by entity relations", () => {
+    for (const id of ["123_resume", "5_file", "42_administrativeFile", "7_picture"]) {
+      expect(DocumentIdSchema.safeParse({ id }).success, id).toBe(true);
+    }
+  });
+
+  it("should still accept a bare numeric id", () => {
+    expect(DocumentIdSchema.safeParse({ id: "123" }).success).toBe(true);
+  });
+
+  it("should keep the path-traversal / query-injection guard", () => {
+    for (const id of [
+      "",
+      "../invoices/5",
+      "1?maxResults=99999",
+      "1/financial",
+      "abc",
+      "%2e%2e",
+      "123_",
+      "123_res ume",
+      "123_resume/../x",
+      "_resume",
+    ]) {
+      expect(DocumentIdSchema.safeParse({ id }).success, id).toBe(false);
+    }
+  });
+
+  it("should reject extra fields (strict mode)", () => {
+    expect(DocumentIdSchema.safeParse({ id: "123_resume", tab: "information" }).success).toBe(false);
+  });
+
+  it("should explain the suffix in its error message", () => {
+    const result = DocumentIdSchema.safeParse({ id: "cv.pdf" });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toContain("123_resume");
   });
 });
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -531,6 +531,28 @@ export const IdSchema = z
   })
   .strict();
 
+// Document ids are the one exception to the numeric rule: entity relations
+// expose them **suffixed** with the document's parent type
+// (`{"resumes":{"data":[{"id":"123_resume"}]}}`). Validating them with
+// `EntityIdSchema` rejected the id the caller was legitimately given, and
+// stripping the suffix to satisfy the schema produces an id BoondManager
+// answers with its app shell in HTTP 200 (see the `text/html` guard in
+// `apiDownload`) — a silent failure. The suffix alphabet stays letters-only so
+// the id still can't smuggle a path segment, `..`, `?` or `#` into the API
+// path. Letters are allowed in both cases because Boond derives the suffix
+// from camelCase parent types (`administrativeFile`).
+export const DocumentIdSchema = z
+  .object({
+    id: z
+      .string()
+      .regex(
+        /^\d+(_[A-Za-z]+)?$/,
+        "L'identifiant de document doit être numérique, avec un suffixe optionnel (ex. 123_resume)"
+      )
+      .describe("Identifiant du document, tel qu'exposé par les relations d'entités (ex. 123_resume)"),
+  })
+  .strict();
+
 // ID + tab param schema
 export const IdTabSchema = z
   .object({
@@ -1652,6 +1674,7 @@ export type OpportunitySearchInput = z.infer<typeof OpportunitySearchSchema>;
 export type ProjectSearchInput = z.infer<typeof ProjectSearchSchema>;
 export type IdInput = z.infer<typeof IdSchema>;
 export type IdTabInput = z.infer<typeof IdTabSchema>;
+export type DocumentIdInput = z.infer<typeof DocumentIdSchema>;
 export type ResourceTimesheetInput = z.infer<typeof ResourceTimesheetSchema>;
 export type TimesheetSearchInput = z.infer<typeof TimesheetSearchSchema>;
 export type TimesheetGetInput = z.infer<typeof TimesheetGetSchema>;

--- a/src/services/boond-client.test.ts
+++ b/src/services/boond-client.test.ts
@@ -1964,6 +1964,54 @@ describe("apiDownload", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // BoondManager answers an unknown /documents/<id> with the app shell (HTTP
+  // 200, text/html) instead of a 404 when the request doesn't ask for JSON.
+  // Returning it as the document's content made a truncated id look like a
+  // corrupted file — see issue #186.
+  describe("HTML app-shell guard", () => {
+    function htmlResponse(headers: Record<string, string>) {
+      const bytes = Buffer.from("<!DOCTYPE html><html><body>BoondManager</body></html>");
+      return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(headers),
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+      });
+    }
+
+    it("refuses an HTML page served in place of a document", async () => {
+      vi.stubGlobal("fetch", htmlResponse({ "content-type": "text/html; charset=utf-8" }));
+      await expect(apiDownload("/documents/123")).rejects.toThrow(/HTML page instead of a document/);
+    });
+
+    it("points at the suffixed id in the error", async () => {
+      vi.stubGlobal("fetch", htmlResponse({ "content-type": "text/html" }));
+      await expect(apiDownload("/documents/123")).rejects.toThrow(/123_resume/);
+      await expect(apiDownload("/documents/123")).rejects.toThrow(/GET \/documents\/123/);
+    });
+
+    it("still downloads a genuine HTML file (attachment filename present)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        htmlResponse({
+          "content-type": "text/html",
+          "content-disposition": 'attachment; filename="lettre.html"',
+        })
+      );
+      const doc = await apiDownload("/documents/123_file");
+      expect(doc.contentType).toBe("text/html");
+      expect(doc.filename).toBe("lettre.html");
+      expect(doc.data.toString()).toContain("BoondManager");
+    });
+
+    it("leaves other content types untouched", async () => {
+      vi.stubGlobal("fetch", htmlResponse({ "content-type": "application/xhtml+xml" }));
+      await expect(apiDownload("/documents/123_resume")).resolves.toMatchObject({
+        contentType: "application/xhtml+xml",
+      });
+    });
+  });
+
   describe("byte progress", () => {
     /** A body delivered in `chunks` slices of `chunkBytes`, plus its Content-Length. */
     function streamedResponse(chunks: number, chunkBytes: number, withContentLength = true) {

--- a/src/services/boond-client.ts
+++ b/src/services/boond-client.ts
@@ -791,12 +791,30 @@ export async function apiDownload(path: string, onProgress?: ProgressReporter): 
     throw new Error(formatApiError(response.status, response.statusText, "GET", path, errorText));
   }
 
+  const contentType = response.headers.get("content-type")?.split(";")[0].trim() || "application/octet-stream";
+  const filename = parseContentDispositionFilename(response.headers.get("content-disposition"));
+
+  // BoondManager only answers 404 on an unknown document when the request asks
+  // for JSON. With the `Accept: */*` this function sends, it serves the
+  // application shell instead — HTTP 200, `text/html`, ~9 KB — which the caller
+  // would happily surface as the document's text content. A truncated id then
+  // looks like a corrupted file rather than a wrong id, so refuse the shell
+  // here. An HTML *document* is still downloadable: a real file download
+  // carries a `Content-Disposition` filename, the shell doesn't.
+  if (contentType === "text/html" && !filename) {
+    throw new Error(
+      [
+        "BoondManager returned an HTML page instead of a document (HTTP 200, text/html).",
+        `Endpoint: GET ${path}`,
+        "Hint: The document id is most likely wrong or truncated. Entity relations expose suffixed ids " +
+          "(e.g. `123_resume`, `123_file`) — pass the id verbatim, suffix included. BoondManager serves its " +
+          "application shell for an unknown /documents/<id> instead of a 404.",
+      ].join("\n")
+    );
+  }
+
   const data = await readDownloadBody(response, onProgress);
-  return {
-    data,
-    contentType: response.headers.get("content-type")?.split(";")[0].trim() || "application/octet-stream",
-    filename: parseContentDispositionFilename(response.headers.get("content-disposition")),
-  };
+  return { data, contentType, filename };
 }
 
 /**

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -72,6 +72,34 @@ describe("registerDocumentTools", () => {
       expect(Buffer.from(resource.blob!, "base64").toString()).toBe("%PDF-1.4 fake");
     });
 
+    // Entity relations expose suffixed document ids (`123_resume`); rejecting
+    // them pushed the caller into stripping the suffix, which silently returns
+    // the app shell instead of the file — see issue #186.
+    it("accepts the suffixed ids exposed by entity relations", async () => {
+      vi.mocked(apiDownload).mockResolvedValue({
+        data: Buffer.from("%PDF-1.4 fake"),
+        contentType: "application/pdf",
+        filename: "cv-dupont.pdf",
+      });
+      registerDocumentTools(server);
+      const config = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_documents_get")![1];
+      const schema = config.inputSchema as unknown as {
+        shape: { id: { safeParse: (v: unknown) => { success: boolean } } };
+      };
+      expect(schema.shape.id.safeParse("123_resume").success).toBe(true);
+      expect(schema.shape.id.safeParse("../invoices/5").success).toBe(false);
+
+      const result = await handlerOf(server, "boond_documents_get")({ id: "123_resume" });
+      expect(apiDownload).toHaveBeenCalledWith("/documents/123_resume", expect.any(Function));
+      expect(result.content[1].resource!.uri).toBe("boond://documents/123_resume");
+    });
+
+    it("mentions the suffix in its description so the id isn't truncated", () => {
+      registerDocumentTools(server);
+      const config = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === "boond_documents_get")![1];
+      expect(config.description).toContain("123_resume");
+    });
+
     it("returns text documents as plain text", async () => {
       vi.mocked(apiDownload).mockResolvedValue({
         data: Buffer.from("Jean Dupont — Développeur TypeScript"),

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -1,8 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apiDownload, apiUploadForm, formatDetailResponse } from "../services/boond-client.js";
 import { progressReporterFrom } from "../services/progress.js";
-import { IdSchema, DocumentCreateSchema } from "../schemas/index.js";
-import type { IdInput, DocumentCreateInput } from "../schemas/index.js";
+import { DocumentIdSchema, DocumentCreateSchema } from "../schemas/index.js";
+import type { DocumentIdInput, DocumentCreateInput } from "../schemas/index.js";
 import { MAX_DOCUMENT_BYTES, CHARACTER_LIMIT } from "../constants.js";
 import { registerDeleteTool, MutationOutputSchema } from "./crud-factory.js";
 
@@ -19,13 +19,13 @@ export function registerDocumentTools(server: McpServer): void {
       title: "Télécharger un document",
       description: `Télécharge le contenu d'un document BoondManager (CV de candidat/ressource, justificatif, contrat, facture...) par son ID.
 
-Où trouver les IDs de documents : dans les onglets des entités — ex. boond_candidates_information expose les relations 'resumes' (CV) et 'files' (dossier administratif).
+Où trouver les IDs de documents : dans les onglets des entités — ex. boond_candidates_information expose les relations 'resumes' (CV) et 'files' (dossier administratif). ⚠️ Reprendre l'ID **tel quel**, suffixe compris (ex. '123_resume') : un ID tronqué à sa partie numérique ne désigne aucun document.
 
 Le contenu est retourné en ressource MCP embarquée (base64 pour les binaires type PDF/DOCX, texte brut pour les fichiers texte). Taille max: ${Math.round(MAX_DOCUMENT_BYTES / 1024 / 1024)} Mo — à n'utiliser que lorsque le contenu du fichier est réellement nécessaire (un CV en base64 occupe beaucoup de contexte).
 
 Args:
-  - id (string): Identifiant du document`,
-      inputSchema: IdSchema,
+  - id (string): Identifiant du document, tel qu'exposé par la relation (ex. 123_resume)`,
+      inputSchema: DocumentIdSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -33,7 +33,7 @@ Args:
         openWorldHint: false,
       },
     },
-    async (params: IdInput, extra: unknown) => {
+    async (params: DocumentIdInput, extra: unknown) => {
       // Byte-level progress, but only when the client asked for it and the
       // response announces a Content-Length (see readDownloadBody).
       const doc = await apiDownload(`/documents/${params.id}`, progressReporterFrom(extra));


### PR DESCRIPTION
Closes #186.

`boond_documents_get` could not download a CV. Depending on the id passed, the call was either rejected at validation or "succeeded" by returning an HTML page instead of the PDF, with no error.

Entity relations expose document ids **suffixed** with the parent type (`{"resumes":{"data":[{"id":"123_resume"}]}}`), which `IdSchema` (numeric only) rejected. The natural reaction is to strip the suffix — and that is where the failure became invisible: `/documents/123` does not exist, but BoondManager only answers `404` when JSON is explicitly requested. With the `Accept: */*` that `apiDownload` sends, it serves the application shell in HTTP 200, `text/html`. `isTextMime("text/html")` is true, so that page was returned as the document's text content: from the caller's side, an unreadable CV rather than a wrong id.

## What changed

Both halves are fixed, because either one alone leaves the trap:

- **`DocumentIdSchema`** (`/^\d+(_[A-Za-z]+)?$/`), used by `boond_documents_get` **only** — every other tool keeps `IdSchema`. The suffix alphabet stays letters-only, so an id still cannot smuggle a path segment, `..`, `?` or `#` into the API path. Both cases are allowed (the issue proposed `[a-z]`): Boond derives the suffix from camelCase parent types, so `123_administrativeFile` would otherwise have been rejected too.
- **HTML app-shell guard in `apiDownload`** — a `text/html` response with **no `Content-Disposition` filename** now throws an explicit error naming the likely cause (truncated id) instead of being handed back as the document. That condition is an addition to the fix proposed in the issue: it is what keeps genuine HTML documents downloadable — a real file download carries an attachment filename, the app shell does not.
- The tool description now says to pass the id **verbatim, suffix included** — that is what the model reads before calling.

## Tests

11 added (1043 total):
- schema accepts `123_resume` / `42_administrativeFile`, still rejects `../invoices/5`, `1?maxResults=…`, `123_`, `abc`;
- `apiDownload` throws on the shell (error names both `123_resume` and the endpoint), downloads an HTML file that carries an attachment filename, leaves other content types untouched;
- the tool forwards the suffixed id to `/documents/123_resume` and keeps the suffix in its description.

`npm test`, `lint`, `typecheck`, `build`, `docs:tools:check`, `plugin:manifest:check` all green. Version bumped to **2.12.1** across the 7 copies + the plugin npm pin, `CHANGELOG.md` entry added, and `CLAUDE.md` §Documents documents why the two halves must stay together.

## Not covered here

`boond_documents_delete` still validates with `IdSchema` (per the issue). If the API also expects the suffixed id on `DELETE /documents/{id}`, deleting a CV stays out of reach — worth a real API check before changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)