### PR TITLE
fix(ci): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,26 @@ jobs:
         with:
           fetch-depth: 0
           # This job never pushes back with git (releases use GITHUB_TOKEN via
-          # the API, MCP Registry uses OIDC, npm uses NODE_AUTH_TOKEN), so don't
-          # leave a usable git credential on disk for downloaded tools to find.
+          # the API, and both the MCP Registry and npm authenticate with OIDC),
+          # so don't leave a usable git credential on disk for downloaded tools.
           persist-credentials: false
 
       - name: Setup Node.js
+        # ⚠️ `registry-url` is deliberately ABSENT and must stay absent.
+        # Setting it makes setup-node write `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+        # into .npmrc unconditionally. With trusted publishing there is no
+        # NODE_AUTH_TOKEN, so that line expands to an EMPTY token — and the npm
+        # CLI reads "auth is already configured", skips the OIDC exchange, and
+        # publishes with empty credentials. The registry answers
+        # `404 Not Found - PUT`, which reads exactly like a bad token and sends
+        # you looking at the wrong thing (that is how v2.13.0's first release
+        # attempt failed). Without registry-url, npm defaults to
+        # registry.npmjs.org anyway and no auth line is written, so the OIDC
+        # exchange happens. `auth-token-line: false` would be the explicit fix
+        # but does not exist at this pinned SHA.
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 22
-          registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
       - name: Install dependencies
@@ -75,15 +86,36 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
           echo "Detected: version=$TAG_VERSION prerelease=$IS_PRERELEASE npm_tag=$NPM_TAG"
 
+      # Trusted publishing needs npm >= 11.5.1; Node 22 still bundles 10.9.x.
+      # Upgraded here rather than right after setup-node on purpose: lint,
+      # typecheck, tests and build then run under the exact npm that ci.yml
+      # uses, so a release can't pass checks in an environment CI never
+      # exercises. The blast radius stays limited to publishing.
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: |
+          npm install -g npm@^12.0.2
+          npm --version
+
       # npm publish runs BEFORE the prune below: `prepublishOnly` re-runs
       # `tsc` (a devDependency), so the full dev tree must still be present.
       - name: Publish to npm
+        # No NODE_AUTH_TOKEN: authentication is OIDC trusted publishing,
+        # configured on npmjs.com against (fauguste, boondmanager-mcp-server,
+        # release.yml). `permissions.id-token: write` above is what lets the
+        # runner mint the OIDC token. Nothing to rotate, nothing to expire —
+        # the previous long-lived NPM_TOKEN expired silently at its 90-day cap
+        # and broke the release.
+        #
         # `--tag <npm_tag>` ensures prereleases land under e.g. `@alpha`
         # rather than overwriting the default `latest` dist-tag and reaching
         # users running `npm install boondmanager-mcp-server` without a tag.
+        #
+        # `--provenance` is redundant under trusted publishing (attestations
+        # are generated automatically for a public repo + public package) and
+        # is kept deliberately: it turns provenance into a hard requirement, so
+        # if the automatic path ever stops applying the release fails loudly
+        # instead of quietly shipping an unattested tarball.
         run: npm publish --provenance --access public --tag "${{ steps.version.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Strip devDependencies before packing — `mcpb pack` bundles the whole
       # node_modules tree, so without this the .mcpb ships vitest/typescript/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1041,11 +1041,32 @@ read-only, confirmation *kept* for deletes. Pinned in
 
 | Secret | Used by | Purpose |
 |--------|---------|---------|
-| `NPM_TOKEN` | `release.yml` | npm publish (automation token, scoped to this package) |
 | `DOCKERHUB_USERNAME` | `release.yml`, `docker-publish.yml` | Docker Hub user/org that owns the published repo |
 | `DOCKERHUB_TOKEN` | `release.yml`, `docker-publish.yml` | Docker Hub access token (Account Settings → Security) |
 
 `GITHUB_TOKEN` is auto-provided by GitHub Actions and covers GHCR, GitHub Releases, and CodeQL — no extra setup. The MCP Registry uses GitHub OIDC (no secret).
+
+**npm needs no secret either**: publishing goes through **OIDC trusted
+publishing**, configured on npmjs.com (package → Settings → Trusted publishers)
+against `fauguste` / `boondmanager-mcp-server` / `release.yml`, with
+`permissions.id-token: write` in the workflow. `NPM_TOKEN` was removed after a
+long-lived automation token expired silently at its 90-day cap and broke the
+v2.13.0 release.
+
+Two traps this configuration must keep clear of, both of which produce the
+*same* misleading `404 Not Found - PUT` that reads like a bad token:
+
+- **`registry-url` must stay off `actions/setup-node`.** It writes
+  `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`
+  unconditionally; with no token that expands to an empty value, npm concludes
+  auth is already configured, skips the OIDC exchange, and publishes with empty
+  credentials. (`auth-token-line: false` is the explicit fix but does not exist
+  at the pinned SHA.)
+- **npm must be ≥ 11.5.1** (Node ≥ 22.14.0). Node 22 bundles npm 10.9.x, which
+  has no OIDC support at all, so `release.yml` upgrades npm in a dedicated step
+  placed *after* the test/build steps — those keep running under the same npm as
+  `ci.yml`, so a release can never pass checks in an environment CI never
+  exercised.
 
 ## Code Style
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -9,7 +9,7 @@ the reference for what gets pushed where on each release.
 
 | Channel | URL / Identifier | Sync mechanism | Frequency |
 |---|---|---|---|
