### PR TITLE
chore(release): 2.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "boondmanager-mcp",
       "source": "./plugins/boondmanager-mcp",
       "description": "BoondManager ERP/CRM — 180 outils, 11 prompts, 22 resources",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "category": "productivity",
       "tags": ["erp", "crm", "boondmanager", "esn", "recrutement", "facturation"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.14.1] - 2026-09-08
+
+Version de maintenance : **aucun changement fonctionnel**. Le catalogue est inchangé (182 outils, 12 prompts, 22 ressources, 6 templates) et aucun schéma annoncé ne bouge — un client déjà connecté ne verra aucune différence. Le contenu est une remise à niveau des dépendances, dont une correction de vulnérabilité et un passage de Vitest en majeure.
+
+### Security
+
+- **`@humanfs/node` 0.16.7 → 0.16.8** ([alerte Dependabot #44](https://github.com/fauguste/boondmanager-mcp-server/security/dependabot), *moderate*) : la copie récursive suivait les fichiers symlinkés et recopiait donc des données situées **hors de l'arbre source**. Dépendance de développement, transitive via `eslint`, jamais empaquetée dans le serveur publié et jamais atteinte à l'exécution : l'exposition réelle se limitait au poste qui lance `npm run lint`. Le correctif est un bump de lockfile seul — `eslint` déclare `^0.16.6`, donc `0.16.8` était déjà dans la plage autorisée, sans mise à jour d'ESLint ni changement de `package.json`. `npm audit` repasse à **0 vulnérabilité**.
+
+### Changed
+
+- **Vitest 4.1.10 → 5.0.0** et `@vitest/coverage-v8` de même (majeure). Aucune adaptation nécessaire : `vitest.config.ts` n'utilise que des options stables (`globals`, `environment`, `include`, `coverage.provider`/`reporter`/`thresholds`), aucune source n'a changé, et les 64 fichiers de tests passent inchangés en tenant les mêmes seuils de couverture. La majeure réoutille la couverture en interne (`istanbul-reports` cède la place à `@vitest/istanbul-lib-*`). Note pour les contributeurs : `@vitest/coverage-v8` déclare un peer **exact** sur `vitest`, donc les deux paquets doivent être bumpés dans le **même** commit — Dependabot en ouvre une PR par paquet et chacune échoue alors sur `npm ci` en `ERESOLVE`, ce qui se lit à tort comme « Vitest 5 casse la suite ».
+- **Dépendances applicatives** (toutes dans les plages déjà déclarées, donc lockfile uniquement) : `zod` 4.4.3 → 4.5.4, et en transitif `qs` 6.15.2 → 6.16.0, `fast-uri` 3.1.5 → 3.1.7, plus quelques micro-bumps (`hasown`, `side-channel`, `es-object-atoms`). `@modelcontextprotocol/sdk` reste en **1.30.0** : le niveau de spec MCP négocié est donc toujours `2025-11-25`, inchangé.
+- **Outillage de développement** : `eslint` 10.8.1 → 10.9.1, `typescript-eslint` 8.67.0 → 8.69.0, `@types/node` 26.2.0 → 26.4.1, `lint-staged` 17.3.0 → 17.4.1.
+- **CI / image Docker** : `github/codeql-action` v4.37.7 → v4.37.9, `docker/setup-buildx-action` et `docker/setup-qemu-action` repinnés sur v4, `softprops/action-gh-release` repinné sur v3, et le digest de l'image de base `node:26-alpine` rafraîchi (`aadf416` → `2d984a1`). Toutes les actions restent épinglées par SHA.
+
+### Documentation
+
+- `docs/distribution.md` suit désormais le référencement dans awesome-ai-plugins ([#194](https://github.com/fauguste/boondmanager-mcp-server/issues/194)).
+- `CLAUDE.md` : la section *Testing* annonçait « Vitest 4 » et « 1083 tests » — corrigé en Vitest 5 et **1120 tests** (64 fichiers), le compte réel après les ajouts de la 2.14.0.
+
 ## [2.14.0] - 2026-08-21
 
 Photo de justificatif → ligne de frais dans BoondManager ([#179](https://github.com/fauguste/boondmanager-mcp-server/issues/179)). Le ticket demandait « juste un prompt » : la vérification préalable du schéma qu'il imposait a montré que l'outil d'écriture visé ne fonctionnait pas du tout, d'où un lot plus large que prévu. Catalogue : **182 outils** (180 → 182), **12 prompts** (11 → 12), 22 ressources, 6 templates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,7 +561,7 @@ How it is wired, and why it is wired that way:
 
 ## Testing
 
-- **Framework**: Vitest 4 (with `globals: true`)
+- **Framework**: Vitest 5 (with `globals: true`)
 - **Pattern**: Each module file has a corresponding `.test.ts` file
 - **Approach**: Mock `McpServer` with `{ registerTool: vi.fn() }`,
   `registerPrompt`, `registerResource` as needed, then verify:
@@ -572,7 +572,7 @@ How it is wired, and why it is wired that way:
      the right tool names and filter shortcuts
   5. For resources: read callback hits the expected API path
 - **Coverage**: V8 provider, excludes test files and index.ts
-- **Current stats**: 64 test files, **1083 tests**
+- **Current stats**: 64 test files, **1120 tests**
 
 ### Test file template (for read-only search+get domains):
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Serveur MCP pour l'API BoondManager (ERP/CRM ESN) - 182 outils, 12 prompts, 22 ressources.",
   "mcpServers": {
     "boondmanager": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "boondmanager-mcp-server",
   "display_name": "BoondManager MCP Server",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "MCP Server for BoondManager API - 182 tools, 12 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boondmanager-mcp-server",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boondmanager-mcp-server",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "MCP Server for BoondManager API - 182 tools, 12 prompts, 22 resources (ERP/CRM)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/boondmanager-mcp/.claude-plugin/plugin.json
+++ b/plugins/boondmanager-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "boondmanager-mcp",
   "displayName": "BoondManager MCP Server",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "MCP Server for BoondManager API - 182 tools, 12 prompts, 22 resources (ERP/CRM)",
   "author": {
     "name": "Frédéric Auguste",

--- a/plugins/boondmanager-mcp/.mcp.json
+++ b/plugins/boondmanager-mcp/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "boondmanager-mcp-server@2.14.0"
+        "boondmanager-mcp-server@2.14.1"
       ],
       "env": {
         "BOOND_BASE_URL": "${user_config.base_url}",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.fauguste/boondmanager-mcp-server",
   "title": "BoondManager MCP Server",
   "description": "MCP Server for BoondManager API - 182 tools, 12 prompts, 22 resources (ERP/CRM)",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "websiteUrl": "https://github.com/fauguste/boondmanager-mcp-server",
   "repository": {
     "url": "https://github.com/fauguste/boondmanager-mcp-server",
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.14.0/boondmanager-mcp-server-v2.14.0.mcpb",
+      "identifier": "https://github.com/fauguste/boondmanager-mcp-server/releases/download/v2.14.1/boondmanager-mcp-server-v2.14.1.mcpb",
       "fileSha256": "PLACEHOLDER",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release de maintenance : **aucun changement fonctionnel**. Catalogue inchangé (182 outils, 12 prompts, 22 ressources, 6 templates), aucun schéma annoncé modifié, `@modelcontextprotocol/sdk` toujours en 1.30.0 — le niveau de spec MCP négocié reste `2025-11-25`. Un client déjà connecté ne verra aucune différence.

## Contenu

**Security** — `@humanfs/node` 0.16.7 → 0.16.8 ([Dependabot #44](https://github.com/fauguste/boondmanager-mcp-server/security/dependabot), *moderate*) : la copie récursive suivait les symlinks hors de l'arbre source. Dev-only, transitive via `eslint`. `npm audit` → **0 vulnérabilité**. Déjà mergé en #209, ici c'est le commit de release.

**Changed**
- `vitest` + `@vitest/coverage-v8` 4.1.10 → **5.0.0** (majeure) — aucun changement de source ni de `vitest.config.ts`
- `zod` 4.4.3 → 4.5.4 ; en transitif `qs` 6.16.0, `fast-uri` 3.1.7 (plages déjà déclarées, lockfile seul)
- `eslint` 10.9.1, `typescript-eslint` 8.69.0, `@types/node` 26.4.1, `lint-staged` 17.4.1
- CI : CodeQL v4.37.9, buildx/qemu/gh-release repinnés, digest `node:26-alpine` rafraîchi

**Documentation** — corrige deux faits périmés dans la section *Testing* de `CLAUDE.md` : « Vitest 4 » → Vitest 5, et « 1083 tests » → **1120 tests** (le compte réel depuis la 2.14.0).

## Versions bumpées

Les 7 emplacements suivis + le pin npm du plugin, tous à `2.14.1` :
`package.json`, `manifest.json`, `server.json`, `gemini-extension.json`, `plugin.json`, `marketplace.json`, le pin `boondmanager-mcp-server@2.14.1` dans `.mcp.json`, et l'URL `.mcpb` dans `server.json.packages[1].identifier`.

## Vérifications locales

Toutes les portes de la CI passées avant push :

| Contrôle | Résultat |
|---|---|
| `npm test` | 64 fichiers, **1120 tests** ✅ |
| `test:coverage` | 90,1 % stmts / 81,2 % branches / 91,4 % lines — au-dessus des seuils ✅ |
| `lint` / `typecheck` / `build` | propres ✅ |
| `docs:tools:check` | TOOLS.md à jour ✅ |
| `plugin:manifest:check` | à jour (v2.14.1, 14 options) ✅ |
| `mcpb validate` | schéma valide ✅ |
| Cohérence des versions | 7/7 alignées ✅ |
| `npm audit` | 0 vulnérabilité ✅ |

Extraction des notes de release par `release.yml` vérifiée en dry-run sur la section `## [2.14.1]` (3 153 octets).

## Après le merge

`git tag v2.14.1 && git push origin main v2.14.1` déclenche npm (OIDC), GitHub Release + `.mcpb`, MCP Registry, GHCR et Docker Hub, puis la checklist de vérification en 7 points de `docs/distribution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)