### PR TITLE
fix(deps): bump @humanfs/node to 0.16.8 (Dependabot #44)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -235,25 +235,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }


### PR DESCRIPTION
## Faille corrigée

Dependabot alert [#44](https://github.com/fauguste/boondmanager-mcp-server/security/dependabot/44) — **moderate**:

> humanfs: Recursive copy follows symlinked files and copies data from outside the source tree

- **Package**: `@humanfs/node` (dev-only, transitive)
- **Vulnerable**: `< 0.16.8` — lockfile had `0.16.7`
- **Patched**: `0.16.8`
- **Chemin**: `eslint@10.9.1 → @humanfs/node`

## Correctif

Lockfile-only. `eslint` declares `"@humanfs/node": "^0.16.6"`, so `0.16.8` is already inside the allowed range — no `package.json` change and no ESLint upgrade needed.

The bump also pulls `@humanfs/core` 0.19.1 → 0.19.2 and its new `@humanfs/types@0.15.0` (both dev-only, Apache-2.0). 21 insertions / 7 deletions, nothing else in the tree moved.

Impact on the shipped server: **none** — the package is a dev dependency of the linter, never bundled and never reached at runtime.

## Vérifications

- `npm audit` → `0 vulnerabilities` (was 1 moderate)
- `npm ci` clean from the updated lockfile
- `npm test` → 64 files, **1120 tests passed**
- `npm run lint` / `typecheck` / `build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)