-| **npm** | [`boondmanager-mcp-server`](https://www.npmjs.com/package/boondmanager-mcp-server) | `npm publish --provenance` step in `release.yml` | every `v*` tag |
+| **npm** | [`boondmanager-mcp-server`](https://www.npmjs.com/package/boondmanager-mcp-server) | `npm publish --provenance` step in `release.yml`, authenticated by **OIDC trusted publishing** (no `NPM_TOKEN`; see the secrets section of `CLAUDE.md` for the two traps that make it fail with a misleading 404) | every `v*` tag |
 | **MCP Registry** | [`io.github.fauguste/boondmanager-mcp-server`](https://registry.modelcontextprotocol.io/) | `mcp-publisher publish` in `release.yml` (GitHub OIDC) | every `v*` tag |
 | **GitHub Releases (.mcpb bundle)** | [releases page](https://github.com/fauguste/boondmanager-mcp-server/releases) | `softprops/action-gh-release@v3` in `release.yml`; body sourced from `CHANGELOG.md` | every `v*` tag |
 | **GitHub Container Registry** | `ghcr.io/fauguste/boondmanager-mcp-server` | `docker/build-push-action@v6` in `release.yml`; multi-arch (amd64+arm64), tags `:latest`, `:X`, `:X.Y`, `:X.Y.Z` | every `v*` tag |


### PR DESCRIPTION
Débloque la publication de **v2.13.0**, dont le tag est poussé mais dont rien n'a été publié.

## Ce qui s'est passé

```
npm error 404 Not Found - PUT https://registry.npmjs.org/boondmanager-mcp-server
```

Un 404 sur `PUT` est la façon dont npm signale un échec d'**authentification** (404 plutôt que 403, pour ne pas divulguer l'existence d'un paquet). `NPM_TOKEN` a été créé le 2026-05-20 ; les granular tokens npm plafonnent à 90 jours, donc expiration vers le 2026-08-18 — après la publication de 2.12.2 le 2026-08-14, avant ce tag.

Le job étant monolithique, l'échec à l'étape 10/24 a *skippé* les étapes 11 à 24 : ni bundle MCPB, ni GitHub Release, ni MCP Registry, ni GHCR, ni Docker Hub. **Aucune publication partielle** — rien n'est dans un état incohérent.

## Pourquoi OIDC plutôt qu'une rotation

Roter le token remet la même panne au calendrier dans 90 jours au plus tard, silencieusement. Trusted publishing supprime le secret : `permissions.id-token: write` était déjà en place pour le MCP Registry.

## Les deux pièges traités ici

Les deux produisent **le même 404 trompeur**, ce qui rend la panne difficile à diagnostiquer.

1. **`registry-url` retiré de `actions/setup-node`.** Il écrit inconditionnellement `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` dans `.npmrc`. Sans token, la valeur est **vide**, et npm en conclut que l'auth est configurée : il ne déclenche jamais l'échange OIDC et publie avec des credentials vides → exactement le 404 ci-dessus. **Se contenter de supprimer le bloc `env: NODE_AUTH_TOKEN` aurait reproduit l'échec à l'identique.** `auth-token-line: false` serait le correctif explicite mais n'existe pas au SHA épinglé de setup-node ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551), [npm/documentation#1960](https://github.com/npm/documentation/issues/1960)).
2. **npm ≥ 11.5.1** (plancher du trusted publishing ; Node 22 embarque 10.9.x, sans aucun support OIDC). L'upgrade est placé **après** les étapes de test/build : lint, typecheck, tests et build continuent de tourner sous le même npm que `ci.yml`, donc une release ne peut pas valider ses checks dans un environnement que la CI n'a jamais exercé.

`--provenance` est conservé bien que les attestations soient automatiques sous trusted publishing : il fait de la provenance une exigence dure, donc si le chemin automatique cesse de s'appliquer, la release échoue bruyamment au lieu de livrer discrètement un tarball non attesté.

## Prérequis manuel (une seule fois)

Sur npmjs.com → paquet `boondmanager-mcp-server` → Settings → Trusted publishers :

| Champ | Valeur |
|---|---|
| Organization or user | `fauguste` |
| Repository | `boondmanager-mcp-server` |
| Workflow filename | `release.yml` |
| Environment | *(vide)* |
| Allowed actions | `npm publish` |

## Après le merge

Le workflow d'un tag push est lu **au commit du tag**, donc corriger `main` ne republie pas `v2.13.0` : le tag devra être repositionné sur le `main` corrigé. C'est sans risque ici puisque rien n'a consommé ce tag (npm, GitHub Release et GHCR n'ont aucune trace de 2.13.0).

Suivi possible, hors périmètre : ajouter un `workflow_dispatch` à `release.yml` pour rejouer une release sans repositionner de tag — l'étape de vérification version↔tag dérive aujourd'hui la version de `GITHUB_REF`, il faudrait l'adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)