### PR TITLE
fix(schemas): drop the draft-07 $schema from advertised tool schemas (v2.12.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "boondmanager-mcp",
       "source": "./plugins/boondmanager-mcp",
       "description": "BoondManager ERP/CRM — 180 outils, 11 prompts, 22 resources",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "category": "productivity",
       "tags": ["erp", "crm", "boondmanager", "esn", "recrutement", "facturation"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.2] - 2026-08-14
+
+### Fixed
+
+- **Tous les outils `*_search` étaient inutilisables sur les clients dont le validateur ne connaît que JSON Schema 2020-12.** Le SDK convertit nos schémas Zod avec `z.toJSONSchema(schema, { target: 'draft-7' })`, ce qui estampille chaque `inputSchema` / `outputSchema` annoncé d'un `"$schema": "http://json-schema.org/draft-07/schema#"`. Un hôte qui valide le `structuredContent` avec un validateur **2020-12 uniquement** (`Ajv2020`) refuse alors de *compiler* le schéma — `no schema with key or ref "http://json-schema.org/draft-07/schema#"` — et l'échec se produit à l'enregistrement de l'outil côté client, donc **avant tout appel** : l'outil n'échoue pas, il devient indisponible. Le symptôme était asymétrique et déroutant : seuls les **59 outils qui déclarent un `outputSchema`** (tous les `*_search`, plus create/update/delete) étaient touchés, alors que les ~120 sans (`*_get`, dictionnaires, reporting) fonctionnaient — bien que les 180 portent le même `$schema` sur leur `inputSchema`. Résultat côté utilisateur : impossible de chercher une entité, seulement de la relire quand on connaît déjà son ID. Correctif : la déclaration de dialecte est retirée des schémas annoncés (`src/schema-dialect.ts`, décorateur de réponses `tools/list` branché via l'API publique `Server.setRequestHandler`, même mécanisme que les icônes). `$schema` ne fait **pas** partie de la forme `Tool.inputSchema` / `Tool.outputSchema` de la spec MCP, et le catalogue n'utilise **aucun mot-clé propre à un dialecte** (ni `$ref`, ni `$defs`, ni `definitions`) : ne rien déclarer est la seule option qui satisfasse à la fois les validateurs 2020-12 et draft-07 — annoncer 2020-12 aurait déplacé la panne vers le client du SDK MCP lui-même, dont l'Ajv 8 est en draft-07 par défaut. Le retrait est récursif mais ne touche que les `$schema` de type *chaîne*, sans quoi un filtre qui s'appellerait `$schema` disparaîtrait de la forme annoncée. Effet de bord bienvenu : **~10 Kio de moins sur `tools/list`** (282,9 Kio au lieu de 293,4). Trois tests le verrouillent sur un vrai client : aucun dialecte annoncé nulle part, les 239 schémas compilent sous `Ajv2020`, et un `structuredContent` réel valide toujours.
+
 ## [2.12.1] - 2026-08-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ src/
 ├── server.ts             # createMcpServer() factory — instantiates McpServer (name/version/description + instructions) + registers tools/prompts/resources
 ├── instructions.ts       # SERVER_INSTRUCTIONS — cross-cutting usage rules sent once at initialize
 ├── icons.ts              # DOMAIN_ICONS (SEP-973) + installProtocolIcons() — decorates tools/list & prompts/list responses
+├── schema-dialect.ts     # installSchemaDialectCompat() — strips the SDK's draft-07 `$schema` from advertised input/outputSchema
 ├── constants.ts          # DEFAULT_BASE_URL, pagination limits, API_PATHS, ENTITY_TABS
 ├── types.ts              # JsonApiResource, JsonApiResponse, BoondConfig, SearchParams
 ├── transports/
@@ -468,7 +469,7 @@ How it is wired, and why it is wired that way:
      the right tool names and filter shortcuts
   5. For resources: read callback hits the expected API path
 - **Coverage**: V8 provider, excludes test files and index.ts
-- **Current stats**: 62 test files, **1032 tests**
+- **Current stats**: 63 test files, **1051 tests**
 
 ### Test file template (for read-only search+get domains):
 
@@ -592,7 +593,7 @@ The crud-factory tools declare an MCP `outputSchema` and return
   would double the payload). No `mimeType`/`sizes` — the URI carries the type and
   SVG is scalable. Path data uses `,` separators so nothing needs `%20`.
 - **Byte cost is the design constraint**: icons ride on *every* `tools/list`
-  entry — measured **~40 KiB, ~14 % of the 295 KiB payload**. Capped in
+  entry — measured **~40 KiB, ~14 % of the 283 KiB payload**. Capped in
   `src/tools/descriptions.test.ts` (absolute + share-of-payload) and per-icon in
   `src/icons.test.ts`. Opt-out: `BOOND_MCP_ICONS=0|false|no|off`.
 - **Delivery mechanism**: SDK 1.30 types `icons` on `Tool`/`Prompt` but its
@@ -608,6 +609,46 @@ The crud-factory tools declare an MCP `outputSchema` and return
   (`src/tools/registration-decorators.ts`), never from parsing tool names — so
   `boond_provider_invoices_*` and `boond_workflow_*` get the right glyph.
 - The TOOLS.md generator ignores icons on purpose (it renders a text catalogue).
+
+## No JSON Schema Dialect on Advertised Schemas
+
+`src/schema-dialect.ts::installSchemaDialectCompat()` strips `$schema` from
+every `inputSchema` / `outputSchema` in `tools/list`. Same shim mechanism and
+same "before the first registration" constraint as `installProtocolIcons`.
+
+Why it exists: the SDK converts Zod v4 schemas with
+`z.toJSONSchema(schema, { target: 'draft-7' })` (hardcoded in
+`server/zod-json-schema-compat.js`, no option to change or omit), which stamps
+`"$schema": "http://json-schema.org/draft-07/schema#"` on all 239 advertised
+schemas. A host that validates `structuredContent` with a **2020-12-only**
+validator (`Ajv2020`) refuses to *compile* such a schema —
+`no schema with key or ref "http://json-schema.org/draft-07/schema#"` — and that
+happens at client-side tool registration, i.e. **before any call**: the tool
+doesn't fail, it disappears.
+
+The symptom is asymmetric and misleading, so recognise it: only the **59 tools
+that declare an `outputSchema`** (every `*_search`, plus create/update/delete)
+break, while the ~120 without one (`*_get`, dictionaries, reporting) keep
+working — even though *all 180* carry the same `$schema` on their `inputSchema`.
+A client in that state can only re-read entities whose id it already knows.
+
+Design points, each with a test in `src/schema-dialect.test.ts`:
+
+- **Declaring nothing, not declaring 2020-12.** `$schema` is not part of MCP's
+  `Tool.inputSchema` / `Tool.outputSchema` shape, and the catalogue uses no
+  dialect-specific keyword (no `$ref`, no `$defs`, no `definitions`) — so every
+  validator reads the schemas identically under its own default dialect.
+  Announcing 2020-12 would just move the break to draft-07-only validators, the
+  MCP SDK's own client among them (plain Ajv 8, draft-07 by default).
+- **Only *string* `$schema` members are removed.** A property *named* `$schema`
+  inside `properties` is a schema **object**; a blind recursive delete would
+  silently drop it from the advertised input shape.
+- `stripSchemaDialect` returns its input **by identity** when there is nothing to
+  strip, so the day the SDK stops emitting the declaration this costs nothing.
+- Bonus: ~10 KiB off `tools/list` (282.9 KiB instead of 293.4).
+
+Deletable the moment the SDK omits `$schema` or lets us pick the target — the
+test asserts over a real client, so the regression can't return quietly.
 
 ## Deterministic `tools/list` Order
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Serveur MCP pour l'API BoondManager (ERP/CRM ESN) - 180 outils, 11 prompts, 22 ressources.",
   "mcpServers": {
     "boondmanager": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -21,6 +21,7 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "^4.0.18",
+        "ajv": "^8.17.1",
         "eslint": "^10.0.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -68,6 +68,7 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "ajv": "^8.17.1",
     "eslint": "^10.0.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",

--- a/plugins/boondmanager-mcp/.claude-plugin/plugin.json
+++ b/plugins/boondmanager-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "boondmanager-mcp",
   "displayName": "BoondManager MCP Server",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/plugins/boondmanager-mcp/.mcp.json
+++ b/plugins/boondmanager-mcp/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "boondmanager-mcp-server@2.12.1"
+        "boondmanager-mcp-server@2.12.2"
       ],
       "env": {
         "BOOND_BASE_URL": "${user_config.base_url}",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 180 tools, 11 prompts, 22 resources (ERP/CRM)",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -20,14 +20,14 @@
     {
       "registryType": "npm",
       "identifier": "boondmanager-mcp-server",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.12.1/boondmanager-mcp-server-v2.12.1.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.12.2/boondmanager-mcp-server-v2.12.2.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"

--- a/src/schema-dialect.test.ts
+++ b/src/schema-dialect.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import { stripSchemaDialect } from "./schema-dialect.js";
+import { connectMcpClient, useDefaultServerSurface } from "./tools/test-helpers.js";
+
+/**
+ * Regression suite for the draft-07 `$schema` that made every tool with an
+ * `outputSchema` (i.e. every `*_search`) unusable on hosts whose validator only
+ * knows JSON Schema 2020-12. See `schema-dialect.ts` for the full story.
+ */
+
+useDefaultServerSurface();
+
+/** Collect every JSON Pointer at which a `$schema` string still appears. */
+function dialectDeclarations(value: unknown, path = ""): string[] {
+  if (Array.isArray(value)) return value.flatMap((item, i) => dialectDeclarations(item, `${path}/${i}`));
+  if (value === null || typeof value !== "object") return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, member]) =>
+    key === "$schema" && typeof member === "string"
+      ? [`${path}/$schema`]
+      : dialectDeclarations(member, `${path}/${key}`)
+  );
+}
+
+describe("stripSchemaDialect", () => {
+  it("removes the dialect declaration at the root", () => {
+    expect(stripSchemaDialect({ $schema: "http://json-schema.org/draft-07/schema#", type: "object" })).toEqual({
+      type: "object",
+    });
+  });
+
+  it("removes nested declarations too (arrays and objects)", () => {
+    const stripped = stripSchemaDialect({
+      type: "object",
+      properties: { a: { $schema: "x", type: "string" } },
+      anyOf: [{ $schema: "y", type: "number" }],
+    });
+    expect(dialectDeclarations(stripped)).toEqual([]);
+    expect(stripped).toEqual({ type: "object", properties: { a: { type: "string" } }, anyOf: [{ type: "number" }] });
+  });
+
+  it("keeps a property *named* `$schema` — a schema object is not a dialect declaration", () => {
+    // Deleting this would silently drop a filter from the advertised input shape.
+    const schema = { type: "object", properties: { $schema: { type: "string" } } };
+    expect(stripSchemaDialect(schema)).toEqual(schema);
+  });
+
+  it("returns the input by identity when there is nothing to strip", () => {
+    const schema = { type: "object", properties: { id: { type: "string" } } };
+    expect(stripSchemaDialect(schema)).toBe(schema);
+  });
+
+  it("leaves non-objects untouched", () => {
+    expect(stripSchemaDialect("x")).toBe("x");
+    expect(stripSchemaDialect(null)).toBe(null);
+    expect(stripSchemaDialect(3)).toBe(3);
+  });
+});
+
+describe("advertised tool schemas (over a real client)", () => {
+  it("declare no JSON Schema dialect at all", async () => {
+    const { client, close } = await connectMcpClient();
+    try {
+      const { tools } = await client.listTools();
+      const offenders = tools.flatMap((tool) => [
+        ...dialectDeclarations(tool.inputSchema).map((p) => `${tool.name}.inputSchema${p}`),
+        ...dialectDeclarations(tool.outputSchema).map((p) => `${tool.name}.outputSchema${p}`),
+      ]);
+      expect(offenders).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("compile under a 2020-12-only validator — the one that used to reject them", async () => {
+    const { client, close } = await connectMcpClient();
+    try {
+      const { tools } = await client.listTools();
+      // strict:false — the assertion is about *dialect* support, not about Ajv's
+      // opinions on unknown keywords in a third-party schema.
+      const ajv = new Ajv2020({ strict: false });
+      const failures: string[] = [];
+      for (const tool of tools) {
+        for (const field of ["inputSchema", "outputSchema"] as const) {
+          const schema = tool[field];
+          if (!schema) continue;
+          try {
+            ajv.compile(schema);
+          } catch (error) {
+            failures.push(`${tool.name}.${field}: ${(error as Error).message}`);
+          }
+        }
+      }
+      expect(failures).toEqual([]);
+      // Guard the guard: the suite is only meaningful while some tool actually
+      // declares an outputSchema (that is the half the host validator compiles).
+      expect(tools.filter((t) => t.outputSchema).length).toBeGreaterThan(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it("still validate a real structuredContent payload under 2020-12", async () => {
+    const { client, close } = await connectMcpClient();
+    try {
+      const { tools } = await client.listTools();
+      const search = tools.find((t) => t.name === "boond_candidates_search");
+      const validate = new Ajv2020({ strict: false }).compile(search!.outputSchema!);
+      expect(validate({ total: 2, count: 1, items: [{ id: "42", type: "candidate", summary: "Jean Dupont" }] })).toBe(
+        true
+      );
+      expect(validate({ items: [] })).toBe(false); // `count` is required
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/schema-dialect.ts
+++ b/src/schema-dialect.ts
@@ -1,0 +1,137 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Strip the JSON Schema **dialect declaration** (`$schema`) from the
+ * `inputSchema` / `outputSchema` advertised in `tools/list`.
+ *
+ * ## The bug this fixes
+ *
+ * `McpServer` converts our Zod schemas with `toJsonSchemaCompat`, which for
+ * Zod v4 calls `z.toJSONSchema(schema, { target: 'draft-7' })` — and that
+ * stamps every advertised schema with
+ *
+ *     "$schema": "http://json-schema.org/draft-07/schema#"
+ *
+ * Hosts that validate `structuredContent` with a **2020-12-only** validator
+ * (Ajv's `Ajv2020`, which is what the JSON Schema tooling around the Claude
+ * tool API uses) refuse to *compile* such a schema at all:
+ *
+ *     no schema with key or ref "http://json-schema.org/draft-07/schema#"
+ *
+ * The compile happens when the tool is registered client-side, i.e. **before**
+ * any call, so the tool doesn't fail — it becomes unusable. The symptom is
+ * asymmetric and looks baffling: only the 59 tools that declare an
+ * `outputSchema` are affected (every `*_search`, plus create/update/delete),
+ * while the ~120 tools without one (`*_get`, dictionaries, reporting) work
+ * fine — even though *all* 180 carry the same `$schema` on their `inputSchema`.
+ * That leaves a client able to read an entity only if the id is already known,
+ * with no way to search for it.
+ *
+ * ## Why removing the declaration is the right fix
+ *
+ * - `$schema` is **not** part of MCP's `Tool.inputSchema` / `Tool.outputSchema`
+ *   shape. The spec asks for "a JSON Schema object"; the dialect declaration is
+ *   optional metadata that no client needs, and most servers never emit.
+ * - Our schemas use **no dialect-specific keyword** (verified over the whole
+ *   catalogue: `type`, `properties`, `required`, `items`, `enum`, `pattern`,
+ *   `propertyNames`, `additionalProperties`, `anyOf` — identical semantics in
+ *   draft-07 and 2020-12; no `$ref`, no `$defs`, no `definitions`). Dropping
+ *   the declaration therefore changes no schema's meaning: every validator
+ *   applies its own default dialect and reads them the same way.
+ * - The alternative — declaring 2020-12 instead — would just move the failure
+ *   to draft-07-only validators (the MCP SDK's own client uses plain Ajv 8,
+ *   whose default *is* draft-07). Declaring nothing is the only choice that
+ *   satisfies both.
+ * - Bonus: 45 bytes × 239 schemas ≈ **10 KiB off the `tools/list` payload**,
+ *   which this codebase budgets carefully (see `icons.ts`).
+ *
+ * ## Why a response decorator
+ *
+ * `registerTool` takes Zod, and the draft-07 target is hardcoded inside the SDK
+ * (`server/zod-json-schema-compat.js`) with no option to change or omit it — so
+ * there is nothing to pass at registration time. Same shim mechanism as
+ * `installProtocolIcons`: wrap the `tools/list` handler through the public
+ * `Server.setRequestHandler`, keyed on schema identity. When the SDK stops
+ * emitting `$schema` (or lets us choose), this file can be deleted —
+ * `schema-dialect.test.ts` asserts over a real client, so the regression can't
+ * come back silently.
+ */
+
+/** The two fields of a `tools/list` entry that carry a JSON Schema. */
+const SCHEMA_FIELDS = ["inputSchema", "outputSchema"] as const;
+
+/**
+ * Recursively drop `$schema` string members. Returns the input **by identity**
+ * when there is nothing to strip, so a future SDK that stops emitting the
+ * declaration costs no allocation at all.
+ *
+ * The `typeof === "string"` guard matters: a dialect declaration is always a
+ * string URI, whereas a *property named* `$schema` inside a `properties` map
+ * would be a schema **object**. Without the guard this would silently delete
+ * such a property from the advertised input shape.
+ */
+export function stripSchemaDialect<T>(value: T): T {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const out = value.map((item) => {
+      const stripped = stripSchemaDialect(item);
+      if (stripped !== item) changed = true;
+      return stripped;
+    });
+    return (changed ? out : value) as T;
+  }
+  if (value === null || typeof value !== "object") return value;
+
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, member] of Object.entries(value as Record<string, unknown>)) {
+    if (key === "$schema" && typeof member === "string") {
+      changed = true;
+      continue;
+    }
+    const stripped = stripSchemaDialect(member);
+    if (stripped !== member) changed = true;
+    out[key] = stripped;
+  }
+  return (changed ? out : value) as T;
+}
+
+/** Strip the dialect from one `tools/list` entry, keeping identity when possible. */
+function withoutSchemaDialect<T extends object>(tool: T): T {
+  let result = tool;
+  for (const field of SCHEMA_FIELDS) {
+    const schema = (result as Record<string, unknown>)[field];
+    if (schema === undefined || schema === null) continue;
+    const stripped = stripSchemaDialect(schema);
+    if (stripped !== schema) result = { ...result, [field]: stripped };
+  }
+  return result;
+}
+
+type AnyHandler = (...args: unknown[]) => unknown;
+
+/**
+ * Remove the JSON Schema dialect declaration from `tools/list` responses.
+ *
+ * MUST be called before the first `registerTool` on this server: it works by
+ * intercepting the `setRequestHandler` call the SDK makes when it lazily
+ * installs the `tools/list` handler.
+ */
+export function installSchemaDialectCompat(server: McpServer): void {
+  // `Server.setRequestHandler` is generic over the request schema; the shim is
+  // schema-agnostic, hence the single cast at the boundary.
+  const underlying = server.server as unknown as {
+    setRequestHandler: (schema: unknown, handler: AnyHandler) => void;
+  };
+  const original = underlying.setRequestHandler.bind(underlying);
+
+  underlying.setRequestHandler = (schema: unknown, handler: AnyHandler) => {
+    if (schema !== ListToolsRequestSchema) return original(schema, handler);
+    return original(schema, async (...args: unknown[]) => {
+      const result = (await handler(...args)) as { tools?: object[] };
+      if (!Array.isArray(result?.tools)) return result;
+      return { ...result, tools: result.tools.map(withoutSchemaDialect) };
+    });
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import {
   type RegistrationIndex,
 } from "./tools/registration-decorators.js";
 import { installProtocolIcons } from "./icons.js";
+import { installSchemaDialectCompat } from "./schema-dialect.js";
 
 // Re-exported for the catalogue generator and tests that import it from here.
 export { REGISTERED_DOMAINS } from "./constants.js";
@@ -225,6 +226,13 @@ export function createMcpServer(): McpServer {
   // call. The index it closes over is filled during registerAll below.
   const index = createRegistrationIndex();
   installProtocolIcons(server, index);
+
+  // Same "before any registration" constraint, same mechanism: drops the
+  // draft-07 `$schema` the SDK stamps on every advertised inputSchema/
+  // outputSchema, which a 2020-12-only host validator refuses to compile —
+  // making every tool that declares an outputSchema (all `*_search`) unusable
+  // client-side. See schema-dialect.ts.
+  installSchemaDialectCompat(server);
 
   // Operator-configured restrictions (env-driven). Absent config = full surface.
   registerAll(server, resolveAccessPolicy(), index);


### PR DESCRIPTION
## Le symptôme

Côté client, **tous les outils `*_search` refusent de s'exécuter** : leur schéma est déclaré en JSON Schema draft-07, que le validateur de l'hôte ne sait pas charger. Seule la lecture unitaire (`*_get`, dictionnaires, reporting) fonctionne — mais elle exige de connaître les ID à l'avance, donc le serveur devient inexploitable pour découvrir quoi que ce soit.

## La cause

Le SDK convertit nos schémas Zod v4 avec `z.toJSONSchema(schema, { target: 'draft-7' })` — codé en dur dans `server/zod-json-schema-compat.js`, sans option pour le changer ni l'omettre. Les **239 schémas annoncés** portent donc :

```json
"$schema": "http://json-schema.org/draft-07/schema#"
```

Un hôte qui valide le `structuredContent` avec un validateur **2020-12 uniquement** (`Ajv2020`) refuse de *compiler* ce schéma :

```
no schema with key or ref "http://json-schema.org/draft-07/schema#"
```

Et cela se produit à l'enregistrement de l'outil côté client, donc **avant tout appel** : l'outil n'échoue pas, il devient indisponible.

**L'asymétrie qui rendait le diagnostic trompeur** : sur 180 outils, seuls les **59 qui déclarent un `outputSchema`** (tous les `*_search`, plus create/update/delete) cassent. Les ~120 sans (`*_get`, dictionnaires, reporting) passent — alors que **les 180** portent le même `$schema` sur leur `inputSchema`. Autrement dit : c'est bien le seul `outputSchema` que l'hôte compile.

## Le correctif

`src/schema-dialect.ts` — `installSchemaDialectCompat()` retire la déclaration de dialecte des `inputSchema`/`outputSchema` dans `tools/list`, via le même décorateur de réponses (et la même contrainte « avant la première registration ») que `installProtocolIcons`.

Choix de conception, chacun verrouillé par un test :

- **Ne rien déclarer, plutôt qu'annoncer 2020-12.** `$schema` ne fait pas partie de la forme `Tool.inputSchema`/`outputSchema` de la spec MCP, et le catalogue n'utilise **aucun mot-clé propre à un dialecte** (ni `$ref`, ni `$defs`, ni `definitions`) : chaque validateur lit les schémas de façon identique sous son dialecte par défaut. Annoncer 2020-12 aurait déplacé la panne vers les validateurs draft-07, dont **le client du SDK MCP lui-même** (Ajv 8, draft-07 par défaut).
- **Seuls les `$schema` de type _chaîne_ sont retirés.** Une propriété *nommée* `$schema` dans un `properties` est un objet-schéma ; une suppression récursive aveugle l'aurait effacée de la forme annoncée.
- `stripSchemaDialect` rend son entrée **par identité** quand il n'y a rien à retirer → coût nul le jour où le SDK cesse d'émettre la déclaration. Ce fichier est supprimable tel quel à ce moment-là.

Effet de bord bienvenu : **~10 Kio de moins sur `tools/list`** (282,9 Kio au lieu de 293,4), budget que ce dépôt surveille.

## Vérification

**Contre-épreuve** — en désactivant le correctif, la suite échoue et liste les 239 schémas fautifs, `Ajv2020` en tête.

**En local** — `src/schema-dialect.test.ts`, 8 tests dont 3 sur un vrai client MCP : aucun dialecte annoncé nulle part, les 239 schémas compilent sous `Ajv2020`, un `structuredContent` réel valide toujours (`count` requis inclus).

**Contre le tenant live** (stdio, lecture seule) :

| Outil | Résultat |
|---|---|
| `boond_candidates_search` | total=42 794, count=3 — `structuredContent` **VALID** |
| `boond_resources_search` | total=2 081, count=3 — **VALID** |
| `boond_agencies_search` | total=11, count=11 — **VALID** |
| `boond_opportunities_search` (avec `fields`) | total=11 988, count=3 — **VALID** (branche `attributes`) |

0 échec de compilation `Ajv2020` sur 239 schémas.

**Chaîne complète** : `lint`, `typecheck`, **1051 tests / 63 fichiers**, `build`, drift `TOOLS.md`, drift plugin, `mcpb validate` — tout vert.

## Release v2.12.2

Second commit : les 8 références de version alignées — `package.json`, `manifest.json`, `server.json` (version + URL d'exemple du `.mcpb`), `gemini-extension.json`, `marketplace.json`, `plugin.json` et le pin npm `boondmanager-mcp-server@2.12.2` du plugin (régénéré via `npm run plugin:manifest`), plus `package-lock.json`. `ajv` devient une devDependency explicite : le test l'utilise directement plutôt que via la copie transitive du SDK.

Le tag `v2.12.2` **n'est pas posé** — à faire après merge sur `main`, c'est lui qui déclenche le workflow de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
